### PR TITLE
Fix kmm 24 preflight tests

### DIFF
--- a/tests/hw-accel/kmm/internal/await/await.go
+++ b/tests/hw-accel/kmm/internal/await/await.go
@@ -150,11 +150,13 @@ func PreflightStageDone(apiClient *clients.Settings, preflight, module, nsname s
 				if moduleStatus.Name == module && moduleStatus.Namespace == nsname {
 					status := moduleStatus.VerificationStage
 					glog.V(kmmparams.KmmLogLevel).Infof("Stage: %s", status)
+
 					return status == "Done", nil
 				}
 			}
 
 			glog.V(kmmparams.KmmLogLevel).Infof("module %s not found in preflight validation status", module)
+
 			return false, nil
 		})
 }

--- a/tests/hw-accel/kmm/internal/await/await.go
+++ b/tests/hw-accel/kmm/internal/await/await.go
@@ -28,7 +28,7 @@ func BuildPodCompleted(apiClient *clients.Settings, nsname string, timeout time.
 			var err error
 
 			if buildPod[nsname] == "" {
-				// Search across all pod phases; preflight pull pods may finish quickly.
+				// Search across all pod phases to catch build pods that may complete quickly
 				pods, err := pod.List(apiClient, nsname, metav1.ListOptions{})
 
 				if err != nil {
@@ -36,10 +36,9 @@ func BuildPodCompleted(apiClient *clients.Settings, nsname string, timeout time.
 				}
 
 				for _, podObj := range pods {
-					// Detect both build pods and preflight pull pods.
-					if strings.Contains(podObj.Object.Name, "-build") || strings.Contains(podObj.Object.Name, "-pull-pod") {
+					if strings.Contains(podObj.Object.Name, "-build") {
 						buildPod[nsname] = podObj.Object.Name
-						glog.V(kmmparams.KmmLogLevel).Infof("Detected build/pull pod '%s'\n", podObj.Object.Name)
+						glog.V(kmmparams.KmmLogLevel).Infof("Build pod '%s' found\n", podObj.Object.Name)
 					}
 				}
 			}

--- a/tests/hw-accel/kmm/internal/await/await.go
+++ b/tests/hw-accel/kmm/internal/await/await.go
@@ -127,7 +127,6 @@ func ModuleObjectDeleted(apiClient *clients.Settings, moduleName, nsName string,
 		})
 }
 
-/**
 // PreflightStageDone awaits preflightvalidationocp to be in stage Done.
 func PreflightStageDone(apiClient *clients.Settings, preflight, module, nsname string,
 	timeout time.Duration) error {
@@ -141,18 +140,23 @@ func PreflightStageDone(apiClient *clients.Settings, preflight, module, nsname s
 			}
 
 			preflightValidationOCP, err := pre.Get()
-
-			if err == nil {
-				status := preflightValidationOCP.Status.CRStatuses[module].VerificationStage
-				glog.V(kmmparams.KmmLogLevel).Infof("Stage: %s", status)
-
-				return status == "Done", nil
+			if err != nil {
+				return false, err
 			}
 
-			return false, err
+			// Search for the module in the new Modules array structure
+			for _, moduleStatus := range preflightValidationOCP.Status.Modules {
+				if moduleStatus.Name == module && moduleStatus.Namespace == nsname {
+					status := moduleStatus.VerificationStage
+					glog.V(kmmparams.KmmLogLevel).Infof("Stage: %s", status)
+					return status == "Done", nil
+				}
+			}
+
+			glog.V(kmmparams.KmmLogLevel).Infof("module %s not found in preflight validation status", module)
+			return false, nil
 		})
 }
-**/
 
 func deploymentPerLabel(apiClient *clients.Settings, moduleName, label string,
 	timeout time.Duration, selector map[string]string) error {

--- a/tests/hw-accel/kmm/internal/get/get.go
+++ b/tests/hw-accel/kmm/internal/get/get.go
@@ -167,6 +167,7 @@ func PreflightReason(apiClient *clients.Settings, preflight, module, nsname stri
 		if moduleStatus.Name == module && moduleStatus.Namespace == nsname {
 			reason := moduleStatus.StatusReason
 			glog.V(kmmparams.KmmLogLevel).Infof("VerificationStatus: %s", reason)
+			fmt.Printf("DEBUG: Actual preflight reason for %s/%s: '%s'\n", nsname, module, reason)
 			return reason, nil
 		}
 	}

--- a/tests/hw-accel/kmm/internal/get/get.go
+++ b/tests/hw-accel/kmm/internal/get/get.go
@@ -164,7 +164,6 @@ func PreflightReason(apiClient *clients.Settings, preflight, module, nsname stri
 		if moduleStatus.Name == module && moduleStatus.Namespace == nsname {
 			reason := moduleStatus.StatusReason
 			glog.V(kmmparams.KmmLogLevel).Infof("VerificationStatus: %s", reason)
-			fmt.Printf("DEBUG: Actual preflight reason for %s/%s: '%s'\n", nsname, module, reason)
 			return reason, nil
 		}
 	}

--- a/tests/hw-accel/kmm/internal/get/get.go
+++ b/tests/hw-accel/kmm/internal/get/get.go
@@ -164,11 +164,13 @@ func PreflightReason(apiClient *clients.Settings, preflight, module, nsname stri
 		if moduleStatus.Name == module && moduleStatus.Namespace == nsname {
 			reason := moduleStatus.StatusReason
 			glog.V(kmmparams.KmmLogLevel).Infof("VerificationStatus: %s", reason)
+
 			return reason, nil
 		}
 	}
 
 	glog.V(kmmparams.KmmLogLevel).Infof("module %s not found in preflight validation status", module)
+
 	return "", fmt.Errorf("module %s not found in namespace %s", module, nsname)
 }
 

--- a/tests/hw-accel/kmm/internal/get/get.go
+++ b/tests/hw-accel/kmm/internal/get/get.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/go-version"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/kmm"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/olm"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/kmmparams"
@@ -149,22 +150,30 @@ func ModuleLoadedMessage(module, nsname string) string {
 }
 
 // PreflightReason returns the reason of a preflightvalidationocp check.
-/**
+
 func PreflightReason(apiClient *clients.Settings, preflight, module, nsname string) (string, error) {
-	pre, _ := kmm.PullPreflightValidationOCP(apiClient, preflight, nsname)
-
-	preflightValidationOCP, err := pre.Get()
-
-	if err == nil {
-		reason := preflightValidationOCP.Status.CRStatuses[module].StatusReason
-		glog.V(kmmparams.KmmLogLevel).Infof("VerificationStatus: %s", reason)
-
-		return reason, nil
+	pre, err := kmm.PullPreflightValidationOCP(apiClient, preflight, nsname)
+	if err != nil {
+		return "", err
 	}
 
-	return "", err
+	preflightValidationOCP, err := pre.Get()
+	if err != nil {
+		return "", err
+	}
+
+	// Search for the module in the new Modules array structure
+	for _, moduleStatus := range preflightValidationOCP.Status.Modules {
+		if moduleStatus.Name == module && moduleStatus.Namespace == nsname {
+			reason := moduleStatus.StatusReason
+			glog.V(kmmparams.KmmLogLevel).Infof("VerificationStatus: %s", reason)
+			return reason, nil
+		}
+	}
+
+	glog.V(kmmparams.KmmLogLevel).Infof("module %s not found in preflight validation status", module)
+	return "", fmt.Errorf("module %s not found in namespace %s", module, nsname)
 }
-**/
 
 // ModuleUnloadedMessage returns message for a module unloaded event.
 func ModuleUnloadedMessage(module, nsname string) string {

--- a/tests/hw-accel/kmm/internal/get/get.go
+++ b/tests/hw-accel/kmm/internal/get/get.go
@@ -128,17 +128,15 @@ func SigningData(key string, value string) map[string][]byte {
 	return secretContents
 }
 
-// PreflightImage returns preflightvalidationocp image to be used based on architecture.
+// PreflightImage returns preflightvalidationocp DTK image to be used based on architecture.
 func PreflightImage(arch string) string {
-	if arch == "arm64" {
-		arch = "aarch64"
+	// Use specific DTK images with SHA for KMM 2.4 compatibility
+	if arch == "arm64" || arch == "aarch64" {
+		return kmmparams.PreflightDTKImageARM64
 	}
 
-	if arch == "amd64" {
-		arch = "x86_64"
-	}
-
-	return fmt.Sprintf(kmmparams.PreflightTemplateImage, arch)
+	// Default to x86_64/amd64
+	return kmmparams.PreflightDTKImageX86
 }
 
 // ModuleLoadedMessage returns message for a module loaded event.
@@ -150,7 +148,6 @@ func ModuleLoadedMessage(module, nsname string) string {
 }
 
 // PreflightReason returns the reason of a preflightvalidationocp check.
-
 func PreflightReason(apiClient *clients.Settings, preflight, module, nsname string) (string, error) {
 	pre, err := kmm.PullPreflightValidationOCP(apiClient, preflight, nsname)
 	if err != nil {

--- a/tests/hw-accel/kmm/internal/kmmparams/const.go
+++ b/tests/hw-accel/kmm/internal/kmmparams/const.go
@@ -220,11 +220,13 @@ const (
 	// DefaultNodesNamespace represents namespace of the nodes events.
 	DefaultNodesNamespace = "default"
 	// PreflightDTKImageX86 represents x86_64 DTK image for KMM 2.4 preflightvalidationocp.
-	// Compatible with OpenShift Container Platform 4.18
-	PreflightDTKImageX86 = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7bfeb4d93b12a70c561de0d104d21c1898dac65d96808ff2d2f772134b4261e8"
+	// Compatible with OpenShift Container Platform 4.18.
+	PreflightDTKImageX86 = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:" +
+		"7bfeb4d93b12a70c561de0d104d21c1898dac65d96808ff2d2f772134b4261e8"
 	// PreflightDTKImageARM64 represents ARM64 DTK image for KMM 2.4 preflightvalidationocp.
-	// Compatible with OpenShift Container Platform 4.18
-	PreflightDTKImageARM64 = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ada767898092f36e8d965292843f9a772b2df449aeda06580430162696bd5ddf"
+	// Compatible with OpenShift Container Platform 4.18.
+	PreflightDTKImageARM64 = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:" +
+		"ada767898092f36e8d965292843f9a772b2df449aeda06580430162696bd5ddf"
 	// PreflightName represents preflightvalidation ocp object name.
 	PreflightName = "preflight"
 	// ScannerTestNamespace represents test case namespace name.

--- a/tests/hw-accel/kmm/internal/kmmparams/const.go
+++ b/tests/hw-accel/kmm/internal/kmmparams/const.go
@@ -219,8 +219,10 @@ const (
 	TolerationModuleTestNamespace = "79205-tol"
 	// DefaultNodesNamespace represents namespace of the nodes events.
 	DefaultNodesNamespace = "default"
-	// PreflightTemplateImage represents image against which preflightvalidationocp will build against.
-	PreflightTemplateImage = "quay.io/openshift-release-dev/ocp-release:4.16.15-%s"
+	// PreflightDTKImageX86 represents x86_64 DTK image for KMM 2.4 preflightvalidationocp.
+	PreflightDTKImageX86 = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7bfeb4d93b12a70c561de0d104d21c1898dac65d96808ff2d2f772134b4261e8"
+	// PreflightDTKImageARM64 represents ARM64 DTK image for KMM 2.4 preflightvalidationocp.
+	PreflightDTKImageARM64 = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ada767898092f36e8d965292843f9a772b2df449aeda06580430162696bd5ddf"
 	// PreflightName represents preflightvalidation ocp object name.
 	PreflightName = "preflight"
 	// ScannerTestNamespace represents test case namespace name.

--- a/tests/hw-accel/kmm/internal/kmmparams/const.go
+++ b/tests/hw-accel/kmm/internal/kmmparams/const.go
@@ -220,8 +220,10 @@ const (
 	// DefaultNodesNamespace represents namespace of the nodes events.
 	DefaultNodesNamespace = "default"
 	// PreflightDTKImageX86 represents x86_64 DTK image for KMM 2.4 preflightvalidationocp.
+	// Compatible with OpenShift Container Platform 4.18
 	PreflightDTKImageX86 = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7bfeb4d93b12a70c561de0d104d21c1898dac65d96808ff2d2f772134b4261e8"
 	// PreflightDTKImageARM64 represents ARM64 DTK image for KMM 2.4 preflightvalidationocp.
+	// Compatible with OpenShift Container Platform 4.18
 	PreflightDTKImageARM64 = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ada767898092f36e8d965292843f9a772b2df449aeda06580430162696bd5ddf"
 	// PreflightName represents preflightvalidation ocp object name.
 	PreflightName = "preflight"

--- a/tests/hw-accel/kmm/modules/tests/realtime-test.go
+++ b/tests/hw-accel/kmm/modules/tests/realtime-test.go
@@ -198,7 +198,7 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelLong
 
 		})
 
-		It("should be able to run preflightvalidation for realtime kernel", reportxml.ID("RT001"), func() {
+		It("should be able to run preflightvalidation for realtime kernel", reportxml.ID("84177"), func() {
 			By("Get kernel version from cluster")
 			kernelVersion, err := get.KernelFullVersion(APIClient, GeneralConfig.WorkerLabelMap)
 			if err != nil {

--- a/tests/hw-accel/kmm/modules/tests/realtime-test.go
+++ b/tests/hw-accel/kmm/modules/tests/realtime-test.go
@@ -2,7 +2,7 @@ package tests
 
 import (
 	"fmt"
-
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -196,6 +196,50 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelLong
 				GeneralConfig.WorkerLabelMap)
 			Expect(err).ToNot(HaveOccurred(), "error while checking the module is loaded")
 
+		})
+
+		It("should be able to run preflightvalidation for realtime kernel", reportxml.ID("RT001"), func() {
+			By("Get kernel version from cluster")
+			kernelVersion, err := get.KernelFullVersion(APIClient, GeneralConfig.WorkerLabelMap)
+			if err != nil {
+				Skip("could not get cluster kernel version")
+			}
+
+			By("Detecting cluster architecture")
+			arch, err := get.ClusterArchitecture(APIClient, GeneralConfig.WorkerLabelMap)
+			if err != nil {
+				Skip("could not detect cluster architecture")
+			}
+			dtkImage := get.PreflightImage(arch)
+
+			By("Wait for realtime module to be fully deployed before creating preflight")
+			err = await.ModuleDeployment(APIClient, moduleName, kmmparams.RealtimeKernelNamespace, 2*time.Minute,
+				GeneralConfig.WorkerLabelMap)
+			Expect(err).ToNot(HaveOccurred(), "error while waiting for realtime module deployment")
+
+			By("Create preflightvalidationocp for realtime kernel")
+			pre, err := kmm.NewPreflightValidationOCPBuilder(APIClient, kmmparams.PreflightName,
+				kmmparams.RealtimeKernelNamespace).
+				WithKernelVersion(kernelVersion).
+				WithDtkImage(dtkImage).
+				WithPushBuiltImage(false).
+				Create()
+			Expect(err).ToNot(HaveOccurred(), "error while creating realtime preflight")
+
+			By("Await preflightvalidationocp checks for realtime kernel")
+			err = await.PreflightStageDone(APIClient, kmmparams.PreflightName, moduleName,
+				kmmparams.RealtimeKernelNamespace, 3*time.Minute)
+			Expect(err).NotTo(HaveOccurred(), "preflightvalidationocp did not complete for realtime kernel")
+
+			By("Get status of the realtime preflightvalidationocp checks")
+			status, _ := get.PreflightReason(APIClient, kmmparams.PreflightName, moduleName,
+				kmmparams.RealtimeKernelNamespace)
+			Expect(strings.Contains(status, "Verification successful")).
+				To(BeTrue(), "expected realtime preflight success message not found")
+
+			By("Delete realtime preflight validation")
+			_, err = pre.Delete()
+			Expect(err).ToNot(HaveOccurred(), "error deleting realtime preflightvalidation")
 		})
 	})
 })

--- a/tests/hw-accel/kmm/modules/tests/signing-test.go
+++ b/tests/hw-accel/kmm/modules/tests/signing-test.go
@@ -54,12 +54,12 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 			crb := define.ModuleCRB(*svcAccount, kmodName)
 			err = crb.Delete()
 			Expect(err).ToNot(HaveOccurred(), "error creating test namespace")
-			/*
-				By("Delete preflightvalidationocp")
-				_, err = kmm.NewPreflightValidationOCPBuilder(APIClient, kmmparams.PreflightName,
-					kmmparams.ModuleBuildAndSignNamespace).Delete()
-				Expect(err).ToNot(HaveOccurred(), "error deleting preflightvalidationocp")
-			*/
+
+			By("Delete preflightvalidationocp")
+			_, err = kmm.NewPreflightValidationOCPBuilder(APIClient, kmmparams.PreflightName,
+				kmmparams.ModuleBuildAndSignNamespace).Delete()
+			Expect(err).ToNot(HaveOccurred(), "error deleting preflightvalidationocp")
+
 			By("Delete Namespace")
 			err = namespace.NewBuilder(APIClient, kmmparams.ModuleBuildAndSignNamespace).Delete()
 			Expect(err).ToNot(HaveOccurred(), "error creating test namespace")

--- a/tests/hw-accel/kmm/modules/tests/use-dtk-auto-test.go
+++ b/tests/hw-accel/kmm/modules/tests/use-dtk-auto-test.go
@@ -202,6 +202,11 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 				Skip("could not get cluster kernel version")
 			}
 
+			By("Wait for module to be fully deployed before creating preflight")
+			err = await.ModuleDeployment(APIClient, moduleName, kmmparams.UseDtkModuleTestNamespace, 2*time.Minute,
+				GeneralConfig.WorkerLabelMap)
+			Expect(err).ToNot(HaveOccurred(), "error while waiting for module deployment")
+
 			By("Create preflightvalidationocp")
 			pre, err := kmm.NewPreflightValidationOCPBuilder(APIClient, kmmparams.PreflightName,
 				kmmparams.UseDtkModuleTestNamespace).

--- a/tests/hw-accel/kmm/modules/tests/use-dtk-auto-test.go
+++ b/tests/hw-accel/kmm/modules/tests/use-dtk-auto-test.go
@@ -76,13 +76,6 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 
 		It("should use DTK_AUTO parameter", reportxml.ID("54283"), func() {
 
-			By("Detecting cluster architecture")
-			arch, err := get.ClusterArchitecture(APIClient, GeneralConfig.WorkerLabelMap)
-			if err != nil {
-				Skip("could not detect cluster architecture")
-			}
-			dtkImage := get.PreflightImage(arch)
-
 			configmapContents := define.MultiStageConfigMapContent(kmodName)
 
 			By("Create ConfigMap")
@@ -106,7 +99,6 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 
 			kernelMapping.WithContainerImage(image).
 				WithBuildArg(kmmparams.BuildArgName, buildArgValue).
-				WithBuildArg("DTK_AUTO", dtkImage).
 				WithBuildDockerCfgFile(dockerfileConfigMap.Object.Name)
 			kerMapOne, err := kernelMapping.BuildKernelMappingConfig()
 			Expect(err).ToNot(HaveOccurred(), "error creating kernel mapping")

--- a/tests/hw-accel/kmm/modules/tests/use-dtk-auto-test.go
+++ b/tests/hw-accel/kmm/modules/tests/use-dtk-auto-test.go
@@ -194,12 +194,19 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 			if err != nil {
 				Skip("could not detect cluster architecture")
 			}
-			preflightImage := get.PreflightImage(arch)
+			dtkImage := get.PreflightImage(arch)
+
+			By("Get kernel version from cluster")
+			kernelVersion, err := get.KernelFullVersion(APIClient, GeneralConfig.WorkerLabelMap)
+			if err != nil {
+				Skip("could not get cluster kernel version")
+			}
 
 			By("Create preflightvalidationocp")
 			pre, err := kmm.NewPreflightValidationOCPBuilder(APIClient, kmmparams.PreflightName,
 				kmmparams.UseDtkModuleTestNamespace).
-				WithKernelVersion(preflightImage).
+				WithKernelVersion(kernelVersion).
+				WithDtkImage(dtkImage).
 				WithPushBuiltImage(false).
 				Create()
 			Expect(err).ToNot(HaveOccurred(), "error while creating preflight")
@@ -231,12 +238,19 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 			if err != nil {
 				Skip("could not detect cluster architecture")
 			}
-			preflightImage := get.PreflightImage(arch)
+			dtkImage := get.PreflightImage(arch)
+
+			By("Get kernel version from cluster")
+			kernelVersion, err := get.KernelFullVersion(APIClient, GeneralConfig.WorkerLabelMap)
+			if err != nil {
+				Skip("could not get cluster kernel version")
+			}
 
 			By("Create preflightvalidationocp")
 			_, err = kmm.NewPreflightValidationOCPBuilder(APIClient, kmmparams.PreflightName,
 				kmmparams.UseDtkModuleTestNamespace).
-				WithKernelVersion(preflightImage).
+				WithKernelVersion(kernelVersion).
+				WithDtkImage(dtkImage).
 				WithPushBuiltImage(true).
 				Create()
 			Expect(err).ToNot(HaveOccurred(), "error while creating preflight")

--- a/tests/hw-accel/kmm/modules/tests/use-dtk-auto-test.go
+++ b/tests/hw-accel/kmm/modules/tests/use-dtk-auto-test.go
@@ -2,12 +2,14 @@ package tests
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/await"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/check"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/define"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/get"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/kmmparams"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/modules/internal/tsparams"
 
@@ -61,12 +63,10 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 			err = crb.Delete()
 			Expect(err).ToNot(HaveOccurred(), "error deleting test namespace")
 
-			/*
-				By("Delete preflightvalidationocp")
-				_, err = kmm.NewPreflightValidationOCPBuilder(APIClient, kmmparams.PreflightName,
-					kmmparams.UseDtkModuleTestNamespace).Delete()
-				Expect(err).ToNot(HaveOccurred(), "error deleting preflightvalidationocp")
-			*/
+			By("Delete preflightvalidationocp")
+			_, err = kmm.NewPreflightValidationOCPBuilder(APIClient, kmmparams.PreflightName,
+				kmmparams.UseDtkModuleTestNamespace).Delete()
+			Expect(err).ToNot(HaveOccurred(), "error deleting preflightvalidationocp")
 
 			By("Delete Namespace")
 			err = namespace.NewBuilder(APIClient, kmmparams.UseDtkModuleTestNamespace).Delete()
@@ -186,75 +186,75 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 			Expect(err.Error()).To(ContainSubstring("missing spec.moduleLoader.container.kernelMappings"))
 			Expect(err.Error()).To(ContainSubstring(".containerImage"))
 		})
-		/*
-			It("should be able to run preflightvalidation with no push to registry", reportxml.ID("56330"), func() {
-				By("Detecting cluster architecture")
 
-				arch, err := get.ClusterArchitecture(APIClient, GeneralConfig.WorkerLabelMap)
-				if err != nil {
-					Skip("could not detect cluster architecture")
-				}
-				preflightImage := get.PreflightImage(arch)
+		It("should be able to run preflightvalidation with no push to registry", reportxml.ID("56330"), func() {
+			By("Detecting cluster architecture")
 
-				By("Create preflightvalidationocp")
-				pre, err := kmm.NewPreflightValidationOCPBuilder(APIClient, kmmparams.PreflightName,
-					kmmparams.UseDtkModuleTestNamespace).
-					WithReleaseImage(preflightImage).
-					WithPushBuiltImage(false).
-					Create()
-				Expect(err).ToNot(HaveOccurred(), "error while creating preflight")
+			arch, err := get.ClusterArchitecture(APIClient, GeneralConfig.WorkerLabelMap)
+			if err != nil {
+				Skip("could not detect cluster architecture")
+			}
+			preflightImage := get.PreflightImage(arch)
 
-				By("Await build pod to complete build")
-				err = await.BuildPodCompleted(APIClient, kmmparams.UseDtkModuleTestNamespace, 5*time.Minute)
-				Expect(err).ToNot(HaveOccurred(), "error while building module")
+			By("Create preflightvalidationocp")
+			pre, err := kmm.NewPreflightValidationOCPBuilder(APIClient, kmmparams.PreflightName,
+				kmmparams.UseDtkModuleTestNamespace).
+				WithKernelVersion(preflightImage).
+				WithPushBuiltImage(false).
+				Create()
+			Expect(err).ToNot(HaveOccurred(), "error while creating preflight")
 
-				By("Await preflightvalidationocp checks")
-				err = await.PreflightStageDone(APIClient, kmmparams.PreflightName, moduleName,
-					kmmparams.UseDtkModuleTestNamespace, 3*time.Minute)
-				Expect(err).NotTo(HaveOccurred(), "preflightvalidationocp did not complete")
+			By("Await build pod to complete build")
+			err = await.BuildPodCompleted(APIClient, kmmparams.UseDtkModuleTestNamespace, 5*time.Minute)
+			Expect(err).ToNot(HaveOccurred(), "error while building module")
 
-				By("Get status of the preflightvalidationocp checks")
-				status, _ := get.PreflightReason(APIClient, kmmparams.PreflightName, moduleName,
-					kmmparams.UseDtkModuleTestNamespace)
-				Expect(strings.Contains(status, "Verification successful (build compiles)")).
-					To(BeTrue(), "expected message not found")
+			By("Await preflightvalidationocp checks")
+			err = await.PreflightStageDone(APIClient, kmmparams.PreflightName, moduleName,
+				kmmparams.UseDtkModuleTestNamespace, 3*time.Minute)
+			Expect(err).NotTo(HaveOccurred(), "preflightvalidationocp did not complete")
 
-				By("Delete preflight validation")
-				_, err = pre.Delete()
-				Expect(err).ToNot(HaveOccurred(), "error deleting preflightvalidation")
-			})
+			By("Get status of the preflightvalidationocp checks")
+			status, _ := get.PreflightReason(APIClient, kmmparams.PreflightName, moduleName,
+				kmmparams.UseDtkModuleTestNamespace)
+			Expect(strings.Contains(status, "Verification successful (build compiles)")).
+				To(BeTrue(), "expected message not found")
 
-			It("should be able to run preflightvalidation and push to registry", reportxml.ID("56328"), func() {
-				By("Detecting cluster architecture")
+			By("Delete preflight validation")
+			_, err = pre.Delete()
+			Expect(err).ToNot(HaveOccurred(), "error deleting preflightvalidation")
+		})
 
-				arch, err := get.ClusterArchitecture(APIClient, GeneralConfig.WorkerLabelMap)
-				if err != nil {
-					Skip("could not detect cluster architecture")
-				}
-				preflightImage := get.PreflightImage(arch)
+		It("should be able to run preflightvalidation and push to registry", reportxml.ID("56328"), func() {
+			By("Detecting cluster architecture")
 
-				By("Create preflightvalidationocp")
-				_, err = kmm.NewPreflightValidationOCPBuilder(APIClient, kmmparams.PreflightName,
-					kmmparams.UseDtkModuleTestNamespace).
-					WithReleaseImage(preflightImage).
-					WithPushBuiltImage(true).
-					Create()
-				Expect(err).ToNot(HaveOccurred(), "error while creating preflight")
+			arch, err := get.ClusterArchitecture(APIClient, GeneralConfig.WorkerLabelMap)
+			if err != nil {
+				Skip("could not detect cluster architecture")
+			}
+			preflightImage := get.PreflightImage(arch)
 
-				By("Await build pod to complete build")
-				err = await.BuildPodCompleted(APIClient, kmmparams.UseDtkModuleTestNamespace, 10*time.Minute)
-				Expect(err).ToNot(HaveOccurred(), "error while building module")
+			By("Create preflightvalidationocp")
+			_, err = kmm.NewPreflightValidationOCPBuilder(APIClient, kmmparams.PreflightName,
+				kmmparams.UseDtkModuleTestNamespace).
+				WithKernelVersion(preflightImage).
+				WithPushBuiltImage(true).
+				Create()
+			Expect(err).ToNot(HaveOccurred(), "error while creating preflight")
 
-				By("Await preflightvalidationocp checks")
-				err = await.PreflightStageDone(APIClient, kmmparams.PreflightName, moduleName,
-					kmmparams.UseDtkModuleTestNamespace, 3*time.Minute)
-				Expect(err).NotTo(HaveOccurred(), "preflightvalidationocp did not complete")
+			By("Await build pod to complete build")
+			err = await.BuildPodCompleted(APIClient, kmmparams.UseDtkModuleTestNamespace, 10*time.Minute)
+			Expect(err).ToNot(HaveOccurred(), "error while building module")
 
-				By("Get status of the preflightvalidationocp checks")
-				status, _ := get.PreflightReason(APIClient, kmmparams.PreflightName, moduleName,
-					kmmparams.UseDtkModuleTestNamespace)
-				Expect(strings.Contains(status, "Verification successful (build compiles and image pushed)")).
-					To(BeTrue(), "expected message not found")
-			})*/
+			By("Await preflightvalidationocp checks")
+			err = await.PreflightStageDone(APIClient, kmmparams.PreflightName, moduleName,
+				kmmparams.UseDtkModuleTestNamespace, 3*time.Minute)
+			Expect(err).NotTo(HaveOccurred(), "preflightvalidationocp did not complete")
+
+			By("Get status of the preflightvalidationocp checks")
+			status, _ := get.PreflightReason(APIClient, kmmparams.PreflightName, moduleName,
+				kmmparams.UseDtkModuleTestNamespace)
+			Expect(strings.Contains(status, "Verification successful (build compiles and image pushed)")).
+				To(BeTrue(), "expected message not found")
+		})
 	})
 })

