### PR TITLE
Fix realtime failure test

### DIFF
--- a/tests/hw-accel/kmm/modules/tests/realtime-test.go
+++ b/tests/hw-accel/kmm/modules/tests/realtime-test.go
@@ -58,7 +58,7 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelLong
 			mcpName = get.MachineConfigPoolName(APIClient)
 		})
 
-		AfterEach(func() {
+		AfterAll(func() {
 			By("Delete Module")
 			_, _ = kmm.NewModuleBuilder(APIClient, moduleName, kmmparams.RealtimeKernelNamespace).Delete()
 
@@ -211,11 +211,6 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelLong
 				Skip("could not detect cluster architecture")
 			}
 			dtkImage := get.PreflightImage(arch)
-
-			By("Wait for realtime module to be fully deployed before creating preflight")
-			err = await.ModuleDeployment(APIClient, moduleName, kmmparams.RealtimeKernelNamespace, 2*time.Minute,
-				GeneralConfig.WorkerLabelMap)
-			Expect(err).ToNot(HaveOccurred(), "error while waiting for realtime module deployment")
 
 			By("Create preflightvalidationocp for realtime kernel")
 			pre, err := kmm.NewPreflightValidationOCPBuilder(APIClient, kmmparams.PreflightName,


### PR DESCRIPTION
Use AfterAll instead of AfterEach
remove unnecessary wait for realtime module deployment before preflight

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Consolidated teardown to run once per suite, reducing per-test overhead and improving stability. Cleanup now removes all created resources and waits for the cluster to stabilize.
  - Adjusted test flow to wait for module deployment before creating preflight validation resources, reducing flakes and improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->