### PR TITLE
rhwa: Rapidast on FAR operator

### DIFF
--- a/images/rhwa/dast/Dockerfile
+++ b/images/rhwa/dast/Dockerfile
@@ -1,5 +1,10 @@
 # Use the official RAPIDast image as the base
+<<<<<<< HEAD
 FROM quay.io/redhatproductsecurity/rapidast:2.12.1
+=======
+FROM quay.io/redhatproductsecurity/rapidast:2.8.0
+
+>>>>>>> 963ff25d (Retrieve scan results)
 
 # Set working directory to the RAPIDast installation
 WORKDIR /opt/rapidast

--- a/images/rhwa/dast/Dockerfile
+++ b/images/rhwa/dast/Dockerfile
@@ -1,10 +1,5 @@
 # Use the official RAPIDast image as the base
-<<<<<<< HEAD
 FROM quay.io/redhatproductsecurity/rapidast:2.12.1
-=======
-FROM quay.io/redhatproductsecurity/rapidast:2.8.0
-
->>>>>>> 963ff25d (Retrieve scan results)
 
 # Set working directory to the RAPIDast installation
 WORKDIR /opt/rapidast

--- a/images/rhwa/dast/config/rapidastConfig.yaml
+++ b/images/rhwa/dast/config/rapidastConfig.yaml
@@ -39,7 +39,7 @@ scanners:
     # 'inline' is used when container.type is not 'podman'
     # 'toolDir' specifies the default directory where inline scripts are located
     #toolDir: scanners/generic/tools
-    inline: "trivy k8s --include-namespaces $NAMESPACE --include-kinds pod --severity=HIGH,CRITICAL --scanners=misconfig --report all --format json"
+    inline: "trivy k8s --include-namespaces $NAMESPACE --severity=HIGH,CRITICAL --scanners=misconfig --report all --format json"
     container:
       parameters:
         # Optional: list of expected return codes, anything else will be considered as an error. by default: [0]

--- a/images/rhwa/dast/config/rapidastConfig.yaml
+++ b/images/rhwa/dast/config/rapidastConfig.yaml
@@ -39,8 +39,16 @@ scanners:
     # 'inline' is used when container.type is not 'podman'
     # 'toolDir' specifies the default directory where inline scripts are located
     #toolDir: scanners/generic/tools
+<<<<<<< HEAD
     inline: "trivy k8s --include-namespaces $NAMESPACE --include-kinds pod --severity=HIGH,CRITICAL --scanners=misconfig --report all --format json"
     container:
       parameters:
         # Optional: list of expected return codes, anything else will be considered as an error. by default: [0]
         validReturns: [ 0 ]
+=======
+    inline: "trivy k8s -n $NAMESPACE pod --severity=HIGH,CRITICAL --scanners=misconfig --report all --format json"
+    container:
+      parameters:
+        # Optional: list of expected return codes, anything else will be considered as an error. by default: [0]
+        validReturns: [ 0 ]
+>>>>>>> 963ff25d (Retrieve scan results)

--- a/images/rhwa/dast/config/rapidastConfig.yaml
+++ b/images/rhwa/dast/config/rapidastConfig.yaml
@@ -39,16 +39,8 @@ scanners:
     # 'inline' is used when container.type is not 'podman'
     # 'toolDir' specifies the default directory where inline scripts are located
     #toolDir: scanners/generic/tools
-<<<<<<< HEAD
     inline: "trivy k8s --include-namespaces $NAMESPACE --include-kinds pod --severity=HIGH,CRITICAL --scanners=misconfig --report all --format json"
     container:
       parameters:
         # Optional: list of expected return codes, anything else will be considered as an error. by default: [0]
         validReturns: [ 0 ]
-=======
-    inline: "trivy k8s -n $NAMESPACE pod --severity=HIGH,CRITICAL --scanners=misconfig --report all --format json"
-    container:
-      parameters:
-        # Optional: list of expected return codes, anything else will be considered as an error. by default: [0]
-        validReturns: [ 0 ]
->>>>>>> 963ff25d (Retrieve scan results)

--- a/tests/rhwa/far-operator/far_suite_test.go
+++ b/tests/rhwa/far-operator/far_suite_test.go
@@ -48,8 +48,8 @@ var _ = ReportAfterSuite("", func(report Report) {
 		report, RHWAConfig.GetReportPath(), RHWAConfig.TCPrefix)
 })
 