--- a/tests/hw-accel/kmm/modules/tests/use-dtk-auto-test.go
+++ b/tests/hw-accel/kmm/modules/tests/use-dtk-auto-test.go
@@ -76,6 +76,13 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 
 		It("should use DTK_AUTO parameter", reportxml.ID("54283"), func() {
 
+			By("Detecting cluster architecture")
+			arch, err := get.ClusterArchitecture(APIClient, GeneralConfig.WorkerLabelMap)
+			if err != nil {
+				Skip("could not detect cluster architecture")
+			}
+			dtkImage := get.PreflightImage(arch)
+
 			configmapContents := define.MultiStageConfigMapContent(kmodName)
 
 			By("Create ConfigMap")
@@ -99,6 +106,7 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 
 			kernelMapping.WithContainerImage(image).
 				WithBuildArg(kmmparams.BuildArgName, buildArgValue).
+				WithBuildArg("DTK_AUTO", dtkImage).
 				WithBuildDockerCfgFile(dockerfileConfigMap.Object.Name)
 			kerMapOne, err := kernelMapping.BuildKernelMappingConfig()
 			Expect(err).ToNot(HaveOccurred(), "error creating kernel mapping")

--- a/tests/hw-accel/kmm/modules/tests/use-dtk-auto-test.go
+++ b/tests/hw-accel/kmm/modules/tests/use-dtk-auto-test.go
@@ -229,7 +229,8 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 			By("Get status of the preflightvalidationocp checks")
 			status, _ := get.PreflightReason(APIClient, kmmparams.PreflightName, moduleName,
 				kmmparams.UseDtkModuleTestNamespace)
-			Expect(strings.Contains(status, "Verification successful (build compiles)") || strings.Contains(status, "verified image exists")).
+			Expect(strings.Contains(status, "Verification successful (build compiles)") ||
+				strings.Contains(status, "verified image exists")).
 				To(BeTrue(), "expected message not found")
 
 			By("Delete preflight validation")
@@ -274,7 +275,8 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 			By("Get status of the preflightvalidationocp checks")
 			status, _ := get.PreflightReason(APIClient, kmmparams.PreflightName, moduleName,
 				kmmparams.UseDtkModuleTestNamespace)
-			Expect(strings.Contains(status, "Verification successful (build compiles and image pushed)") || strings.Contains(status, "verified image exists")).
+			Expect(strings.Contains(status, "Verification successful (build compiles and image pushed)") ||
+				strings.Contains(status, "verified image exists")).
 				To(BeTrue(), "expected message not found")
 		})
 	})


### PR DESCRIPTION
Updates preflight validation OCP tests for KMM 2.4 compatibility to resolve test failures caused by API-breaking changes.
KMM 2.4 API Migration:

Update from deprecated WithReleaseImage() to WithKernelVersion() + WithDtkImage()
Migrate from Status.CRStatuses[module] to Status.Modules[] array structure
Re-enable previously commented out preflight validation functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Architecture-specific DTK images for preflight validation (x86 and ARM64).
  * Added preflight validation coverage for the realtime kernel.

* **Tests**
  * Re-enabled and stabilized preflight flows (no-push and push) using runtime kernel/architecture detection.
  * Added module deployment gating, improved wait time handling, and ensured test cleanup by deleting created resources.
  * More robust status assertions accepting environment-specific success messages.

* **Improvements**
  * More reliable build-pod detection and clearer logging when modules or build pods are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->