-//var _ = AfterSuite(func() {
-//	By("Deleting test namespace")
-//	err := testNS.DeleteAndWait(rhwaparams.DefaultTimeout)
-//	Expect(err).ToNot(HaveOccurred(), "error to delete test namespace")
-//})
+var _ = AfterSuite(func() {
+	By("Deleting test namespace")
+	err := testNS.DeleteAndWait(rhwaparams.DefaultTimeout)
+	Expect(err).ToNot(HaveOccurred(), "error to delete test namespace")
+})

--- a/tests/rhwa/far-operator/far_suite_test.go
+++ b/tests/rhwa/far-operator/far_suite_test.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/far-operator/tests"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwainittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwaparams"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var (
@@ -35,7 +36,10 @@ var _ = BeforeSuite(func() {
 		testNS.WithLabel(key, value)
 	}
 	_, err := testNS.Create()
-	Expect(err).ToNot(HaveOccurred(), "error to create test namespace")
+
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		Expect(err).ToNot(HaveOccurred(), "error to create test namespace")
+	}
 })
 
 var _ = JustAfterEach(func() {

--- a/tests/rhwa/far-operator/far_suite_test.go
+++ b/tests/rhwa/far-operator/far_suite_test.go
@@ -6,14 +6,20 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/params"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/reporter"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/far-operator/internal/farparams"
 	_ "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/far-operator/tests"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwainittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwaparams"
 )
 
-var _, currentFile, _, _ = runtime.Caller(0)
+var (
+	_, currentFile, _, _ = runtime.Caller(0)
+	testNS               = namespace.NewBuilder(APIClient, rhwaparams.TestNamespaceName)
+)
 
 func TestFAR(t *testing.T) {
 	_, reporterConfig := GinkgoConfiguration()
@@ -22,6 +28,15 @@ func TestFAR(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "FAR", Label(farparams.Labels...), reporterConfig)
 }
+
+var _ = BeforeSuite(func() {
+	By("Creating test namespace with privileged labels")
+	for key, value := range params.PrivilegedNSLabels {
+		testNS.WithLabel(key, value)
+	}
+	_, err := testNS.Create()
+	Expect(err).ToNot(HaveOccurred(), "error to create test namespace")
+})
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
@@ -32,3 +47,9 @@ var _ = ReportAfterSuite("", func(report Report) {
 	reportxml.Create(
 		report, RHWAConfig.GetReportPath(), RHWAConfig.TCPrefix)
 })
+
+//var _ = AfterSuite(func() {
+//	By("Deleting test namespace")
+//	err := testNS.DeleteAndWait(rhwaparams.DefaultTimeout)
+//	Expect(err).ToNot(HaveOccurred(), "error to delete test namespace")
+//})

--- a/tests/rhwa/far-operator/tests/dast.go
+++ b/tests/rhwa/far-operator/tests/dast.go
@@ -1,0 +1,61 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/deployment"
+	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
+
+	"github.com/openshift-kni/eco-gotests/tests/rhwa/far-operator/internal/farparams"
+	rapidast "github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rapidast"
+	. "github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwainittools"
+	"github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwaparams"
+)
+
+var _ = Describe(
+	"FAR Post Deployment tests",
+	Ordered,
+	ContinueOnFailure,
+	Label(farparams.Label), Label("dast"), func() {
+		BeforeAll(func() {
+			By("Get FAR deployment object")
+			farDeployment, err := deployment.Pull(
+				APIClient, farparams.OperatorDeploymentName, rhwaparams.RhwaOperatorNs)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get FAR deployment")
+
+			By("Verify FAR deployment is Ready")
+			Expect(farDeployment.IsReady(rhwaparams.DefaultTimeout)).To(BeTrue(), "FAR deployment is not Ready")
+		})
+
+		It("Verify FAR Operator passes trivy scan without vulnerabilities", reportxml.ID("76877"), func() {
+
+			By("Creating rapidast pod")
+			dastTestPod := rapidast.PrepareRapidastPod(APIClient)
+
+			output, err := rapidast.RunRapidastScan(*dastTestPod, rhwaparams.RhwaOperatorNs)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Checking vulnerability scan results")
+			var parsableStruct rapidast.DASTReport
+			err = json.Unmarshal(output.Bytes(), &parsableStruct)
+			Expect(err).ToNot(HaveOccurred())
+
+			var vulnerabilityFound = false
+			for _, resource := range parsableStruct.Resources {
+				for _, result := range resource.Results {
+					if result.MisconfSummary.Failures > 0 {
+						fmt.Printf("%d vulnerability(s) found in %s\n", result.MisconfSummary.Failures, resource.Name)
+						for _, misconfiguration := range result.Misconfigurations {
+							fmt.Printf("- %+v\n", misconfiguration)
+						}
+						vulnerabilityFound = true
+					}
+				}
+			}
+			Expect(vulnerabilityFound).NotTo(BeTrue(), "Found vulnerability(s)")
+		})
+	})

--- a/tests/rhwa/far-operator/tests/dast.go
+++ b/tests/rhwa/far-operator/tests/dast.go
@@ -34,7 +34,8 @@ var _ = Describe(
 		It("Verify FAR Operator passes trivy scan without vulnerabilities", reportxml.ID("76877"), func() {
 
 			By("Creating rapidast pod")
-			dastTestPod := rapidast.PrepareRapidastPod(APIClient)
+			dastTestPod, err := rapidast.PrepareRapidastPod(APIClient)
+			Expect(err).ToNot(HaveOccurred())
 
 			output, err := rapidast.RunRapidastScan(*dastTestPod, rhwaparams.RhwaOperatorNs)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/rhwa/far-operator/tests/dast.go
+++ b/tests/rhwa/far-operator/tests/dast.go
@@ -7,13 +7,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/openshift-kni/eco-goinfra/pkg/deployment"
-	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
-
-	"github.com/openshift-kni/eco-gotests/tests/rhwa/far-operator/internal/farparams"
-	rapidast "github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rapidast"
-	. "github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwainittools"
-	"github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwaparams"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/far-operator/internal/farparams"
+	rapidast "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rapidast"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwainittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwaparams"
 )
 
 var _ = Describe(

--- a/tests/rhwa/far-operator/tests/dast.go
+++ b/tests/rhwa/far-operator/tests/dast.go
@@ -13,6 +13,8 @@ import (
 	rapidast "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rapidast"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwainittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwaparams"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe(
@@ -21,6 +23,14 @@ var _ = Describe(
 	ContinueOnFailure,
 	Label(farparams.Label), Label("dast"), func() {
 		BeforeAll(func() {
+			By("Verify fence-agents-remediation is the only deployment in namespace")
+			deploymentList, err := deployment.List(APIClient, rhwaparams.RhwaOperatorNs, metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred(), "Failed to list deployments")
+
+			if len(deploymentList) != 1 {
+				Skip(fmt.Sprintf("Expected only fence-agents-remediation deployment, found %d deployment(s)", len(deploymentList)))
+			}
+
 			By("Get FAR deployment object")
 			farDeployment, err := deployment.Pull(
 				APIClient, farparams.OperatorDeploymentName, rhwaparams.RhwaOperatorNs)

--- a/tests/rhwa/far-operator/tests/far.go
+++ b/tests/rhwa/far-operator/tests/far.go
@@ -128,7 +128,8 @@ var _ = Describe(
 			Expect(err).ToNot(HaveOccurred(), "Failed to create client test pod")
 
 			By("Running vulnerability scan")
-			command := []string{"bash", "-c", "NAMESPACE=openshift-workload-availability rapidast.py --config ./config/rapidastConfig.yaml 2> /dev/null"}
+			command := []string{"bash", "-c",
+				fmt.Sprintf("NAMESPACE=%s rapidast.py --config ./config/rapidastConfig.yaml 2> /dev/null", rhwaparams.RhwaOperatorNs)}
 			output, err := dastTestPod.ExecCommand(command)
 			Expect(err).ToNot(HaveOccurred(), "Command failed")
 

--- a/tests/rhwa/far-operator/tests/far.go
+++ b/tests/rhwa/far-operator/tests/far.go
@@ -5,26 +5,14 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-<<<<<<< HEAD
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/rbac"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/serviceaccount"
+
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/far-operator/internal/farparams"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwainittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwaparams"
-=======
-
-	"github.com/openshift-kni/eco-goinfra/pkg/deployment"
-	"github.com/openshift-kni/eco-goinfra/pkg/pod"
-	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
-
-	"github.com/openshift-kni/eco-gotests/tests/rhwa/far-operator/internal/farparams"
-	. "github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwainittools"
-	"github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwaparams"
->>>>>>> e8f14f6a (extract preparation of rapidast pod)
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/tests/rhwa/far-operator/tests/far.go
+++ b/tests/rhwa/far-operator/tests/far.go
@@ -3,10 +3,10 @@ package tests
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+<<<<<<< HEAD
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
@@ -16,8 +16,18 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/far-operator/internal/farparams"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwainittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwaparams"
+=======
 
-	v1 "k8s.io/api/rbac/v1"
+	"github.com/openshift-kni/eco-goinfra/pkg/deployment"
+	"github.com/openshift-kni/eco-goinfra/pkg/pod"
+	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
+
+	"github.com/openshift-kni/eco-gotests/tests/rhwa/far-operator/internal/farparams"
+	. "github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rapidast"
+	. "github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwainittools"
+	"github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwaparams"
+>>>>>>> e8f14f6a (extract preparation of rapidast pod)
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -83,49 +93,7 @@ var _ = Describe(
 
 		It("Verify FAR Operator passes trivy scan without vulnerabilities", reportxml.ID("76877"), func() {
 
-			By("Retrieve list of nodes")
-			nodes, err := nodes.List(APIClient)
-			Expect(err).ToNot(HaveOccurred(), "Error getting nodes list")
-
-			By("Create service account")
-			_, err = serviceaccount.NewBuilder(APIClient, "trivy-service-account", rhwaparams.TestNamespaceName).Create()
-			Expect(err).ToNot(HaveOccurred(), "Failed to create Service Account")
-
-			_, err = rbac.NewClusterRoleBuilder(APIClient, "trivy-clusterrole", v1.PolicyRule{
-				APIGroups: []string{
-					"",
-				},
-				Resources: []string{
-					"pods",
-				},
-				Verbs: []string{
-					"get",
-					"list",
-					"watch",
-				},
-			}).Create()
-			Expect(err).ToNot(HaveOccurred(), "Failed to create Cluster Role")
-
-			_, err = rbac.NewClusterRoleBindingBuilder(APIClient, "trivy-clusterrole-binding", "trivy-clusterrole", v1.Subject{
-				Kind:      "ServiceAccount",
-				Name:      "trivy-service-account",
-				Namespace: rhwaparams.TestNamespaceName,
-			}).Create()
-			Expect(err).ToNot(HaveOccurred(), "Failed to create ClusterRoleBinding")
-
-			By("Creating client test pod")
-			dastTestPod := pod.NewBuilder(
-				APIClient, "rapidastclientpod", rhwaparams.TestNamespaceName, rhwaparams.TestContainerDast).
-				DefineOnNode(nodes[0].Object.Name).
-				WithTolerationToMaster().
-				WithPrivilegedFlag()
-			Expect(err).ToNot(HaveOccurred(), "Failed to create client test pod")
-
-			dastTestPod.Definition.Spec.ServiceAccountName = "trivy-service-account"
-
-			By("Creating client test pod")
-			_, err = dastTestPod.CreateAndWaitUntilRunning(time.Minute)
-			Expect(err).ToNot(HaveOccurred(), "Failed to create client test pod")
+			dastTestPod := PrepareRapidastPod(APIClient)
 
 			By("Running vulnerability scan")
 			command := []string{"bash", "-c",

--- a/tests/rhwa/far-operator/tests/far.go
+++ b/tests/rhwa/far-operator/tests/far.go
@@ -1,10 +1,10 @@
 package tests
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
-	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
@@ -20,6 +20,38 @@ import (
 	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+type DASTReport struct {
+	ClusterName string
+	Resources   []struct {
+		Name      string
+		Namespace string
+		Results   []struct {
+			Target         string
+			Class          string
+			Type           string
+			MisconfSummary struct {
+				Success    int
+				Failures   int
+				Exceptions int
+			}
+			Misconfigurations []struct {
+				Type        string
+				ID          string
+				AVDID       string
+				Description string
+				Message     string
+				Namespace   string
+				Query       string
+				Resolution  string
+				Severity    string
+				PrimaryURL  string
+				References  []string
+				Status      string
+			}
+		}
+	}
+}
 
 var _ = Describe(
 	"FAR Post Deployment tests",
@@ -79,31 +111,41 @@ var _ = Describe(
 				Name:      "trivy-service-account",
 				Namespace: rhwaparams.TestNamespaceName,
 			}).Create()
-			Expect(err).ToNot(HaveOccurred(), "Failed to create Cluster Role Binding")
+			Expect(err).ToNot(HaveOccurred(), "Failed to create ClusterRoleBinding")
 
+			By("Creating client test pod")
 			dastTestPod := pod.NewBuilder(
 				APIClient, "rapidastclientpod", rhwaparams.TestNamespaceName, rhwaparams.TestContainerDast).
 				DefineOnNode(nodes[0].Object.Name).
 				WithTolerationToMaster().
 				WithPrivilegedFlag()
+			Expect(err).ToNot(HaveOccurred(), "Failed to create client test pod")
 
 			dastTestPod.Definition.Spec.ServiceAccountName = "trivy-service-account"
 
 			By("Creating client test pod")
-			dastTestPod, err = pod.NewBuilder(
-				APIClient, "rapidastclientpod", rhwaparams.TestNamespaceName, rhwaparams.TestContainerDast).
-				DefineOnNode(nodes[0].Object.Name).
-				WithTolerationToMaster().
-				WithPrivilegedFlag().CreateAndWaitUntilRunning(time.Minute)
+			_, err = dastTestPod.CreateAndWaitUntilRunning(time.Minute)
 			Expect(err).ToNot(HaveOccurred(), "Failed to create client test pod")
 
-			//TODO: check that the command can be actually executed by the pod.
-			command := []string{"bash", "-c", "export NAMESPACE=openshift-workload-availability rapidast.py --config ./config/rapidastConfig.yaml"}
+			By("Running vulnerability scan")
+			command := []string{"bash", "-c", "NAMESPACE=openshift-workload-availability rapidast.py --config ./config/rapidastConfig.yaml 2> /dev/null"}
 			output, err := dastTestPod.ExecCommand(command)
 			Expect(err).ToNot(HaveOccurred(), "Command failed")
 
-			//TODO: The output of the rapidast command is a JSON that can be handled
-			glog.V(90).Infof("TRIVY command output: %s/n:", output.String())
+			By("Checking vulnerability scan results")
+			var parsableStruct DASTReport
+			err = json.Unmarshal(output.Bytes(), &parsableStruct)
+			Expect(err).ToNot(HaveOccurred())
 
+			var vulnerability_found bool = false
+			for _, resource := range parsableStruct.Resources {
+				for _, result := range resource.Results {
+					if result.MisconfSummary.Failures > 0 {
+						fmt.Printf("%d vulnerability(s) found in %s\n", result.MisconfSummary.Failures, resource.Name)
+						vulnerability_found = true
+					}
+				}
+			}
+			Expect(vulnerability_found).NotTo(BeTrue(), "Found vulnerability(s)")
 		})
 	})

--- a/tests/rhwa/far-operator/tests/far.go
+++ b/tests/rhwa/far-operator/tests/far.go
@@ -2,18 +2,22 @@ package tests
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/rbac"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
-
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/serviceaccount"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/far-operator/internal/farparams"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwainittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwaparams"
 
+	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -43,5 +47,63 @@ var _ = Describe(
 				listOptions,
 			)
 			Expect(err).ToNot(HaveOccurred(), "Pod is not ready")
+		})
+
+		It("Verify FAR Operator passes trivy scan without vulnerabilities", reportxml.ID("76877"), func() {
+
+			By("Retrieve list of nodes")
+			nodes, err := nodes.List(APIClient)
+			Expect(err).ToNot(HaveOccurred(), "Error getting nodes list")
+
+			By("Create service account")
+			_, err = serviceaccount.NewBuilder(APIClient, "trivy-service-account", rhwaparams.TestNamespaceName).Create()
+			Expect(err).ToNot(HaveOccurred(), "Failed to create Service Account")
+
+			_, err = rbac.NewClusterRoleBuilder(APIClient, "trivy-clusterrole", v1.PolicyRule{
+				APIGroups: []string{
+					"",
+				},
+				Resources: []string{
+					"pods",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+				},
+			}).Create()
+			Expect(err).ToNot(HaveOccurred(), "Failed to create Cluster Role")
+
+			_, err = rbac.NewClusterRoleBindingBuilder(APIClient, "trivy-clusterrole-binding", "trivy-clusterrole", v1.Subject{
+				Kind:      "ServiceAccount",
+				Name:      "trivy-service-account",
+				Namespace: rhwaparams.TestNamespaceName,
+			}).Create()
+			Expect(err).ToNot(HaveOccurred(), "Failed to create Cluster Role Binding")
+
+			dastTestPod := pod.NewBuilder(
+				APIClient, "rapidastclientpod", rhwaparams.TestNamespaceName, rhwaparams.TestContainerDast).
+				DefineOnNode(nodes[0].Object.Name).
+				WithTolerationToMaster().
+				WithPrivilegedFlag()
+
+			dastTestPod.Definition.Spec.ServiceAccountName = "trivy-service-account"
+
+			By("Creating client test pod")
+			dastTestPod, err = pod.NewBuilder(
+				APIClient, "rapidastclientpod", rhwaparams.TestNamespaceName, rhwaparams.TestContainerDast).
+				DefineOnNode(nodes[0].Object.Name).
+				WithTolerationToMaster().
+				WithPrivilegedFlag().CreateAndWaitUntilRunning(time.Minute)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create client test pod")
+
+			//TODO: check that the command can be actually executed by the pod.
+			command := []string{"bash", "-c", "export NAMESPACE=openshift-workload-availability rapidast.py --config ./config/rapidastConfig.yaml"}
+			output, err := dastTestPod.ExecCommand(command)
+			Expect(err).ToNot(HaveOccurred(), "Command failed")
+
+			//TODO: The output of the rapidast command is a JSON that can be handled
+			glog.V(90).Infof("TRIVY command output: %s/n:", output.String())
+
 		})
 	})

--- a/tests/rhwa/far-operator/tests/far.go
+++ b/tests/rhwa/far-operator/tests/far.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"encoding/json"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -23,7 +22,6 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 
 	"github.com/openshift-kni/eco-gotests/tests/rhwa/far-operator/internal/farparams"
-	. "github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rapidast"
 	. "github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwainittools"
 	"github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwaparams"
 >>>>>>> e8f14f6a (extract preparation of rapidast pod)
@@ -57,33 +55,5 @@ var _ = Describe(
 				listOptions,
 			)
 			Expect(err).ToNot(HaveOccurred(), "Pod is not ready")
-		})
-
-		It("Verify FAR Operator passes trivy scan without vulnerabilities", reportxml.ID("76877"), func() {
-
-			By("Creating rapidast pod")
-			dastTestPod := PrepareRapidastPod(APIClient)
-
-			By("Running vulnerability scan")
-			command := []string{"bash", "-c",
-				fmt.Sprintf("NAMESPACE=%s rapidast.py --config ./config/rapidastConfig.yaml 2> /dev/null", rhwaparams.RhwaOperatorNs)}
-			output, err := dastTestPod.ExecCommand(command)
-			Expect(err).ToNot(HaveOccurred(), "Command failed")
-
-			By("Checking vulnerability scan results")
-			var parsableStruct DASTReport
-			err = json.Unmarshal(output.Bytes(), &parsableStruct)
-			Expect(err).ToNot(HaveOccurred())
-
-			var vulnerability_found bool = false
-			for _, resource := range parsableStruct.Resources {
-				for _, result := range resource.Results {
-					if result.MisconfSummary.Failures > 0 {
-						fmt.Printf("%d vulnerability(s) found in %s\n", result.MisconfSummary.Failures, resource.Name)
-						vulnerability_found = true
-					}
-				}
-			}
-			Expect(vulnerability_found).NotTo(BeTrue(), "Found vulnerability(s)")
 		})
 	})

--- a/tests/rhwa/far-operator/tests/far.go
+++ b/tests/rhwa/far-operator/tests/far.go
@@ -31,38 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type DASTReport struct {
-	ClusterName string
-	Resources   []struct {
-		Name      string
-		Namespace string
-		Results   []struct {
-			Target         string
-			Class          string
-			Type           string
-			MisconfSummary struct {
-				Success    int
-				Failures   int
-				Exceptions int
-			}
-			Misconfigurations []struct {
-				Type        string
-				ID          string
-				AVDID       string
-				Description string
-				Message     string
-				Namespace   string
-				Query       string
-				Resolution  string
-				Severity    string
-				PrimaryURL  string
-				References  []string
-				Status      string
-			}
-		}
-	}
-}
-
 var _ = Describe(
 	"FAR Post Deployment tests",
 	Ordered,
@@ -93,6 +61,7 @@ var _ = Describe(
 
 		It("Verify FAR Operator passes trivy scan without vulnerabilities", reportxml.ID("76877"), func() {
 
+			By("Creating rapidast pod")
 			dastTestPod := PrepareRapidastPod(APIClient)
 
 			By("Running vulnerability scan")

--- a/tests/rhwa/internal/rapidast/dastreport.go
+++ b/tests/rhwa/internal/rapidast/dastreport.go
@@ -1,5 +1,6 @@
 package rapidast
 
+// DASTReport struct that receives the results of the rapidast scan.
 type DASTReport struct {
 	ClusterName string
 	Resources   []struct {

--- a/tests/rhwa/internal/rapidast/dastreport.go
+++ b/tests/rhwa/internal/rapidast/dastreport.go
@@ -1,0 +1,33 @@
+package rapidast
+
+type DASTReport struct {
+	ClusterName string
+	Resources   []struct {
+		Name      string
+		Namespace string
+		Results   []struct {
+			Target         string
+			Class          string
+			Type           string
+			MisconfSummary struct {
+				Success    int
+				Failures   int
+				Exceptions int
+			}
+			Misconfigurations []struct {
+				Type        string
+				ID          string
+				AVDID       string
+				Description string
+				Message     string
+				Namespace   string
+				Query       string
+				Resolution  string
+				Severity    string
+				PrimaryURL  string
+				References  []string
+				Status      string
+			}
+		}
+	}
+}

--- a/tests/rhwa/internal/rapidast/rapidast.go
+++ b/tests/rhwa/internal/rapidast/rapidast.go
@@ -21,7 +21,7 @@ const (
 	logLevel = rhwaparams.LogLevel
 )
 
-// PrepareRapidastPod initializes the pod in the cluster that allows to run rapidast.
+// PrepareRapidastPod initializes the pod responsible for running rapidast scanner
 func PrepareRapidastPod(apiClient *clients.Settings) (*pod.Builder, error) {
 	nodes, err := nodes.List(apiClient)
 	if err != nil {

--- a/tests/rhwa/internal/rapidast/rapidast.go
+++ b/tests/rhwa/internal/rapidast/rapidast.go
@@ -1,0 +1,83 @@
+package rapidast
+
+import (
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/nodes"
+	"github.com/openshift-kni/eco-goinfra/pkg/pod"
+	"github.com/openshift-kni/eco-goinfra/pkg/rbac"
+	"github.com/openshift-kni/eco-goinfra/pkg/serviceaccount"
+	. "github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwainittools"
+	"github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwaparams"
+
+	v1 "k8s.io/api/rbac/v1"
+)
+
+const (
+	logLevel = rhwaparams.LogLevel
+)
+
+func PrepareRapidastPod(apiClient *clients.Settings) *pod.Builder {
+	nodes, err := nodes.List(apiClient)
+	if err != nil {
+		glog.V(logLevel).Infof(
+			"Error in node list retrieval %s", err.Error())
+	}
+
+	_, err = serviceaccount.NewBuilder(APIClient, "trivy-service-account", rhwaparams.TestNamespaceName).Create()
+	if err != nil {
+		glog.V(logLevel).Infof(
+			"Error in service acount creation %s", err.Error())
+	}
+
+	_, err = rbac.NewClusterRoleBuilder(APIClient, "trivy-clusterrole", v1.PolicyRule{
+		APIGroups: []string{
+			"",
+		},
+		Resources: []string{
+			"pods",
+		},
+		Verbs: []string{
+			"get",
+			"list",
+			"watch",
+		},
+	}).Create()
+	if err != nil {
+		glog.V(logLevel).Infof(
+			"Error in ClusterRoleBuilder creation %s", err.Error())
+	}
+
+	_, err = rbac.NewClusterRoleBindingBuilder(APIClient, "trivy-clusterrole-binding", "trivy-clusterrole", v1.Subject{
+		Kind:      "ServiceAccount",
+		Name:      "trivy-service-account",
+		Namespace: rhwaparams.TestNamespaceName,
+	}).Create()
+	if err != nil {
+		glog.V(logLevel).Infof(
+			"Error in ClusterRoleBindingBuilder creation %s", err.Error())
+	}
+
+	dastTestPod := pod.NewBuilder(
+		APIClient, "rapidastclientpod", rhwaparams.TestNamespaceName, rhwaparams.TestContainerDast).
+		DefineOnNode(nodes[0].Object.Name).
+		WithTolerationToMaster().
+		WithPrivilegedFlag()
+	if err != nil {
+		glog.V(logLevel).Infof(
+			"Error in rapidast client pod definition %s", err.Error())
+	}
+
+	dastTestPod.Definition.Spec.ServiceAccountName = "trivy-service-account"
+
+	_, err = dastTestPod.CreateAndWaitUntilRunning(time.Minute)
+	if err != nil {
+		glog.V(logLevel).Infof(
+			"Error in rapidast client pod creation %s", err.Error())
+	}
+
+	return dastTestPod
+
+}

--- a/tests/rhwa/internal/rapidast/rapidast.go
+++ b/tests/rhwa/internal/rapidast/rapidast.go
@@ -21,17 +21,19 @@ const (
 	logLevel = rhwaparams.LogLevel
 )
 
-// PrepareRapidastPod initializes the pod responsible for running rapidast scanner
+// PrepareRapidastPod initializes the pod responsible for running rapidast scanner.
 func PrepareRapidastPod(apiClient *clients.Settings) (*pod.Builder, error) {
 	nodes, err := nodes.List(apiClient)
 	if err != nil {
 		glog.V(logLevel).Infof("Error in node list retrieval %s", err.Error())
+
 		return nil, err
 	}
 
 	_, err = serviceaccount.NewBuilder(APIClient, "trivy-service-account", rhwaparams.TestNamespaceName).Create()
 	if err != nil {
 		glog.V(logLevel).Infof("Error in service account creation %s", err.Error())
+
 		return nil, err
 	}
 
@@ -50,6 +52,7 @@ func PrepareRapidastPod(apiClient *clients.Settings) (*pod.Builder, error) {
 	}).Create()
 	if err != nil {
 		glog.V(logLevel).Infof("Error in ClusterRoleBuilder creation %s", err.Error())
+
 		return nil, err
 	}
 
@@ -60,6 +63,7 @@ func PrepareRapidastPod(apiClient *clients.Settings) (*pod.Builder, error) {
 	}).Create()
 	if err != nil {
 		glog.V(logLevel).Infof("Error in ClusterRoleBindingBuilder creation %s", err.Error())
+
 		return nil, err
 	}
 
@@ -73,6 +77,7 @@ func PrepareRapidastPod(apiClient *clients.Settings) (*pod.Builder, error) {
 	_, err = dastTestPod.CreateAndWaitUntilRunning(time.Minute)
 	if err != nil {
 		glog.V(logLevel).Infof("Error in rapidast client pod creation %s", err.Error())
+
 		return nil, err
 	}
 

--- a/tests/rhwa/internal/rapidast/rapidast.go
+++ b/tests/rhwa/internal/rapidast/rapidast.go
@@ -6,13 +6,13 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
-	"github.com/openshift-kni/eco-goinfra/pkg/nodes"
-	"github.com/openshift-kni/eco-goinfra/pkg/pod"
-	"github.com/openshift-kni/eco-goinfra/pkg/rbac"
-	"github.com/openshift-kni/eco-goinfra/pkg/serviceaccount"
-	. "github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwainittools"
-	"github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwaparams"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/rbac"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/serviceaccount"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwainittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwaparams"
 
 	v1 "k8s.io/api/rbac/v1"
 )

--- a/tests/rhwa/internal/rhwaparams/const.go
+++ b/tests/rhwa/internal/rhwaparams/const.go
@@ -11,10 +11,10 @@ const (
 	RhwaOperatorNs = "openshift-workload-availability"
 	// DefaultTimeout represents the default timeout.
 	DefaultTimeout = 300 * time.Second
-	// TestNamespaceName namespace where all dast test cases are performed
+	// TestNamespaceName namespace where all dast test cases are performed.
 	TestNamespaceName = "dast-tests"
-
+	// LogLevel for the supporting functions.
 	LogLevel = 90
-
+	// TestContainerDast specifies the container image to use for rapidast tests.
 	TestContainerDast = "quay.io/frmoreno/eco-dast:latest"
 )

--- a/tests/rhwa/internal/rhwaparams/const.go
+++ b/tests/rhwa/internal/rhwaparams/const.go
@@ -11,4 +11,8 @@ const (
 	RhwaOperatorNs = "openshift-workload-availability"
 	// DefaultTimeout represents the default timeout.
 	DefaultTimeout = 300 * time.Second
+	// TestNamespaceName namespace where all dast test cases are performed
+	TestNamespaceName = "dast-tests"
+
+	TestContainerDast = "quay.io/frmoreno/eco-dast:latest"
 )

--- a/tests/rhwa/internal/rhwaparams/const.go
+++ b/tests/rhwa/internal/rhwaparams/const.go
@@ -16,5 +16,5 @@ const (
 	// LogLevel for the supporting functions.
 	LogLevel = 90
 	// TestContainerDast specifies the container image to use for rapidast tests.
-	TestContainerDast = "quay.io/frmoreno/eco-dast:latest"
+	TestContainerDast = "quay.io/ocp-edge-qe/eco-dast:latest"
 )

--- a/tests/rhwa/internal/rhwaparams/const.go
+++ b/tests/rhwa/internal/rhwaparams/const.go
@@ -14,5 +14,7 @@ const (
 	// TestNamespaceName namespace where all dast test cases are performed
 	TestNamespaceName = "dast-tests"
 
+	LogLevel = 90
+
 	TestContainerDast = "quay.io/frmoreno/eco-dast:latest"
 )


### PR DESCRIPTION
This test runs a container to run rapidast utility from inside the cluster, running inside the trivy scanner that checks for vulnerabilities in running pods of the configured namespace.
The test fails in case there is a vulnerability found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - End-to-end DAST security scan added for FAR Operator post-deployment to detect misconfigurations.

* **Tests**
  - Automated privileged test namespace creation/cleanup and JUnit report integration.
  - New DAST test runs RapidAST scans in a privileged pod, captures structured reports, and fails on detected misconfigurations.
  - Test helpers added to provision the scanning pod and execute scans.

* **Style**
  - Import-order cleanup in tests.

* **Chores**
  - Scanner configuration adjusted and test config values (namespace, log level, scan image) added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->