### PR TITLE
hwaccel: adding multiple utills for deploying all operators

### DIFF
--- a/tests/hw-accel/amdgpu/basic/internal/tsparams/amdgpu-vars.go
+++ b/tests/hw-accel/amdgpu/basic/internal/tsparams/amdgpu-vars.go
@@ -1,0 +1,15 @@
+package tsparams
+
+import "github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpuparams"
+
+// Re-export variables from amdgpuparams for convenience.
+var (
+	// Labels represents the range of labels that can be used for test cases selection.
+	Labels = amdgpuparams.Labels
+
+	// ReporterNamespacesToDump tells to the reporter from where to collect logs.
+	ReporterNamespacesToDump = amdgpuparams.ReporterNamespacesToDump
+
+	// ReporterCRDsToDump tells to the reporter what CRs to dump.
+	ReporterCRDsToDump = amdgpuparams.ReporterCRDsToDump
+)

--- a/tests/hw-accel/amdgpu/basic/internal/tsparams/consts.go
+++ b/tests/hw-accel/amdgpu/basic/internal/tsparams/consts.go
@@ -1,0 +1,172 @@
+package tsparams
+
+import "github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpuparams"
+
+const (
+	// LabelSuite represents amdgpu label that can be used for test cases selection.
+	LabelSuite = "amdgpu"
+)
+
+// Re-export constants from amdgpuparams for convenience.
+const (
+	AMDGPUTestNamespace     = amdgpuparams.AMDGPUTestNamespace
+	AMDGPUOperatorNamespace = amdgpuparams.AMDGPUOperatorNamespace
+	LogLevel                = amdgpuparams.LogLevel
+)
+
+// ROCMSmiScript contains a bash script for testing ROCm GPU functionality.
+const ROCMSmiScript = `
+#!/bin/bash
+set -e
+
+echo "=== ROCm GPU Test Started ==="
+echo "Date: $(date)"
+echo "Hostname: $(hostname)"
+
+# Function to check GPU availability with multiple attempts
+check_gpu() {
+    echo "=== Checking GPU availability ==="
+
+    # Try rocm-smi first
+    if rocm-smi --showid --showproductname --showvram 2>/dev/null; then
+        echo "SUCCESS: rocm-smi detected GPU"
+        return 0
+    fi
+
+    # Fallback: try basic rocm-smi
+    if rocm-smi 2>/dev/null; then
+        echo "SUCCESS: Basic rocm-smi working"
+        return 0
+    fi
+
+    echo "WARNING: rocm-smi failed, but continuing test"
+    return 0  # Don't fail the test, just warn
+}
+
+# Function to run GPU workload with timeout control
+run_gpu_workload() {
+    echo "=== Starting GPU workload ==="
+
+    # Start workload in background with controlled timeout
+
+    timeout 115 python3 - <<'EOF' &
+import sys
+import time
+import os
+
+try:
+    print(f"Python version: {sys.version}")
+
+    # Try to import and test PyTorch
+    try:
+        import torch
+        print(f"PyTorch version: {torch.__version__}")
+        print(f"CUDA available: {torch.cuda.is_available()}")
+
+        if torch.cuda.is_available():
+            device_count = torch.cuda.device_count()
+            print(f"CUDA devices found: {device_count}")
+
+            for i in range(device_count):
+                print(f"Device {i}: {torch.cuda.get_device_name(i)}")
+
+            device = torch.device("cuda:0")
+            print(f"Using device: {device}")
+
+            # Create larger tensors for higher load and memory usage.
+            # Adjust size (e.g., 8000, 12000) based on your GPU VRAM.
+            tensor_size = 8000
+            print(f"Creating tensors of size ({tensor_size}, {tensor_size})...")
+            a = torch.rand((tensor_size, tensor_size), device=device, dtype=torch.float32)
+            b = torch.rand((tensor_size, tensor_size), device=device, dtype=torch.float32)
+
+            print("Running matrix multiplication workload...")
+            # Run for ~55 seconds to match the monitoring duration
+            for i in range(55):
+                result = torch.matmul(a, b)
+                torch.cuda.synchronize() # Wait for the operation to complete
+                if i % 5 == 0:
+                    print(f"Workload iteration {i}/55 completed")
+                time.sleep(1)
+
+            print("GPU workload completed successfully")
+        else:
+            print("INFO: CUDA not available, but test continues")
+
+    except ImportError as e:
+        print(f"INFO: PyTorch not available: {e}")
+    except Exception as e:
+        print(f"WARNING: GPU workload error: {e}")
+
+    print("Workload phase completed")
+
+except Exception as e:
+    print(f"ERROR in workload: {e}")
+    # Don't exit with error - let monitoring continue
+EOF
+
+    WORKLOAD_PID=$!
+    echo "GPU workload started with PID: $WORKLOAD_PID"
+
+    # Wait a bit for workload to start and allocate memory
+    sleep 5
+    return 0
+}
+
+# Function to monitor GPU with rocm-smi - more frequent sampling
+monitor_gpu() {
+    echo "=== Monitoring GPU activity ==="
+
+    for i in {1..30}; do
+        echo "--- ROCm-SMI Output (iteration $i/30) ---"
+
+        # Try comprehensive rocm-smi first
+        if rocm-smi --showuse --showmemuse --showtemp --showpower --showclocks 2>/dev/null; then
+            echo "Detailed monitoring successful"
+        elif rocm-smi --showuse --showpower 2>/dev/null; then
+            echo "Basic monitoring successful"
+        elif rocm-smi 2>/dev/null; then
+            echo "Minimal monitoring successful"
+        else
+            echo "Warning: rocm-smi monitoring failed at iteration $i"
+        fi
+
+        # Show GPU processes if possible
+        rocm-smi --showpids 2>/dev/null || echo "No process info available"
+
+        sleep 2
+    done
+}
+
+# --- Main Execution ---
+echo "Step 1: Initial GPU check"
+check_gpu || echo "GPU check had issues but continuing"
+
+echo "Step 2: Starting GPU workload"
+run_gpu_workload || echo "Workload start had issues but continuing"
+
+echo "Step 3: Monitoring GPU activity for 60 seconds"
+monitor_gpu
+
+echo "Step 4: Waiting for workload to complete and checking status"
+if wait $WORKLOAD_PID; then
+    echo "SUCCESS: Workload process (PID: $WORKLOAD_PID) completed successfully."
+else
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -eq 124 ]; then
+        echo "WARNING: Workload process (PID: $WORKLOAD_PID) was terminated by timeout."
+    else
+        echo "WARNING: Workload process (PID: $WORKLOAD_PID) exited with error code: $EXIT_CODE."
+    fi
+fi
+
+
+echo "Step 5: Final GPU status check"
+echo "=== Final ROCm-SMI Status (after workload) ==="
+rocm-smi --showuse --showmemuse --showtemp --showpower 2>/dev/null || \
+rocm-smi 2>/dev/null || echo "Final status check failed"
+
+echo "=== ROCm GPU Test Completed ==="
+echo "Test finished at: $(date)"
+sleep 15
+`

--- a/tests/hw-accel/amdgpu/basic/tests/basic-test.go
+++ b/tests/hw-accel/amdgpu/basic/tests/basic-test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -9,11 +10,19 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/eco-goinfra/pkg/amdgpu"
 	"github.com/openshift-kni/eco-goinfra/pkg/nodes"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpudeviceconfig"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpuhelpers"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpunfd"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpuparams"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpuregistry"
 	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/deviceconfig"
 	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/labels"
 	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/pods"
 	amdparams "github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/params"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/internal/deploy"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/nfd/nfdparams"
 	"github.com/openshift-kni/eco-gotests/tests/internal/inittools"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -27,16 +36,160 @@ var _ = Describe("AMD GPU Basic Tests", Ordered, Label(amdparams.LabelSuite), fu
 			LabelSelector: fmt.Sprintf("%s=%s", amdparams.AMDNFDLabelKey, amdparams.AMDNFDLabelValue),
 		}
 
-		amdNodeBuilders, amdNodeBuildersErr := nodes.List(apiClient, amdListOptions)
+		var amdNodeBuilders []*nodes.Builder
+		var amdNodeBuildersErr error
 
 		BeforeAll(func() {
 
-			Expect(amdNodeBuildersErr).To(BeNil(),
-				fmt.Sprintf("Failed to get Builders for AMD GPU Worker Nodes. Error:\n%v\n", amdNodeBuildersErr))
+			By("Verifying and configuring internal image registry for AMD GPU operator")
+			err := amdgpuregistry.VerifyAndConfigureInternalRegistry(apiClient)
+			if err != nil {
+				glog.V(amdgpuparams.LogLevel).Infof("Internal registry configuration warning: %v", err)
+				Skip("Internal image registry is not available - required for AMD GPU operator")
+			}
 
-			Expect(amdNodeBuilders).ToNot(BeEmpty(),
-				"'amdNodeBuilders' can't be empty")
+			By("Deploying required operators")
+			err = amdgpuhelpers.DeployAllOperators(apiClient)
+			Expect(err).ToNot(HaveOccurred(), "Failed to deploy required operators")
 
+			By("Creating machineconfig for AMD GPU blacklist")
+			err = amdgpuhelpers.CreateBlacklistMachineConfig(apiClient)
+			Expect(err).ToNot(HaveOccurred(), "failed to create blacklist MachineConfig")
+
+		})
+		AfterAll(func() {
+
+			By("Uninstalling all operators in reverse order")
+
+			By("Uninstalling AMD GPU operator")
+			amdgpuUninstallConfig := amdgpuhelpers.GetDefaultAMDGPUUninstallConfig(
+				apiClient,
+				"amd-gpu-operator-group",
+				"amd-gpu-operator")
+			amdgpuUninstaller := deploy.NewOperatorUninstaller(amdgpuUninstallConfig)
+			err := amdgpuUninstaller.Uninstall()
+			if err != nil {
+				glog.V(amdgpuparams.LogLevel).Infof("AMD GPU operator uninstall completed with issues: %v", err)
+			} else {
+				glog.V(amdgpuparams.LogLevel).Info("AMD GPU operator uninstalled successfully")
+			}
+
+			By("Uninstalling KMM operator")
+			kmmUninstallConfig := amdgpuhelpers.GetDefaultKMMUninstallConfig(apiClient, nil)
+			kmmUninstaller := deploy.NewOperatorUninstaller(kmmUninstallConfig)
+			err = kmmUninstaller.Uninstall()
+			if err != nil {
+				glog.V(amdgpuparams.LogLevel).Infof("KMM operator uninstall completed with issues: %v", err)
+			} else {
+				glog.V(amdgpuparams.LogLevel).Info("KMM operator uninstalled successfully")
+			}
+
+			By("Uninstalling NFD operator")
+			nfdUninstallConfig := deploy.OperatorUninstallConfig{
+				APIClient:         apiClient,
+				Namespace:         nfdparams.NFDNamespace,
+				OperatorGroupName: "nfd-operator-group",
+				SubscriptionName:  "nfd-subscription",
+				CustomResourceCleaner: deploy.NewNFDCustomResourceCleaner(
+					apiClient, nfdparams.NFDNamespace, glog.Level(amdgpuparams.LogLevel)),
+				LogLevel: glog.Level(amdgpuparams.LogLevel),
+			}
+			nfdUninstaller := deploy.NewOperatorUninstaller(nfdUninstallConfig)
+			err = nfdUninstaller.Uninstall()
+			if err != nil {
+				glog.V(amdgpuparams.LogLevel).Infof("NFD operator uninstall completed with issues: %v", err)
+			} else {
+				glog.V(amdgpuparams.LogLevel).Info("NFD operator uninstalled successfully")
+			}
+
+			glog.V(amdgpuparams.LogLevel).Info("All operator uninstallations completed")
+		})
+		It("Should verify internal registry is configured and available", func() {
+			By("Checking internal image registry configuration")
+			err := amdgpuregistry.VerifyAndConfigureInternalRegistry(apiClient)
+			Expect(err).NotTo(HaveOccurred(), "Internal image registry should be properly configured")
+
+			By("Verifying image registry pods are running")
+			pods, err := apiClient.CoreV1Interface.Pods("openshift-image-registry").List(
+				context.Background(), metav1.ListOptions{
+					LabelSelector: "docker-registry=default",
+				})
+			Expect(err).NotTo(HaveOccurred(), "Should be able to list image registry pods")
+
+			runningPods := 0
+			for _, pod := range pods.Items {
+				if pod.Status.Phase == corev1.PodRunning {
+					allReady := true
+					for _, containerStatus := range pod.Status.ContainerStatuses {
+						if !containerStatus.Ready {
+							allReady = false
+
+							break
+						}
+					}
+					if allReady {
+						runningPods++
+					}
+				}
+			}
+
+			Expect(runningPods).To(BeNumerically(">", 0), "At least one image registry pod should be running")
+			glog.V(amdgpuparams.LogLevel).Infof("Internal image registry verified: %d pods running", runningPods)
+		})
+
+		It("Should create NodeFeatureDiscovery for AMD GPU detection", func() {
+			By("Deploying NFD custom resource with AMD GPU worker config")
+
+			nfdCRUtils := deploy.NewNFDCRUtils(apiClient, nfdparams.NFDNamespace, "amd-gpu-nfd-instance")
+
+			nfdConfig := deploy.NFDCRConfig{
+				EnableTopology: false,
+				Image:          "",
+				WorkerConfig:   "",
+			}
+			glog.V(amdgpuparams.LogLevel).Infof("NFD CR deployment : %+v", nfdConfig)
+			err := nfdCRUtils.DeployNFDCR(nfdConfig)
+			if err != nil {
+				glog.V(amdgpuparams.LogLevel).Infof("NFD CR deployment result: %v", err)
+				Skip("NFD CR deployment may require existing NFD operator or custom configuration")
+			}
+
+			By("Creating AMD GPU FeatureRule for enhanced detection")
+			err = amdgpunfd.CreateAMDGPUFeatureRule(apiClient)
+			if err != nil {
+				glog.V(amdgpuparams.LogLevel).Infof("AMD GPU FeatureRule creation result: %v", err)
+				Skip("AMD GPU FeatureRule creation may require NFD operator or manual creation")
+			}
+
+			By("NFD CR deployed successfully for AMD GPU detection")
+			glog.V(amdgpuparams.LogLevel).Info("NFD custom resource created with AMD GPU worker configuration")
+
+		})
+		It("Should provide instructions for DeviceConfig creation", func() {
+			By("Creating DeviceConfig custom resource")
+			err := amdgpudeviceconfig.CreateDeviceConfig(apiClient, amdgpuparams.DefaultDeviceConfigName)
+			if err != nil {
+				glog.V(amdgpuparams.LogLevel).Infof("DeviceConfig creation result: %v", err)
+
+			}
+			Expect(err).ToNot(HaveOccurred(), "DeviceConfig should be created successfully")
+
+			deviceConfigBuilder, deviceConfigBuilderErr := amdgpu.Pull(
+				apiClient,
+				amdgpuparams.DefaultDeviceConfigName,
+				amdgpuparams.AMDGPUOperatorNamespace)
+
+			if deviceConfigBuilderErr != nil {
+				glog.Info(deviceConfigBuilder)
+			}
+
+			By("Waiting for cluster stability after DeviceConfig creation")
+			err = amdgpuhelpers.WaitForClusterStabilityAfterDeviceConfig(apiClient)
+			if err != nil {
+				glog.V(amdgpuparams.LogLevel).Infof("Cluster stability check failed: %w", err)
+
+				Skip("Cluster stability check failed - may need longer wait time or manual intervention")
+			}
 		})
 
 		It("Check AMD label was added by NFD", func() {
@@ -54,6 +207,13 @@ var _ = Describe("AMD GPU Basic Tests", Ordered, Label(amdparams.LabelSuite), fu
 
 		It("Node Labeller", func() {
 
+			amdNodeBuilders, amdNodeBuildersErr = nodes.List(apiClient, amdListOptions)
+
+			Expect(amdNodeBuildersErr).To(BeNil(),
+				fmt.Sprintf("Failed to get Builders for AMD GPU Worker Nodes. Error:\n%v\n", amdNodeBuildersErr))
+
+			Expect(amdNodeBuilders).ToNot(BeEmpty(),
+				"'amdNodeBuilders' can't be empty")
 			By("Getting Device Config Builder")
 			deviceConfigBuilder, deviceConfigBuilderErr := amdgpu.Pull(
 				apiClient, amdparams.DeviceConfigName, amdparams.AMDGPUNamespace)
@@ -65,7 +225,7 @@ var _ = Describe("AMD GPU Basic Tests", Ordered, Label(amdparams.LabelSuite), fu
 			glog.V(amdparams.AMDGPULogLevel).Infof("nodeLabellerEnabled: %t", nodeLabellerEnabled)
 
 			By("Enabling the Node Labeller")
-			enableNodeLabellerErr := deviceconfig.SetEnableNodeLabeller(true, deviceConfigBuilder, false)
+			enableNodeLabellerErr := deviceconfig.SetEnableNodeLabeller(true, deviceConfigBuilder, true)
 			Expect(enableNodeLabellerErr).To(BeNil(),
 				fmt.Sprintf("Failed to enable NodeLabeller. Error:\n%v\n", enableNodeLabellerErr))
 
@@ -93,7 +253,7 @@ var _ = Describe("AMD GPU Basic Tests", Ordered, Label(amdparams.LabelSuite), fu
 				"Failed to get DeviceConfigNew Builder. Error:\n%v\n", deviceConfigBuilderNewErr))
 
 			By("Disabling the Node Labeller")
-			disableNodeLabellerErr := deviceconfig.SetEnableNodeLabeller(false, deviceConfigBuilderNew, false)
+			disableNodeLabellerErr := deviceconfig.SetEnableNodeLabeller(false, deviceConfigBuilderNew, true)
 			Expect(disableNodeLabellerErr).To(BeNil(),
 				fmt.Sprintf("Failed to disable NodeLabeller. Error:\n%v\n", disableNodeLabellerErr))
 
@@ -107,14 +267,6 @@ var _ = Describe("AMD GPU Basic Tests", Ordered, Label(amdparams.LabelSuite), fu
 			Expect(missingNodeLabellerLabelsErr).To(BeNil(), fmt.Sprintf("failure occurred while checking "+
 				"that Node Labeller Labels were removed from all AMD GPU Worker Nodes. %v", missingNodeLabellerLabelsErr))
 
-			By("Ensuring that the Node Labeller state is the same as it was before the test")
-			deviceConfigBuilderNew.Exists()
-			if nodeLabellerEnabled != deviceconfig.IsNodeLabellerEnabled(deviceConfigBuilderNew) {
-				restoringNodeLabellerErr := deviceconfig.SetEnableNodeLabeller(nodeLabellerEnabled, deviceConfigBuilderNew, false)
-				Expect(restoringNodeLabellerErr).To(BeNil(),
-					fmt.Sprintf("Failed to restore enableNodeLabeller to '%t'. Error:\n%t\n",
-						nodeLabellerEnabled, *deviceconfig.GetEnableNodeLabeller(deviceConfigBuilderNew)))
-			}
 		})
 	})
 })

--- a/tests/hw-accel/amdgpu/internal/amdgpucommon/cluster.go
+++ b/tests/hw-accel/amdgpu/internal/amdgpucommon/cluster.go
@@ -1,0 +1,39 @@
+package amdgpucommon
+
+import (
+	"context"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// IsSingleNodeOpenShift determines if this is a Single Node OpenShift cluster.
+func IsSingleNodeOpenShift(apiClient *clients.Settings) (bool, error) {
+	nodes, err := apiClient.CoreV1Interface.Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	nodeCount := len(nodes.Items)
+	glog.V(100).Infof("Detected %d nodes in cluster", nodeCount)
+
+	if nodeCount == 1 {
+		node := nodes.Items[0]
+		if _, hasControlPlane := node.Labels["node-role.kubernetes.io/control-plane"]; hasControlPlane {
+			glog.V(100).Infof("Confirmed SNO: single node %s has control-plane role", node.Name)
+
+			return true, nil
+		}
+
+		if _, hasMaster := node.Labels["node-role.kubernetes.io/master"]; hasMaster {
+			glog.V(100).Infof("Confirmed SNO: single node %s has master role", node.Name)
+
+			return true, nil
+		}
+
+		glog.V(100).Infof("Warning: single node %s lacks master/control-plane role", node.Name)
+	}
+
+	return nodeCount == 1, nil
+}

--- a/tests/hw-accel/amdgpu/internal/amdgpucommon/errors.go
+++ b/tests/hw-accel/amdgpu/internal/amdgpucommon/errors.go
@@ -1,0 +1,14 @@
+package amdgpucommon
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+// IsCRDNotAvailable checks if the error indicates that a CRD is not available.
+func IsCRDNotAvailable(err error) bool {
+	return errors.IsNotFound(err) ||
+		strings.Contains(err.Error(), "no matches for kind") ||
+		strings.Contains(err.Error(), "resource mapping not found")
+}

--- a/tests/hw-accel/amdgpu/internal/amdgpucommon/pods.go
+++ b/tests/hw-accel/amdgpu/internal/amdgpucommon/pods.go
@@ -1,0 +1,21 @@
+package amdgpucommon
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// AreAllContainersReady checks if all containers in a pod are ready.
+func AreAllContainersReady(pod corev1.Pod) bool {
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if !containerStatus.Ready {
+			return false
+		}
+	}
+
+	return true
+}
+
+// IsPodRunningAndReady checks if a pod is running and all containers are ready.
+func IsPodRunningAndReady(pod corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodRunning && AreAllContainersReady(pod)
+}

--- a/tests/hw-accel/amdgpu/internal/amdgpucommon/utils.go
+++ b/tests/hw-accel/amdgpu/internal/amdgpucommon/utils.go
@@ -1,0 +1,18 @@
+package amdgpucommon
+
+import "github.com/golang/glog"
+
+// StringPtr returns a pointer to the given string.
+func StringPtr(s string) *string {
+	return &s
+}
+
+// BoolPtr returns a pointer to the given bool.
+func BoolPtr(b bool) *bool {
+	return &b
+}
+
+// LogLevelPtr returns a pointer to the given glog.Level.
+func LogLevelPtr(level glog.Level) *glog.Level {
+	return &level
+}

--- a/tests/hw-accel/amdgpu/internal/amdgpuconfig/amdgpu-config.go
+++ b/tests/hw-accel/amdgpu/internal/amdgpuconfig/amdgpu-config.go
@@ -1,0 +1,205 @@
+package amdgpuconfig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpuparams"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/exec"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// This package now focuses only on node labeling and verification operations
+// Other functionality has been moved to more focused packages:
+// - amdgpudeviceconfig: DeviceConfig CRD operations
+// - amdgpumachineconfig: MachineConfig and MCP operations
+// - amdgpuregistry: Image registry management
+// - amdgpunfd: NodeFeatureDiscovery operations
+
+// WaitForAMDGPUNodes waits for nodes to be labeled with AMD GPU features.
+func WaitForAMDGPUNodes(apiClient *clients.Settings, timeout time.Duration) error {
+	glog.V(90).Info("Waiting for nodes to be labeled with AMD GPU features")
+
+	return WaitForNodeLabel(apiClient, "feature.node.kubernetes.io/amd-gpu", "true", timeout)
+}
+
+// WaitForNodeLabel waits for at least one node to have the specified label.
+func WaitForNodeLabel(apiClient *clients.Settings, labelKey, labelValue string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			nodes, err := apiClient.CoreV1Interface.Nodes().List(ctx, metav1.ListOptions{
+				LabelSelector: labelKey + "=" + labelValue,
+			})
+			if err != nil {
+				glog.V(90).Infof("Error listing nodes: %v", err)
+				time.Sleep(10 * time.Second)
+
+				continue
+			}
+
+			if len(nodes.Items) > 0 {
+				glog.V(90).Infof("Found %d nodes with label %s=%s", len(nodes.Items), labelKey, labelValue)
+
+				return nil
+			}
+
+			glog.V(90).Infof("No nodes found with label %s=%s, waiting...", labelKey, labelValue)
+			time.Sleep(10 * time.Second)
+		}
+	}
+}
+
+// VerifyAMDGPUKernelModule checks if the amdgpu kernel module is properly blacklisted.
+func VerifyAMDGPUKernelModule(apiClient *clients.Settings) error {
+	glog.V(amdgpuparams.LogLevel).Infof("Verifying amdgpu kernel module is blacklisted on nodes")
+
+	nodes, err := getAMDGPUNodes(apiClient)
+	if err != nil {
+		glog.V(amdgpuparams.LogLevel).Infof("Failed to get AMD GPU nodes (this may be expected): %v", err)
+
+		return nil
+	}
+
+	if len(nodes.Items) == 0 {
+		glog.V(amdgpuparams.LogLevel).Infof("No nodes with AMD GPU labels found - verification skipped")
+
+		return nil
+	}
+
+	return verifyKernelModuleOnNodes(apiClient, nodes.Items)
+}
+
+// getAMDGPUNodes retrieves nodes with AMD GPU labels.
+func getAMDGPUNodes(apiClient *clients.Settings) (*corev1.NodeList, error) {
+	nodes, err := apiClient.CoreV1Interface.Nodes().List(
+		context.TODO(), metav1.ListOptions{
+			LabelSelector: "feature.node.kubernetes.io/amd-gpu=true",
+		})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list AMD GPU nodes: %w", err)
+	}
+
+	return nodes, nil
+}
+
+// verifyKernelModuleOnNodes verifies kernel module status on all provided nodes.
+func verifyKernelModuleOnNodes(apiClient *clients.Settings, nodes []corev1.Node) error {
+	success := true
+
+	for _, node := range nodes {
+		if !checkKernelModuleOnNode(apiClient, node.Name) {
+			success = false
+		}
+	}
+
+	if !success {
+		return fmt.Errorf("failed to verify amdgpu module status on some nodes")
+	}
+
+	return nil
+}
+
+// checkKernelModuleOnNode checks kernel module status on a single node.
+func checkKernelModuleOnNode(apiClient *clients.Settings, nodeName string) bool {
+	glog.V(amdgpuparams.LogLevel).Infof("Checking amdgpu module status on node %s", nodeName)
+
+	if !checkModuleBlacklist(apiClient, nodeName) {
+		return false
+	}
+
+	return checkModuleLoadStatus(apiClient, nodeName)
+}
+
+// checkModuleBlacklist checks if amdgpu module is blacklisted.
+func checkModuleBlacklist(apiClient *clients.Settings, nodeName string) bool {
+	blacklistCheck := "modprobe -n -v amdgpu | grep -q 'blacklisted' && echo 'BLACKLISTED' || echo 'NOT_BLACKLISTED'"
+
+	output, err := execCommandOnNode(apiClient, nodeName, blacklistCheck)
+	if err != nil {
+		glog.V(amdgpuparams.LogLevel).Infof("Error checking blacklist on node %s: %v", nodeName, err)
+
+		return false
+	}
+
+	glog.V(amdgpuparams.LogLevel).Infof("Node %s amdgpu module blacklist status: %s", nodeName, output)
+
+	return true
+}
+
+// checkModuleLoadStatus checks if amdgpu module is loaded.
+func checkModuleLoadStatus(apiClient *clients.Settings, nodeName string) bool {
+	loadedCheck := "lsmod | grep amdgpu || echo 'MODULE_NOT_LOADED'"
+	output, err := execCommandOnNode(apiClient, nodeName, loadedCheck)
+
+	if err != nil {
+		glog.V(amdgpuparams.LogLevel).Infof("Error checking module load status on node %s: %v", nodeName, err)
+
+		return false
+	}
+
+	logModuleLoadStatus(nodeName, output)
+
+	return true
+}
+
+// logModuleLoadStatus logs the module load status.
+func logModuleLoadStatus(nodeName, output string) {
+	if strings.Contains(output, "amdgpu") && !strings.Contains(output, "MODULE_NOT_LOADED") {
+		glog.V(amdgpuparams.LogLevel).Infof("WARNING: amdgpu module is still loaded on node %s", nodeName)
+		glog.V(amdgpuparams.LogLevel).Infof("Module status: %s", output)
+	} else {
+		glog.V(amdgpuparams.LogLevel).Infof("Good: amdgpu module is not loaded on node %s", nodeName)
+	}
+}
+
+// execCommandOnNode executes a command on a specific node and returns the output.
+func execCommandOnNode(apiClient *clients.Settings, nodeName, command string) (string, error) {
+	glog.V(amdgpuparams.LogLevel).Infof("Executing command on node %s: %s", nodeName, command)
+
+	podName := fmt.Sprintf("debug-amdgpu-%s", strings.ToLower(nodeName))
+
+	// Build nsenter command for node debugging
+	nsenterCmd := []string{
+		"nsenter", "--target", "1",
+		"--mount", "--uts", "--ipc", "--net", "--pid",
+		"--", "sh", "-c", command,
+	}
+
+	// Create pod command with node debugging configuration
+	podCommand := exec.NewPodCommandDirect(
+		apiClient,
+		podName,
+		"default",
+		"registry.redhat.io/ubi8/ubi:latest",
+		"debug",
+		nsenterCmd,
+		nil, // requests
+		nil, // limits
+	).
+		WithNodeName(nodeName).
+		WithPrivileged(true).
+		WithHostNetwork(true).
+		WithHostPID(true)
+
+	output, err := podCommand.ExecuteAndCleanup(2 * time.Minute)
+	if err != nil {
+		glog.V(amdgpuparams.LogLevel).Infof("Command execution failed on node %s: %v", nodeName, err)
+
+		return output, err
+	}
+
+	glog.V(amdgpuparams.LogLevel).Infof("Command executed successfully on node %s", nodeName)
+
+	return output, nil
+}

--- a/tests/hw-accel/amdgpu/internal/amdgpudelete/custom_resources.go
+++ b/tests/hw-accel/amdgpu/internal/amdgpudelete/custom_resources.go
@@ -1,0 +1,168 @@
+package amdgpudelete
+
+import (
+	"context"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	amdgpuv1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/amd/gpu-operator/api/v1alpha1"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpucommon"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/internal/deploy"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// AMDGPUCustomResourceCleaner implements CustomResourceCleaner for AMD GPU operators.
+type AMDGPUCustomResourceCleaner struct {
+	APIClient *clients.Settings
+	Namespace string
+	LogLevel  glog.Level
+}
+
+// NewAMDGPUCustomResourceCleaner creates a new AMD GPU custom resource cleaner.
+func NewAMDGPUCustomResourceCleaner(
+	apiClient *clients.Settings,
+	namespace string,
+	logLevel glog.Level) *AMDGPUCustomResourceCleaner {
+	return &AMDGPUCustomResourceCleaner{
+		APIClient: apiClient,
+		Namespace: namespace,
+		LogLevel:  logLevel,
+	}
+}
+
+// CleanupCustomResources implements the CustomResourceCleaner interface for AMD GPU.
+func (a *AMDGPUCustomResourceCleaner) CleanupCustomResources() error {
+	glog.V(a.LogLevel).Infof("Deleting AMD GPU custom resources in namespace %s", a.Namespace)
+
+	deviceConfigList, err := a.listDeviceConfigs()
+	if err != nil {
+		return err
+	}
+
+	if deviceConfigList == nil || len(deviceConfigList.Items) == 0 {
+		glog.V(a.LogLevel).Infof("No AMD GPU custom resources found to delete")
+
+		return nil
+	}
+
+	deletedCount := a.deleteDeviceConfigs(deviceConfigList.Items)
+
+	err = a.waitForDeviceConfigCleanup()
+	if err != nil {
+		glog.V(a.LogLevel).Infof("Timeout waiting for AMD GPU DeviceConfigs removal: %v", err)
+	}
+
+	glog.V(a.LogLevel).Infof("Successfully cleaned up %d AMD GPU custom resources", deletedCount)
+
+	return nil
+}
+
+// listDeviceConfigs retrieves all DeviceConfig resources in the namespace.
+func (a *AMDGPUCustomResourceCleaner) listDeviceConfigs() (*amdgpuv1.DeviceConfigList, error) {
+	ctx := context.Background()
+	deviceConfigList := &amdgpuv1.DeviceConfigList{}
+
+	glog.V(a.LogLevel).Infof("Looking for AMD GPU DeviceConfigs in namespace: %s", a.Namespace)
+	err := a.APIClient.Client.List(ctx, deviceConfigList, client.InNamespace(a.Namespace))
+
+	if err != nil {
+		if amdgpucommon.IsCRDNotAvailable(err) {
+			glog.V(a.LogLevel).Info("AMD GPU DeviceConfig CRD not available - skipping DeviceConfig cleanup")
+
+			return &amdgpuv1.DeviceConfigList{}, nil
+		}
+
+		glog.V(a.LogLevel).Infof("Error listing AMD GPU DeviceConfigs: %v", err)
+
+		return nil, err
+	}
+
+	glog.V(a.LogLevel).Infof("Found %d AMD GPU DeviceConfig(s) to delete", len(deviceConfigList.Items))
+
+	return deviceConfigList, nil
+}
+
+// deleteDeviceConfigs deletes all DeviceConfig resources and returns the count of deleted resources.
+func (a *AMDGPUCustomResourceCleaner) deleteDeviceConfigs(deviceConfigs []amdgpuv1.DeviceConfig) int {
+	ctx := context.Background()
+	deletedCount := 0
+
+	for _, deviceConfig := range deviceConfigs {
+		if a.deleteDeviceConfig(ctx, &deviceConfig) {
+			deletedCount++
+		}
+	}
+
+	return deletedCount
+}
+
+// deleteDeviceConfig deletes a single DeviceConfig resource.
+func (a *AMDGPUCustomResourceCleaner) deleteDeviceConfig(
+	ctx context.Context, deviceConfig *amdgpuv1.DeviceConfig) bool {
+	deviceConfigName := deviceConfig.GetName()
+	glog.V(a.LogLevel).Infof("Deleting AMD GPU DeviceConfig: %s", deviceConfigName)
+
+	if len(deviceConfig.GetFinalizers()) > 0 {
+		a.removeFinalizers(ctx, deviceConfig, deviceConfigName)
+	}
+
+	err := a.APIClient.Client.Delete(ctx, deviceConfig)
+	if err != nil {
+		glog.V(a.LogLevel).Infof("Error deleting AMD GPU DeviceConfig %s: %v", deviceConfigName, err)
+
+		return false
+	}
+
+	glog.V(a.LogLevel).Infof("Successfully deleted AMD GPU DeviceConfig: %s", deviceConfigName)
+
+	return true
+}
+
+// removeFinalizers removes finalizers from a DeviceConfig to ensure clean deletion.
+func (a *AMDGPUCustomResourceCleaner) removeFinalizers(
+	ctx context.Context, deviceConfig *amdgpuv1.DeviceConfig, deviceConfigName string) {
+	glog.V(a.LogLevel).Infof("Removing finalizers from AMD GPU DeviceConfig: %s", deviceConfigName)
+	deviceConfig.SetFinalizers([]string{})
+	err := a.APIClient.Client.Update(ctx, deviceConfig)
+
+	if err != nil {
+		glog.V(a.LogLevel).Infof("Warning: failed to remove finalizers from DeviceConfig %s: %v", deviceConfigName, err)
+	}
+}
+
+// waitForDeviceConfigCleanup waits for all DeviceConfig resources to be completely removed.
+func (a *AMDGPUCustomResourceCleaner) waitForDeviceConfigCleanup() error {
+	ctx := context.Background()
+
+	glog.V(a.LogLevel).Info("Waiting for AMD GPU DeviceConfigs to be fully removed...")
+
+	return wait.PollUntilContextTimeout(
+		ctx, 10*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+			return a.checkDeviceConfigRemoval(ctx)
+		})
+}
+
+// checkDeviceConfigRemoval checks if all DeviceConfig resources have been removed.
+func (a *AMDGPUCustomResourceCleaner) checkDeviceConfigRemoval(ctx context.Context) (bool, error) {
+	currentList := &amdgpuv1.DeviceConfigList{}
+
+	err := a.APIClient.Client.List(ctx, currentList, client.InNamespace(a.Namespace))
+	if err != nil {
+		return false, nil
+	}
+
+	if len(currentList.Items) == 0 {
+		glog.V(a.LogLevel).Info("All AMD GPU DeviceConfigs successfully removed")
+
+		return true, nil
+	}
+
+	glog.V(a.LogLevel).Infof("Still waiting for %d AMD GPU DeviceConfigs to be removed", len(currentList.Items))
+
+	return false, nil
+}
+
+// Interface verification.
+var _ deploy.CustomResourceCleaner = (*AMDGPUCustomResourceCleaner)(nil)

--- a/tests/hw-accel/amdgpu/internal/amdgpudeviceconfig/deviceconfig.go
+++ b/tests/hw-accel/amdgpu/internal/amdgpudeviceconfig/deviceconfig.go
@@ -1,0 +1,123 @@
+package amdgpudeviceconfig
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/amdgpu"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	amdgpuv1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/amd/gpu-operator/api/v1alpha1"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpucommon"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpuparams"
+)
+
+// AMDGPUDeviceIDs contains the supported AMD GPU device IDs.
+var AMDGPUDeviceIDs = []string{
+	"75a3",
+	"75a0",
+	"74a5",
+	"74a0",
+	"74a1",
+	"74a9",
+	"74bd",
+	"740f",
+	"7408",
+	"740c",
+	"738c",
+	"738e",
+}
+
+// AMDVGPUDeviceIDs contains the supported AMD vGPU device IDs.
+var AMDVGPUDeviceIDs = []string{
+	"75b3",
+	"75b0",
+	"74b9",
+	"74b5",
+	"7410",
+}
+
+// CreateDeviceConfig creates the DeviceConfig custom resource to trigger AMD GPU driver installation.
+func CreateDeviceConfig(apiClient *clients.Settings, deviceConfigName string) error {
+	glog.V(amdgpuparams.LogLevel).Infof("Creating DeviceConfig: %s", deviceConfigName)
+
+	deviceConfigBuilder, err := createDeviceConfigBuilder(apiClient, deviceConfigName)
+	if err != nil {
+		return fmt.Errorf("failed to create DeviceConfig builder: %w", err)
+	}
+
+	if deviceConfigBuilder.Exists() {
+		glog.V(amdgpuparams.LogLevel).Info("DeviceConfig already exists")
+
+		return nil
+	}
+
+	_, err = deviceConfigBuilder.Create()
+	if err != nil {
+		return handleDeviceConfigCreationError(err, deviceConfigName)
+	}
+
+	glog.V(amdgpuparams.LogLevel).Info("Successfully created DeviceConfig")
+	glog.V(amdgpuparams.LogLevel).Info("This will trigger AMD GPU driver installation via KMM")
+
+	return nil
+}
+
+// createDeviceConfigBuilder creates a DeviceConfig builder with proper definition.
+func createDeviceConfigBuilder(apiClient *clients.Settings, deviceConfigName string) (*amdgpu.Builder, error) {
+	if apiClient == nil {
+		return nil, fmt.Errorf("apiClient cannot be nil")
+	}
+
+	err := apiClient.AttachScheme(amdgpuv1.AddToScheme)
+	if err != nil {
+		return nil, fmt.Errorf("failed to attach amdgpu scheme: %w", err)
+	}
+
+	builder, err := amdgpu.Pull(apiClient, deviceConfigName, amdgpuparams.AMDGPUOperatorNamespace)
+	if err != nil {
+		glog.V(amdgpuparams.LogLevel).Infof("DeviceConfig %s does not exist, will create new one", deviceConfigName)
+	} else if builder != nil {
+		return builder, nil
+	}
+
+	almExampleJSON := fmt.Sprintf(`[{
+		"apiVersion": "amd.com/v1alpha1",
+		"kind": "DeviceConfig",
+		"metadata": {
+			"name": "%s",
+			"namespace": "%s"
+		},
+		"spec": {
+			"driver": {
+				"enable": true,
+				"version": "%s"
+			},
+			"selector": {
+				"feature.node.kubernetes.io/amd-gpu": "true"
+			}
+		}
+	}]`, deviceConfigName, amdgpuparams.AMDGPUOperatorNamespace, amdgpuparams.DefaultDriverVersion)
+
+	builder = amdgpu.NewBuilderFromObjectString(apiClient, almExampleJSON)
+	if builder == nil {
+		return nil, fmt.Errorf("failed to create DeviceConfig builder from JSON")
+	}
+
+	glog.V(amdgpuparams.LogLevel).Infof("Created DeviceConfig builder with definition")
+
+	return builder, nil
+}
+
+// handleDeviceConfigCreationError handles errors during DeviceConfig creation.
+func handleDeviceConfigCreationError(err error, deviceConfigName string) error {
+	glog.V(amdgpuparams.LogLevel).Infof("Error creating DeviceConfig %s: %v", deviceConfigName, err)
+
+	if amdgpucommon.IsCRDNotAvailable(err) {
+		glog.V(amdgpuparams.LogLevel).Info("DeviceConfig CRD not available - manual creation required")
+		glog.V(amdgpuparams.LogLevel).Infof("DeviceConfig creation failed - CRD may not be installed")
+
+		return fmt.Errorf("DeviceConfig CRD not available, manual creation required")
+	}
+
+	return err
+}

--- a/tests/hw-accel/amdgpu/internal/amdgpuhelpers/config.go
+++ b/tests/hw-accel/amdgpu/internal/amdgpuhelpers/config.go
@@ -1,0 +1,346 @@
+package amdgpuhelpers
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpuconfig"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpudelete"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpumachineconfig"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpuparams"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/internal/deploy"
+)
+
+// AMDGPUInstallConfigOptions holds optional overrides for operator installation configuration.
+type AMDGPUInstallConfigOptions struct {
+	OperatorGroupName      *string
+	SubscriptionName       *string
+	CatalogSource          *string
+	CatalogSourceNamespace *string
+	Channel                *string
+	SkipOperatorGroup      *bool
+	TargetNamespaces       []string
+	LogLevel               *glog.Level
+}
+
+// GetDefaultKMMInstallConfig returns the standard KMM installation configuration.
+func GetDefaultKMMInstallConfig(
+	apiClient *clients.Settings,
+	options *AMDGPUInstallConfigOptions) deploy.OperatorInstallConfig {
+	config := deploy.OperatorInstallConfig{
+		APIClient:              apiClient,
+		Namespace:              "openshift-kmm",
+		OperatorGroupName:      "kernel-module-management",
+		SubscriptionName:       "kernel-module-management",
+		PackageName:            "kernel-module-management",
+		CatalogSource:          "redhat-operators",
+		CatalogSourceNamespace: "openshift-marketplace",
+		Channel:                "stable",
+		SkipOperatorGroup:      false,
+		TargetNamespaces:       []string{},
+		LogLevel:               glog.Level(amdgpuparams.LogLevel),
+	}
+
+	if options != nil {
+		if options.OperatorGroupName != nil {
+			config.OperatorGroupName = *options.OperatorGroupName
+		}
+
+		if options.SubscriptionName != nil {
+			config.SubscriptionName = *options.SubscriptionName
+		}
+
+		if options.CatalogSource != nil {
+			config.CatalogSource = *options.CatalogSource
+		}
+
+		if options.CatalogSourceNamespace != nil {
+			config.CatalogSourceNamespace = *options.CatalogSourceNamespace
+		}
+
+		if options.Channel != nil {
+			config.Channel = *options.Channel
+		}
+
+		if options.SkipOperatorGroup != nil {
+			config.SkipOperatorGroup = *options.SkipOperatorGroup
+		}
+
+		if len(options.TargetNamespaces) > 0 {
+			config.TargetNamespaces = options.TargetNamespaces
+		}
+
+		if options.LogLevel != nil {
+			config.LogLevel = *options.LogLevel
+		}
+	}
+
+	return config
+}
+
+// GetAlternativeKMMInstallConfig returns alternative KMM installation configuration.
+// Tries community operators catalog with fast channel.
+func GetAlternativeKMMInstallConfig(
+	apiClient *clients.Settings,
+	options *AMDGPUInstallConfigOptions) deploy.OperatorInstallConfig {
+	config := deploy.OperatorInstallConfig{
+		APIClient:              apiClient,
+		Namespace:              "openshift-kmm",
+		OperatorGroupName:      "kernel-module-management",
+		SubscriptionName:       "kernel-module-management",
+		PackageName:            "kernel-module-management",
+		CatalogSource:          "community-operators",
+		CatalogSourceNamespace: "openshift-marketplace",
+		Channel:                "fast",
+		SkipOperatorGroup:      false,
+		TargetNamespaces:       []string{""},
+		LogLevel:               glog.Level(amdgpuparams.LogLevel),
+	}
+
+	if options != nil {
+		if options.OperatorGroupName != nil {
+			config.OperatorGroupName = *options.OperatorGroupName
+		}
+
+		if options.SubscriptionName != nil {
+			config.SubscriptionName = *options.SubscriptionName
+		}
+
+		if options.CatalogSource != nil {
+			config.CatalogSource = *options.CatalogSource
+		}
+
+		if options.CatalogSourceNamespace != nil {
+			config.CatalogSourceNamespace = *options.CatalogSourceNamespace
+		}
+
+		if options.Channel != nil {
+			config.Channel = *options.Channel
+		}
+
+		if options.SkipOperatorGroup != nil {
+			config.SkipOperatorGroup = *options.SkipOperatorGroup
+		}
+
+		if len(options.TargetNamespaces) > 0 {
+			config.TargetNamespaces = options.TargetNamespaces
+		}
+
+		if options.LogLevel != nil {
+			config.LogLevel = *options.LogLevel
+		}
+	}
+
+	return config
+}
+
+// GetLegacyKMMInstallConfig returns legacy KMM installation configuration.
+// Tries operator with suffix and older channel.
+func GetLegacyKMMInstallConfig(
+	apiClient *clients.Settings,
+	options *AMDGPUInstallConfigOptions) deploy.OperatorInstallConfig {
+	config := deploy.OperatorInstallConfig{
+		APIClient:              apiClient,
+		Namespace:              "openshift-kmm",
+		OperatorGroupName:      "kernel-module-management",
+		SubscriptionName:       "kernel-module-management-operator",
+		PackageName:            "kernel-module-management-operator",
+		CatalogSource:          "redhat-operators",
+		CatalogSourceNamespace: "openshift-marketplace",
+		Channel:                "1.0",
+		SkipOperatorGroup:      false,
+		TargetNamespaces:       []string{"openshift-kmm"},
+		LogLevel:               glog.Level(amdgpuparams.LogLevel),
+	}
+
+	if options != nil {
+		if options.OperatorGroupName != nil {
+			config.OperatorGroupName = *options.OperatorGroupName
+		}
+
+		if options.SubscriptionName != nil {
+			config.SubscriptionName = *options.SubscriptionName
+		}
+
+		if options.CatalogSource != nil {
+			config.CatalogSource = *options.CatalogSource
+		}
+
+		if options.CatalogSourceNamespace != nil {
+			config.CatalogSourceNamespace = *options.CatalogSourceNamespace
+		}
+
+		if options.Channel != nil {
+			config.Channel = *options.Channel
+		}
+
+		if options.SkipOperatorGroup != nil {
+			config.SkipOperatorGroup = *options.SkipOperatorGroup
+		}
+
+		if len(options.TargetNamespaces) > 0 {
+			config.TargetNamespaces = options.TargetNamespaces
+		}
+
+		if options.LogLevel != nil {
+			config.LogLevel = *options.LogLevel
+		}
+	}
+
+	return config
+}
+
+// GetCustomKMMInstallConfig returns a custom KMM configuration for manual testing.
+// Use this when you know the exact package name, channel, and catalog source that work in your environment.
+func GetCustomKMMInstallConfig(
+	apiClient *clients.Settings,
+	packageName string,
+	channel string,
+	catalogSource string) deploy.OperatorInstallConfig {
+	return deploy.OperatorInstallConfig{
+		APIClient:              apiClient,
+		Namespace:              "openshift-operators",
+		OperatorGroupName:      "global-operators",
+		SubscriptionName:       packageName,
+		PackageName:            packageName,
+		CatalogSource:          catalogSource,
+		CatalogSourceNamespace: "openshift-marketplace",
+		Channel:                channel,
+		SkipOperatorGroup:      true,
+		LogLevel:               glog.Level(amdgpuparams.LogLevel),
+	}
+}
+
+// GetDefaultAMDGPUInstallConfig returns the standard AMD GPU installation configuration.
+func GetDefaultAMDGPUInstallConfig(
+	apiClient *clients.Settings,
+	options *AMDGPUInstallConfigOptions) deploy.OperatorInstallConfig {
+	config := deploy.OperatorInstallConfig{
+		APIClient:              apiClient,
+		Namespace:              amdgpuparams.AMDGPUOperatorNamespace,
+		OperatorGroupName:      "amd-gpu-operator-group",
+		SubscriptionName:       "amd-gpu-subscription",
+		PackageName:            "amd-gpu-operator",
+		CatalogSource:          "certified-operators",
+		CatalogSourceNamespace: "openshift-marketplace",
+		Channel:                "alpha",
+
+		TargetNamespaces: []string{},
+		LogLevel:         glog.Level(amdgpuparams.LogLevel),
+	}
+
+	if options != nil {
+		if options.OperatorGroupName != nil {
+			config.OperatorGroupName = *options.OperatorGroupName
+		}
+
+		if options.SubscriptionName != nil {
+			config.SubscriptionName = *options.SubscriptionName
+		}
+
+		if options.CatalogSource != nil {
+			config.CatalogSource = *options.CatalogSource
+		}
+
+		if options.CatalogSourceNamespace != nil {
+			config.CatalogSourceNamespace = *options.CatalogSourceNamespace
+		}
+
+		if options.Channel != nil {
+			config.Channel = *options.Channel
+		}
+
+		if options.SkipOperatorGroup != nil {
+			config.SkipOperatorGroup = *options.SkipOperatorGroup
+		}
+
+		if options.LogLevel != nil {
+			config.LogLevel = *options.LogLevel
+		}
+	}
+
+	return config
+}
+
+// GetDefaultAMDGPUUninstallConfig returns the standard AMD GPU uninstallation configuration.
+func GetDefaultAMDGPUUninstallConfig(
+	apiClient *clients.Settings,
+	operatorGroupName,
+	subscriptionName string) deploy.OperatorUninstallConfig {
+	amdgpuCleaner := amdgpudelete.NewAMDGPUCustomResourceCleaner(
+		apiClient,
+		amdgpuparams.AMDGPUOperatorNamespace,
+		glog.Level(amdgpuparams.LogLevel))
+
+	return deploy.OperatorUninstallConfig{
+		APIClient:             apiClient,
+		Namespace:             amdgpuparams.AMDGPUOperatorNamespace,
+		OperatorGroupName:     operatorGroupName,
+		SubscriptionName:      subscriptionName,
+		CustomResourceCleaner: amdgpuCleaner,
+		LogLevel:              glog.Level(amdgpuparams.LogLevel),
+	}
+}
+
+// GetDefaultKMMUninstallConfig returns the standard KMM uninstallation configuration.
+func GetDefaultKMMUninstallConfig(
+	apiClient *clients.Settings,
+	options *AMDGPUInstallConfigOptions) deploy.OperatorUninstallConfig {
+	kmmCleaner := deploy.NewKMMCustomResourceCleaner(
+		apiClient,
+		amdgpuparams.AMDGPUOperatorNamespace,
+		glog.Level(amdgpuparams.LogLevel))
+
+	return deploy.OperatorUninstallConfig{
+		APIClient:             apiClient,
+		Namespace:             "openshift-kmm",
+		OperatorGroupName:     "kernel-module-management",
+		SubscriptionName:      "kernel-module-management",
+		CustomResourceCleaner: kmmCleaner,
+		LogLevel:              glog.Level(amdgpuparams.LogLevel),
+	}
+}
+
+// CreateBlacklistMachineConfig creates a MachineConfig to blacklist the amdgpu kernel module.
+func CreateBlacklistMachineConfig(apiClient *clients.Settings) error {
+	glog.V(amdgpuparams.LogLevel).Info(
+		"Creating MachineConfig to blacklist amdgpu module (auto-detecting SNO vs multi-node)")
+
+	err := amdgpumachineconfig.CreateAMDGPUBlacklist(apiClient, "worker")
+	if err != nil {
+		glog.V(amdgpuparams.LogLevel).Infof("MachineConfig creation result: %v", err)
+
+		return fmt.Errorf("MachineConfig creation requires cluster admin privileges or may already exist")
+	}
+
+	glog.V(amdgpuparams.LogLevel).Info(
+		"Waiting for MachineConfigPool to become stable after node reboots (auto-detecting MCP name)")
+
+	mcpName, err := amdgpumachineconfig.DetermineMachineConfigPoolName(apiClient)
+	if err != nil {
+		glog.V(amdgpuparams.LogLevel).Infof("Failed to determine MachineConfigPool name: %v", err)
+
+		return fmt.Errorf("failed to determine correct MachineConfigPool name")
+	}
+
+	glog.V(amdgpuparams.LogLevel).Infof("Using MachineConfigPool: %s", mcpName)
+
+	err = amdgpumachineconfig.WaitForMachineConfigPoolStable(apiClient, mcpName, 60*time.Minute)
+	if err != nil {
+		glog.V(amdgpuparams.LogLevel).Infof("MachineConfigPool stability check failed: %v", err)
+
+		return fmt.Errorf("MachineConfigPool stability check failed - may need more time or manual intervention")
+	}
+
+	glog.V(amdgpuparams.LogLevel).Info("Verifying amdgpu kernel module is properly blacklisted")
+
+	err = amdgpuconfig.VerifyAMDGPUKernelModule(apiClient)
+	if err != nil {
+		glog.V(amdgpuparams.LogLevel).Infof("Kernel module verification failed (ignoring): %v", err)
+	}
+
+	return nil
+}

--- a/tests/hw-accel/amdgpu/internal/amdgpuhelpers/deploy.go
+++ b/tests/hw-accel/amdgpu/internal/amdgpuhelpers/deploy.go
@@ -1,0 +1,74 @@
+package amdgpuhelpers
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpuparams"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/internal/deploy"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/nfd/nfdparams"
+)
+
+const (
+	timeout = 10 * time.Minute
+)
+
+// DeployAllOperators deploys NFD, KMM, and AMD GPU operators using the generic installer.
+func DeployAllOperators(apiClient *clients.Settings) error {
+	glog.V(amdgpuparams.LogLevel).Info("Deploying all operators")
+
+	operators := []string{"nfd", "kmm", "amdgpu"}
+	for _, operator := range operators {
+		config := getConfigByName(operator, apiClient)
+		if config.Namespace == "" {
+			return fmt.Errorf("invalid operator name: %s", operator)
+		}
+
+		installer := deploy.NewOperatorInstaller(config)
+		err := installer.Install()
+
+		if err != nil {
+			return fmt.Errorf("failed to install %s operator: %w", operator, err)
+		}
+
+		ready, err := installer.IsReady(timeout)
+		if err != nil {
+			return fmt.Errorf("%s operator readiness check failed: %w", operator, err)
+		}
+
+		if !ready {
+			return fmt.Errorf("%s operator is not ready", operator)
+		}
+	}
+
+	glog.V(amdgpuparams.LogLevel).Info("All operators deployed successfully")
+
+	return nil
+}
+
+func getConfigByName(operatorName string, apiClient *clients.Settings) deploy.OperatorInstallConfig {
+	switch strings.ToLower(operatorName) {
+	case "nfd":
+		return deploy.OperatorInstallConfig{
+			APIClient:              apiClient,
+			Namespace:              nfdparams.NFDNamespace,
+			OperatorGroupName:      "nfd-operator-group",
+			SubscriptionName:       "nfd-subscription",
+			PackageName:            "nfd",
+			CatalogSource:          "redhat-operators",
+			CatalogSourceNamespace: "openshift-marketplace",
+			Channel:                "stable",
+			TargetNamespaces:       []string{nfdparams.NFDNamespace},
+			LogLevel:               glog.Level(amdgpuparams.LogLevel),
+		}
+	case "kmm":
+		return GetDefaultKMMInstallConfig(apiClient, nil)
+	case "amdgpu":
+		return GetDefaultAMDGPUInstallConfig(apiClient, nil)
+	default:
+		return deploy.OperatorInstallConfig{}
+	}
+}

--- a/tests/hw-accel/amdgpu/internal/amdgpuhelpers/wait.go
+++ b/tests/hw-accel/amdgpu/internal/amdgpuhelpers/wait.go
@@ -1,0 +1,82 @@
+package amdgpuhelpers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/clusteroperator"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/nodes"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpuparams"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// WaitForClusterStabilityAfterDeviceConfig waits for the cluster to stabilize after DeviceConfig creation.
+func WaitForClusterStabilityAfterDeviceConfig(apiClients *clients.Settings) error {
+	glog.V(amdgpuparams.LogLevel).Info("Waiting for cluster stability after DeviceConfig creation")
+	time.Sleep(5 * time.Minute)
+
+	glog.V(amdgpuparams.LogLevel).Info("Waiting for all nodes to be ready")
+
+	err := wait.PollUntilContextTimeout(context.Background(),
+		30*time.Second, 15*time.Minute,
+		true,
+		func(ctx context.Context) (bool, error) {
+			allNodes, err := nodes.List(apiClients, metav1.ListOptions{})
+			if err != nil {
+				glog.V(amdgpuparams.LogLevel).Infof("failed to list nodes: %v", err)
+
+				return false, nil
+			}
+
+			for _, node := range allNodes {
+				nodeBuilder, nodeErr := nodes.Pull(apiClients, node.Object.Name)
+				if nodeErr != nil {
+					glog.V(amdgpuparams.LogLevel).Infof("Error pulling node %s: %v", node.Object.Name, nodeErr)
+
+					return false, nil
+				}
+
+				for _, condition := range nodeBuilder.Object.Status.Conditions {
+					if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+						glog.V(amdgpuparams.LogLevel).Infof("Node %s is ready", node.Object.Name)
+
+						return true, nil
+					}
+				}
+
+				glog.V(amdgpuparams.LogLevel).Infof("Node %s is not ready yet", node.Object.Name)
+			}
+
+			return false, nil
+		})
+
+	if err != nil {
+		return fmt.Errorf("nodes are not ready: %w", err)
+	}
+
+	glog.V(amdgpuparams.LogLevel).Info("All nodes are ready, waiting 3 minutes for cluster stabilization")
+	time.Sleep(3 * time.Minute)
+
+	glog.V(amdgpuparams.LogLevel).Info("Waiting for all cluster operators to be available")
+
+	available, err := clusteroperator.WaitForAllClusteroperatorsAvailable(apiClients, 15*time.Minute, metav1.ListOptions{})
+
+	if err != nil {
+		return fmt.Errorf("cluster operators availability check failed: %w", err)
+	}
+
+	if !available {
+		return fmt.Errorf("some cluster operators are not available")
+	}
+
+	glog.V(amdgpuparams.LogLevel).Info("Cluster stability check passed")
+
+	return nil
+}

--- a/tests/hw-accel/amdgpu/internal/amdgpumachineconfig/machineconfig.go
+++ b/tests/hw-accel/amdgpu/internal/amdgpumachineconfig/machineconfig.go
@@ -1,0 +1,310 @@
+package amdgpumachineconfig
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/mco"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpucommon"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpuparams"
+	mcv1 "github.com/openshift/api/machineconfiguration/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	amdgpuBlacklistContent = "YmxhY2tsaXN0IGFtZGdwdQo="
+	conditionStatusTrue    = "True"
+)
+
+// CreateAMDGPUBlacklist creates MachineConfig to blacklist amdgpu kernel module.
+func CreateAMDGPUBlacklist(apiClient *clients.Settings, roleName string) error {
+	mcBuilder, err := mco.PullMachineConfig(apiClient, amdgpuparams.DefaultMachineConfigName)
+
+	if err != nil {
+		glog.V(amdgpuparams.LogLevel).Infof("Failed to pull existing MachineConfig: %v", err)
+	}
+
+	if mcBuilder != nil && mcBuilder.Exists() {
+		glog.V(amdgpuparams.LogLevel).Info("AMD GPU blacklist MachineConfig already exists")
+
+		return nil
+	}
+
+	actualRole, err := determineNodeRole(apiClient, roleName)
+	if err != nil {
+		return fmt.Errorf("failed to determine node role: %w", err)
+	}
+
+	glog.V(amdgpuparams.LogLevel).Infof("Creating MachineConfig to blacklist amdgpu module for role: %s", actualRole)
+	glog.V(amdgpuparams.LogLevel).Info("WARNING: This will trigger automatic node reboots!")
+
+	mcBuilder = mco.NewMCBuilder(apiClient, amdgpuparams.DefaultMachineConfigName)
+
+	mcBuilder.WithLabel("machineconfiguration.openshift.io/role", actualRole)
+
+	if mcBuilder.Exists() {
+		glog.V(amdgpuparams.LogLevel).Info("AMD GPU blacklist MachineConfig already exists")
+
+		return nil
+	}
+
+	rawIgnitionJSON := `{
+  "ignition": {
+    "version": "3.2.0"
+  },
+  "storage": {
+    "files": [
+      {
+        "path": "/etc/modprobe.d/amdgpu-blacklist.conf",
+        "mode": 420,
+        "overwrite": true,
+        "contents": {
+          "source": "data:text/plain;base64,` + amdgpuBlacklistContent + `"
+        }
+      }
+    ]
+  }
+}`
+	mcBuilder.WithRawConfig([]byte(rawIgnitionJSON))
+
+	glog.V(amdgpuparams.LogLevel).Infof("MachineConfig YAML:\n%s", rawIgnitionJSON)
+	glog.V(amdgpuparams.LogLevel).Info("This will cause automatic node reboots!")
+
+	if _, err := mcBuilder.Create(); err != nil {
+		return fmt.Errorf("failed to create MachineConfig: %w", err)
+	}
+
+	return nil
+}
+
+// DetermineMachineConfigPoolName returns the correct MachineConfigPool name for the cluster.
+func DetermineMachineConfigPoolName(apiClient *clients.Settings) (string, error) {
+	isSNO, err := amdgpucommon.IsSingleNodeOpenShift(apiClient)
+	if err != nil {
+		return "", fmt.Errorf("failed to determine cluster type: %w", err)
+	}
+
+	if isSNO {
+		return "master", nil
+	}
+
+	return "worker", nil
+}
+
+// WaitForMachineConfigPoolStable waits for MachineConfigPool to be stable after MachineConfig creation.
+func WaitForMachineConfigPoolStable(apiClient *clients.Settings, mcpName string, timeout time.Duration) error {
+	glog.V(amdgpuparams.LogLevel).
+		Infof("Waiting for MachineConfigPool %s to be stable after MachineConfig update",
+			mcpName)
+	glog.V(amdgpuparams.LogLevel).Infof("This includes waiting for node reboots to complete...")
+
+	isSNO, err := amdgpucommon.IsSingleNodeOpenShift(apiClient)
+	if err != nil {
+		return fmt.Errorf("failed to determine cluster type: %w", err)
+	}
+
+	if isSNO {
+		glog.V(amdgpuparams.LogLevel).Info("SNO environment detected - using resilient polling for node reboot")
+
+		return waitForMCPStableSNO(apiClient, mcpName, timeout)
+	}
+
+	return waitForMCPStableMultiNode(apiClient, mcpName, timeout)
+}
+
+// determineNodeRole automatically determines the correct MachineConfig role for the cluster.
+func determineNodeRole(apiClient *clients.Settings, requestedRole string) (string, error) {
+	isSNO, err := amdgpucommon.IsSingleNodeOpenShift(apiClient)
+	if err != nil {
+		return "", fmt.Errorf("failed to determine cluster type: %w", err)
+	}
+
+	if isSNO {
+		glog.V(amdgpuparams.LogLevel).Info("SNO environment detected - using 'master' role for MachineConfig")
+
+		return "master", nil
+	}
+
+	glog.V(amdgpuparams.LogLevel).Infof("Multi-node environment detected - using requested role: %s", requestedRole)
+
+	return requestedRole, nil
+}
+
+// waitForMCPStableMultiNode handles MCP stability waiting for multi-node clusters.
+func waitForMCPStableMultiNode(apiClient *clients.Settings, mcpName string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	err := waitForMCPUpdating(apiClient, mcpName, ctx)
+	if err != nil {
+		return fmt.Errorf("MachineConfigPool %s did not start updating: %w", mcpName, err)
+	}
+
+	err = waitForMCPStable(apiClient, mcpName, ctx)
+	if err != nil {
+		return fmt.Errorf("MachineConfigPool %s did not become stable: %w", mcpName, err)
+	}
+
+	glog.V(amdgpuparams.LogLevel).Infof("MachineConfigPool %s is now stable - all nodes rebooted successfully", mcpName)
+
+	return nil
+}
+
+// waitForMCPStableSNO handles MCP stability waiting for SNO clusters with API connection resilience.
+func waitForMCPStableSNO(apiClient *clients.Settings, mcpName string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	glog.V(amdgpuparams.LogLevel).Info("Waiting for SNO node reboot and recovery...")
+
+	return wait.PollUntilContextTimeout(
+		ctx, 3*time.Minute, timeout, true, func(ctx context.Context) (bool, error) {
+			return checkSNOMCPStatus(apiClient, mcpName)
+		})
+}
+
+// checkSNOMCPStatus checks if SNO MCP is stable and updated.
+func checkSNOMCPStatus(apiClient *clients.Settings, mcpName string) (bool, error) {
+	mcpBuilder := mco.NewMCPBuilder(apiClient, mcpName)
+	if mcpBuilder == nil {
+		glog.V(amdgpuparams.LogLevel).Infof("Failed to create MCP builder for %s (expected during SNO reboot)", mcpName)
+
+		return false, nil
+	}
+
+	_, err := mcpBuilder.Get()
+	if err != nil {
+		glog.V(amdgpuparams.LogLevel).Infof("API unavailable during SNO reboot (expected): %v", err)
+
+		return false, nil
+	}
+
+	return evaluateMCPStability(mcpBuilder)
+}
+
+// evaluateMCPStability evaluates if MCP is stable and has Updated condition.
+func evaluateMCPStability(mcpBuilder *mco.MCPBuilder) (bool, error) {
+	mcpObj, err := mcpBuilder.Get()
+	if err != nil {
+		return false, nil
+	}
+
+	isStable := isMCPStable(mcpObj)
+	if isStable && hasMCPUpdatedCondition(mcpObj) {
+		glog.V(amdgpuparams.LogLevel).Info("SNO node successfully rebooted and MCP is stable")
+
+		return true, nil
+	}
+
+	logMCPStatus(mcpObj)
+
+	return false, nil
+}
+
+// isMCPStable checks if MCP counts indicate stability.
+func isMCPStable(mcp *mcv1.MachineConfigPool) bool {
+	return mcp.Status.ReadyMachineCount == mcp.Status.MachineCount &&
+		mcp.Status.MachineCount == mcp.Status.UpdatedMachineCount &&
+		mcp.Status.DegradedMachineCount == 0
+}
+
+// hasMCPUpdatedCondition checks if MCP has Updated condition set to True.
+func hasMCPUpdatedCondition(mcp *mcv1.MachineConfigPool) bool {
+	for _, condition := range mcp.Status.Conditions {
+		if condition.Type == "Updated" && condition.Status == conditionStatusTrue {
+			return true
+		}
+	}
+
+	return false
+}
+
+// logMCPStatus logs the current MCP status for debugging.
+func logMCPStatus(mcp *mcv1.MachineConfigPool) {
+	glog.V(amdgpuparams.LogLevel).Infof("SNO MCP status: Ready=%d/%d, Updated=%d/%d, Degraded=%d",
+		mcp.Status.ReadyMachineCount, mcp.Status.MachineCount,
+		mcp.Status.UpdatedMachineCount, mcp.Status.MachineCount, mcp.Status.DegradedMachineCount)
+}
+
+// waitForMCPUpdating waits for the MachineConfigPool to start updating.
+func waitForMCPUpdating(apiClient *clients.Settings, mcpName string, ctx context.Context) error {
+	glog.V(amdgpuparams.LogLevel).Infof("Waiting for MachineConfigPool %s to start updating...", mcpName)
+
+	err := wait.PollUntilContextTimeout(
+		ctx, 30*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
+			mcpBuilder := mco.NewMCPBuilder(apiClient, mcpName)
+			if mcpBuilder == nil {
+				glog.V(amdgpuparams.LogLevel).Infof("Failed to create MCP builder for %s", mcpName)
+
+				return false, nil
+			}
+
+			mcp, err := mcpBuilder.Get()
+			if err != nil {
+				glog.V(amdgpuparams.LogLevel).Infof("Error getting MachineConfigPool %s: %v", mcpName, err)
+
+				return false, nil
+			}
+
+			for _, condition := range mcp.Status.Conditions {
+				if condition.Type == "Updating" && condition.Status == conditionStatusTrue {
+					glog.V(amdgpuparams.LogLevel).Infof("MachineConfigPool %s started updating", mcpName)
+
+					return true, nil
+				}
+			}
+
+			glog.V(amdgpuparams.LogLevel).Infof("MachineConfigPool %s not yet updating, waiting...", mcpName)
+
+			return false, nil
+		})
+
+	return err
+}
+
+// waitForMCPStable waits for the MachineConfigPool to become stable.
+func waitForMCPStable(apiClient *clients.Settings, mcpName string, ctx context.Context) error {
+	glog.V(amdgpuparams.LogLevel).Infof("Waiting for MachineConfigPool %s to become stable...", mcpName)
+
+	err := wait.PollUntilContextTimeout(
+		ctx, 30*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+			mcpBuilder := mco.NewMCPBuilder(apiClient, mcpName)
+			if mcpBuilder == nil {
+				glog.V(amdgpuparams.LogLevel).Infof("Failed to create MCP builder for %s", mcpName)
+
+				return false, nil
+			}
+
+			mcp, err := mcpBuilder.Get()
+			if err != nil {
+				glog.V(amdgpuparams.LogLevel).Infof("Error getting MachineConfigPool %s: %v", mcpName, err)
+
+				return false, nil
+			}
+
+			isStable := mcp.Status.ReadyMachineCount == mcp.Status.MachineCount &&
+				mcp.Status.MachineCount == mcp.Status.UpdatedMachineCount &&
+				mcp.Status.DegradedMachineCount == 0
+
+			if isStable {
+				for _, condition := range mcp.Status.Conditions {
+					if condition.Type == "Updated" && condition.Status == conditionStatusTrue {
+						glog.V(amdgpuparams.LogLevel).Infof("MachineConfigPool %s is stable and updated", mcpName)
+
+						return true, nil
+					}
+				}
+			}
+
+			glog.V(amdgpuparams.LogLevel).Infof("MachineConfigPool %s status: Ready=%d/%d, Updated=%d/%d, Degraded=%d",
+				mcpName, mcp.Status.ReadyMachineCount, mcp.Status.MachineCount,
+				mcp.Status.UpdatedMachineCount, mcp.Status.MachineCount, mcp.Status.DegradedMachineCount)
+
+			return false, nil
+		})
+
+	return err
+}

--- a/tests/hw-accel/amdgpu/internal/amdgpunfd/nfd.go
+++ b/tests/hw-accel/amdgpu/internal/amdgpunfd/nfd.go
@@ -1,0 +1,137 @@
+package amdgpunfd
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/nfd"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpucommon"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpuparams"
+)
+
+// CreateAMDGPUFeatureRule creates an NFD FeatureRule for advanced AMD GPU detection and labeling.
+func CreateAMDGPUFeatureRule(apiClient *clients.Settings) error {
+	glog.V(amdgpuparams.LogLevel).Infof("Creating NFD FeatureRule for enhanced AMD GPU detection")
+
+	featureRuleBuilder := nfd.NewNodeFeatureRuleBuilderFromObjectString(apiClient, getAMDGPUFeatureRuleYAML())
+	if featureRuleBuilder == nil {
+		return fmt.Errorf("failed to create NodeFeatureRule builder")
+	}
+
+	if featureRuleBuilder.Exists() {
+		glog.V(amdgpuparams.LogLevel).Info("AMD GPU FeatureRule already exists")
+
+		return nil
+	}
+
+	_, err := featureRuleBuilder.Create()
+	if err != nil {
+		return handleFeatureRuleCreationError(err)
+	}
+
+	glog.V(amdgpuparams.LogLevel).Info("Successfully created AMD GPU FeatureRule")
+	glog.V(amdgpuparams.LogLevel).Info("This will enhance AMD GPU node detection and labeling via NFD")
+
+	return nil
+}
+
+// getAMDGPUFeatureRuleYAML returns the YAML configuration for AMD GPU NodeFeatureRule.
+func getAMDGPUFeatureRuleYAML() string {
+	return `
+	[
+{
+  "apiVersion": "nfd.openshift.io/v1alpha1",
+  "kind": "NodeFeatureRule",
+  "metadata": {
+    "name": "amd-gpu-feature-rule",
+    "namespace": "openshift-amd-gpu"
+  },
+  "spec": {
+    "rules": [
+      {
+        "name": "amd.gpu.device",
+        "labels": {
+          "amd.com/gpu": "true",
+          "feature.node.kubernetes.io/amd-gpu": "true"
+        },
+        "matchFeatures": [
+          {
+            "feature": "pci.device",
+            "matchExpressions": {
+              "vendor": {
+                "op": "In",
+                "value": [
+                  "1002"
+                ]
+              },
+              "device": {
+                "op": "In",
+                "value": [
+                  "75a3",
+                  "75a0",
+                  "74a5",
+                  "74a0",
+                  "74a1",
+                  "74a9",
+                  "74bd",
+                  "740f",
+                  "7408",
+                  "740c",
+                  "738c",
+                  "738e"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "amd.gpu.class",
+        "labels": {
+          "feature.node.kubernetes.io/amd-gpu-class": "true"
+        },
+        "matchFeatures": [
+          {
+            "feature": "pci.device",
+            "matchExpressions": {
+              "vendor": {
+                "op": "In",
+                "value": [
+                  "1002"
+                ]
+              },
+              "class": {
+                "op": "In",
+                "value": [
+                  "030000",
+                  "030200",
+                  "038000"
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+]
+		`
+}
+
+// handleFeatureRuleCreationError handles errors during FeatureRule creation.
+func handleFeatureRuleCreationError(err error) error {
+	glog.V(amdgpuparams.LogLevel).Infof("Error creating AMD GPU FeatureRule: %v", err)
+
+	if amdgpucommon.IsCRDNotAvailable(err) {
+		featureRuleYAML := getAMDGPUFeatureRuleYAML()
+
+		glog.V(amdgpuparams.LogLevel).Info("NFD FeatureRule CRD not available - manual creation required")
+		glog.V(amdgpuparams.LogLevel).Infof("AMD GPU FeatureRule YAML:\n%s", featureRuleYAML)
+
+		return fmt.Errorf("NFD FeatureRule CRD not available, manual creation required")
+	}
+
+	return err
+}

--- a/tests/hw-accel/amdgpu/internal/amdgpuparams/consts.go
+++ b/tests/hw-accel/amdgpu/internal/amdgpuparams/consts.go
@@ -1,0 +1,48 @@
+package amdgpuparams
+
+const (
+	// AMDGPUTestNamespace represents test case namespace name.
+	AMDGPUTestNamespace = "amd-gpu-test"
+
+	// AMDGPUOperatorNamespace represents AMD GPU operator namespace.
+	AMDGPUOperatorNamespace = "openshift-amd-gpu"
+
+	// NFDNamespace represents NFD operator namespace (re-export for convenience).
+	NFDNamespace = "openshift-nfd"
+
+	// LogLevel represents the default log level for AMD GPU tests.
+	LogLevel = 90
+
+	// DefaultDeviceConfigName represents the default DeviceConfig CR name.
+	DefaultDeviceConfigName = "amd-gpu-device-config"
+
+	// DefaultMachineConfigName represents the default MachineConfig name for blacklisting.
+	DefaultMachineConfigName = "amdgpu-module-blacklist"
+
+	// DefaultDriverVersion represents the default AMD GPU driver version.
+	DefaultDriverVersion = "6.4.3"
+
+	// AMDPCIVendorID represents the AMD GPU PCI vendor ID.
+	AMDPCIVendorID = "1002"
+
+	// DefaultOperatorTimeout represents the default timeout for operator operations.
+	DefaultOperatorTimeout = "15m"
+	// KMMOperatorTimeout represents the timeout for KMM operator operations.
+	KMMOperatorTimeout = "10m"
+	// AMDGPUOperatorTimeout represents the timeout for AMD GPU operator operations.
+	AMDGPUOperatorTimeout = "10m"
+)
+
+var (
+	// AMDRXDeviceIDs contains common AMD GPU PCI device IDs for RX series.
+	AMDRXDeviceIDs = []string{
+		"15d8", // RX 580
+		"67df", // RX 480/580
+		"6fdf", // RX 5500 XT
+		"731f", // RX 6600/6600 XT
+		"73ef", // RX 6650 XT
+		"73ff", // RX 6600M
+		"7340", // RX 7900 XTX
+		"744c", // RX 7900 XT
+	}
+)

--- a/tests/hw-accel/amdgpu/internal/amdgpuparams/vars.go
+++ b/tests/hw-accel/amdgpu/internal/amdgpuparams/vars.go
@@ -1,0 +1,56 @@
+package amdgpuparams
+
+import (
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/internal/hwaccelparams"
+	"github.com/openshift-kni/k8sreporter"
+)
+
+var (
+	// Labels represents the range of labels that can be used for test cases selection.
+	Labels = []string{hwaccelparams.Label, "amdgpu"}
+
+	// ReporterNamespacesToDump tells to the reporter from where to collect logs.
+	ReporterNamespacesToDump = map[string]string{
+		hwaccelparams.NFDNamespace: "nfd-operator",
+		"openshift-kmm":            "kmm-operator",
+		AMDGPUOperatorNamespace:    "amd-gpu-operator",
+		AMDGPUTestNamespace:        "amd-gpu-test",
+	}
+
+	// ReporterCRDsToDump tells to the reporter what CRs to dump.
+	ReporterCRDsToDump = []k8sreporter.CRData{
+		// AMD GPU operator CRDs will be added when available
+		// {Cr: &amdgpuv1.DeviceConfigList{}},
+	}
+
+	// ValidPodNameList contains expected AMD GPU operator pod names.
+	ValidPodNameList = []string{
+		"amd-gpu-operator-controller-manager",
+		"amd-gpu-device-plugin",
+		"amd-gpu-driver",
+	}
+
+	// DefaultWorkerConfig contains the NFD worker configuration for AMD GPU detection.
+	DefaultWorkerConfig = `
+sources:
+  pci:
+    deviceClassWhitelist:
+      - "03"
+      - "0300"  
+      - "0302"
+    deviceLabelFields:
+      - vendor
+      - device
+      - class
+      - subsystem_vendor
+      - subsystem_device
+  custom:
+    - name: "amd-gpu"
+      matchOn:
+        - pciId:
+            vendor: ["1002"]
+            device: ["15d8", "67df", "6fdf", "731f", "73ef", "73ff", "7340", "744c"]
+      labels:
+        amd-gpu: "true"
+`
+)

--- a/tests/hw-accel/amdgpu/internal/amdgpuregistry/registry.go
+++ b/tests/hw-accel/amdgpu/internal/amdgpuregistry/registry.go
@@ -1,0 +1,259 @@
+package amdgpuregistry
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpucommon"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpuparams"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// VerifyAndConfigureInternalRegistry checks and configures the internal image registry for the AMD GPU operator.
+func VerifyAndConfigureInternalRegistry(apiClient *clients.Settings) error {
+	glog.V(amdgpuparams.LogLevel).Info("Verifying internal image registry configuration for AMD GPU operator")
+
+	imageRegistryConfig, err := getImageRegistryConfig(apiClient)
+	if err != nil {
+		return err
+	}
+
+	managementState, found, err := getRegistryManagementState(imageRegistryConfig)
+	if err != nil {
+		return err
+	}
+
+	glog.V(amdgpuparams.LogLevel).Infof("Current image registry management state: %s", managementState)
+
+	if !found || managementState != "Managed" {
+		return configureRegistryAsManaged(apiClient, imageRegistryConfig)
+	}
+
+	return verifyRegistryAvailability(apiClient)
+}
+
+// getImageRegistryConfig retrieves the image registry configuration.
+func getImageRegistryConfig(apiClient *clients.Settings) (*unstructured.Unstructured, error) {
+	ctx := context.Background()
+
+	imageRegistryGVK := schema.GroupVersionKind{
+		Group:   "imageregistry.operator.openshift.io",
+		Version: "v1",
+		Kind:    "Config",
+	}
+
+	imageRegistryConfig := &unstructured.Unstructured{}
+	imageRegistryConfig.SetGroupVersionKind(imageRegistryGVK)
+
+	err := apiClient.Client.Get(ctx, client.ObjectKey{Name: "cluster"}, imageRegistryConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get image registry configuration: %w", err)
+	}
+
+	return imageRegistryConfig, nil
+}
+
+// getRegistryManagementState extracts the management state from registry config.
+func getRegistryManagementState(config *unstructured.Unstructured) (string, bool, error) {
+	managementState, found, err := unstructured.NestedString(config.Object, "spec", "managementState")
+	if err != nil {
+		return "", false, fmt.Errorf("failed to get image registry management state: %w", err)
+	}
+
+	return managementState, found, nil
+}
+
+// configureRegistryAsManaged configures the registry to be managed and sets up storage.
+func configureRegistryAsManaged(apiClient *clients.Settings, config *unstructured.Unstructured) error {
+	glog.V(amdgpuparams.LogLevel).Info("Internal registry is not managed - configuring it for AMD GPU operator")
+
+	err := setRegistryManagementState(config)
+	if err != nil {
+		return err
+	}
+
+	err = ensureRegistryStorage(config)
+	if err != nil {
+		return err
+	}
+
+	err = updateRegistryConfig(apiClient, config)
+	if err != nil {
+		return err
+	}
+
+	glog.V(amdgpuparams.LogLevel).Info("Updated image registry to Managed state")
+
+	return waitForImageRegistryAvailable(apiClient, 10*time.Minute)
+}
+
+// setRegistryManagementState sets the registry management state to "Managed".
+func setRegistryManagementState(config *unstructured.Unstructured) error {
+	err := unstructured.SetNestedField(config.Object, "Managed", "spec", "managementState")
+	if err != nil {
+		return fmt.Errorf("failed to set image registry management state: %w", err)
+	}
+
+	return nil
+}
+
+// ensureRegistryStorage ensures registry has storage configuration.
+func ensureRegistryStorage(config *unstructured.Unstructured) error {
+	storageConfig, storageFound, err := unstructured.NestedMap(config.Object, "spec", "storage")
+	if err != nil {
+		return fmt.Errorf("failed to check image registry storage configuration: %w", err)
+	}
+
+	if !storageFound || storageConfig == nil || len(storageConfig) == 0 {
+		return setEmptyDirStorage(config)
+	}
+
+	return nil
+}
+
+// setEmptyDirStorage sets emptyDir storage for the registry.
+func setEmptyDirStorage(config *unstructured.Unstructured) error {
+	glog.V(amdgpuparams.LogLevel).Info("No storage configured for image registry - adding emptyDir storage for testing")
+
+	newStorageConfig := map[string]interface{}{
+		"emptyDir": map[string]interface{}{},
+	}
+
+	err := unstructured.SetNestedMap(config.Object, newStorageConfig, "spec", "storage")
+
+	if err != nil {
+		return fmt.Errorf("failed to set image registry storage: %w", err)
+	}
+
+	return nil
+}
+
+// updateRegistryConfig updates the registry configuration in the cluster.
+func updateRegistryConfig(apiClient *clients.Settings, config *unstructured.Unstructured) error {
+	ctx := context.Background()
+	err := apiClient.Client.Update(ctx, config)
+
+	if err != nil {
+		return fmt.Errorf("failed to update image registry configuration: %w", err)
+	}
+
+	return nil
+}
+
+// verifyRegistryAvailability verifies that the registry is available.
+func verifyRegistryAvailability(apiClient *clients.Settings) error {
+	glog.V(amdgpuparams.LogLevel).Info("Internal registry is already managed - verifying availability")
+
+	err := waitForImageRegistryAvailable(apiClient, 5*time.Minute)
+	if err != nil {
+		return fmt.Errorf("image registry is not available: %w", err)
+	}
+
+	glog.V(amdgpuparams.LogLevel).Info("Internal image registry is properly configured and available")
+
+	return nil
+}
+
+// verifyRegistryService verifies image registry service.
+func verifyRegistryService(apiClient *clients.Settings) error {
+	glog.V(amdgpuparams.LogLevel).Info("Verifying image registry service")
+
+	ctx := context.Background()
+
+	service, err := apiClient.CoreV1Interface.Services("openshift-image-registry").Get(
+		ctx, "image-registry", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("image registry service not found: %w", err)
+	}
+
+	glog.V(amdgpuparams.LogLevel).Infof("Image registry service found: %s (ClusterIP: %s)",
+		service.Name, service.Spec.ClusterIP)
+
+	routes := &unstructured.UnstructuredList{}
+	routes.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "route.openshift.io",
+		Version: "v1",
+		Kind:    "RouteList",
+	})
+
+	err = apiClient.Client.List(ctx, routes, client.InNamespace("openshift-image-registry"))
+	if err != nil {
+		glog.V(amdgpuparams.LogLevel).Infof("Could not check registry routes: %v", err)
+	} else if len(routes.Items) > 0 {
+		for _, route := range routes.Items {
+			if routeName := route.GetName(); routeName == "default-route" {
+				if host, found, _ := unstructured.NestedString(route.Object, "spec", "host"); found {
+					glog.V(amdgpuparams.LogLevel).Infof("Image registry route available: %s", host)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// waitForImageRegistryAvailable waits for internal image registry to become available.
+func waitForImageRegistryAvailable(apiClient *clients.Settings, timeout time.Duration) error {
+	glog.V(amdgpuparams.LogLevel).Info("Waiting for internal image registry to become available")
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	err := wait.PollUntilContextTimeout(
+		ctx, 15*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+			pods, err := apiClient.CoreV1Interface.Pods("openshift-image-registry").List(
+				ctx, metav1.ListOptions{
+					LabelSelector: "docker-registry=default",
+				})
+			if err != nil {
+				glog.V(amdgpuparams.LogLevel).Infof("Error listing image registry pods: %v", err)
+
+				return false, nil
+			}
+
+			if len(pods.Items) == 0 {
+				glog.V(amdgpuparams.LogLevel).Info("No image registry pods found, waiting...")
+
+				return false, nil
+			}
+
+			runningPods := 0
+
+			for _, pod := range pods.Items {
+				if pod.Status.Phase == corev1.PodRunning {
+					if amdgpucommon.AreAllContainersReady(pod) {
+						runningPods++
+					}
+				}
+			}
+
+			glog.V(amdgpuparams.LogLevel).Infof("Image registry pods: %d running/%d total", runningPods, len(pods.Items))
+
+			if runningPods > 0 {
+				glog.V(amdgpuparams.LogLevel).Info("Internal image registry is available")
+
+				return true, nil
+			}
+
+			return false, nil
+		})
+
+	if err != nil {
+		return fmt.Errorf("timeout waiting for image registry availability: %w", err)
+	}
+
+	err = verifyRegistryService(apiClient)
+	if err != nil {
+		glog.V(amdgpuparams.LogLevel).Infof("Registry service verification warning: %v", err)
+	}
+
+	return nil
+}

--- a/tests/hw-accel/amdgpu/internal/exec/command.go
+++ b/tests/hw-accel/amdgpu/internal/exec/command.go
@@ -1,0 +1,473 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/pod"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/amdgpu/internal/amdgpucommon"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PodCommand represents a command to be executed in a Kubernetes pod.
+type PodCommand struct {
+	apiClient     *clients.Settings
+	name          string
+	nsname        string
+	image         string
+	containerName string
+	commad        []string
+	resources     *ResourceSettings
+	ActualPod     *pod.Builder
+
+	executionMode ExecutionMode
+	script        string
+
+	// Node execution options
+	nodeName    string
+	privileged  bool
+	hostNetwork bool
+	hostPID     bool
+	hostVolumes []HostVolumeMount
+}
+
+// ExecutionMode defines how the command should be executed.
+type ExecutionMode int
+
+const (
+	// ShellCommand uses /bin/sh -c (existing behavior).
+	ShellCommand ExecutionMode = iota
+	// BashScript uses /bin/bash with script as argument.
+	BashScript
+	// DirectCommand executes command directly without shell.
+	DirectCommand
+)
+
+// ResourceSettings contains CPU and memory resource requests and limits.
+type ResourceSettings struct {
+	Requests map[corev1.ResourceName]string
+	Limits   map[corev1.ResourceName]string
+}
+
+// HostVolumeMount represents a host volume mount.
+type HostVolumeMount struct {
+	HostPath      string
+	ContainerPath string
+	ReadOnly      bool
+}
+
+// NewPodCommand creates a new PodCommand with shell execution mode.
+func NewPodCommand(
+	apiClient *clients.Settings,
+	name,
+	nsname,
+	image,
+	containerName string,
+	commad []string,
+	requests, limits map[string]string) *PodCommand {
+	resources := &ResourceSettings{
+		Requests: convertToResourceNameMap(requests),
+		Limits:   convertToResourceNameMap(limits),
+	}
+
+	return &PodCommand{
+		apiClient:     apiClient,
+		name:          name,
+		nsname:        nsname,
+		image:         image,
+		containerName: containerName,
+		commad:        commad,
+		resources:     resources,
+		executionMode: ShellCommand,
+	}
+}
+
+// NewPodCommandWithBashScript creates a PodCommand that executes a bash script.
+// This is better for complex scripts as it avoids shell escaping issues.
+func NewPodCommandWithBashScript(
+	apiClient *clients.Settings,
+	name,
+	nsname,
+	image,
+	containerName string,
+	script string,
+	requests, limits map[string]string) *PodCommand {
+	resources := &ResourceSettings{
+		Requests: convertToResourceNameMap(requests),
+		Limits:   convertToResourceNameMap(limits),
+	}
+
+	return &PodCommand{
+		apiClient:     apiClient,
+		name:          name,
+		nsname:        nsname,
+		image:         image,
+		containerName: containerName,
+		script:        script,
+		resources:     resources,
+		executionMode: BashScript,
+	}
+}
+
+// NewPodCommandDirect creates a PodCommand that executes commands directly without shell.
+func NewPodCommandDirect(
+	apiClient *clients.Settings,
+	name,
+	nsname,
+	image,
+	containerName string,
+	command []string,
+	requests, limits map[string]string) *PodCommand {
+	resources := &ResourceSettings{
+		Requests: convertToResourceNameMap(requests),
+		Limits:   convertToResourceNameMap(limits),
+	}
+
+	return &PodCommand{
+		apiClient:     apiClient,
+		name:          name,
+		nsname:        nsname,
+		image:         image,
+		containerName: containerName,
+		commad:        command,
+		resources:     resources,
+		executionMode: DirectCommand,
+	}
+}
+
+// Run executes the pod command based on the specified execution mode.
+func (p *PodCommand) Run() error {
+	podWorker := pod.NewBuilder(p.apiClient, p.name, p.nsname, p.image)
+
+	container, err := p.getContainerConfig()
+	if err != nil {
+		glog.Errorf("Failed to get container configuration: %v", err)
+
+		return err
+	}
+
+	podWorker.Definition.Spec.Containers = make([]corev1.Container, 0)
+	podWorker.Definition.Spec.Containers = append(podWorker.Definition.Spec.Containers, *container)
+	podWorker.Definition.Spec.RestartPolicy = corev1.RestartPolicyNever
+
+	// Configure node placement
+	if p.nodeName != "" {
+		podWorker.Definition.Spec.NodeName = p.nodeName
+	} else {
+		if isSNO, err := amdgpucommon.IsSingleNodeOpenShift(p.apiClient); err == nil && isSNO {
+			podWorker.Definition.Spec.NodeSelector = map[string]string{}
+		} else {
+			podWorker.Definition.Spec.NodeSelector = map[string]string{"node-role.kubernetes.io/worker": ""}
+		}
+	}
+
+	// Configure host access
+	if p.hostNetwork {
+		podWorker.Definition.Spec.HostNetwork = true
+	}
+
+	if p.hostPID {
+		podWorker.Definition.Spec.HostPID = true
+	}
+
+	// Configure host volumes
+	if len(p.hostVolumes) > 0 {
+		podWorker.Definition.Spec.Volumes = make([]corev1.Volume, 0)
+
+		for i, hostVol := range p.hostVolumes {
+			volumeName := fmt.Sprintf("host-vol-%d", i)
+			hostPathType := corev1.HostPathDirectoryOrCreate
+
+			podWorker.Definition.Spec.Volumes = append(podWorker.Definition.Spec.Volumes, corev1.Volume{
+				Name: volumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: hostVol.HostPath,
+						Type: &hostPathType,
+					},
+				},
+			})
+
+			// Add volume mount to container
+			podWorker.Definition.Spec.Containers[0].VolumeMounts = append(
+				podWorker.Definition.Spec.Containers[0].VolumeMounts,
+				corev1.VolumeMount{
+					Name:      volumeName,
+					MountPath: hostVol.ContainerPath,
+					ReadOnly:  hostVol.ReadOnly,
+				},
+			)
+		}
+	}
+
+	// Set termination grace period for faster cleanup
+	terminationGracePeriod := int64(1)
+	podWorker.Definition.Spec.TerminationGracePeriodSeconds = &terminationGracePeriod
+
+	p.ActualPod, err = podWorker.Create()
+
+	if err != nil {
+		glog.Errorf("Error creating pod: %s", err.Error())
+
+		return err
+	}
+
+	return nil
+}
+
+func (p *PodCommand) getContainerConfig() (*corev1.Container, error) {
+	var (
+		containerBuilder *pod.ContainerBuilder
+		container        *corev1.Container
+		err              error
+	)
+
+	switch p.executionMode {
+	case ShellCommand:
+		containerBuilder = pod.NewContainerBuilder(p.containerName, p.image, []string{"/bin/sh", "-c"})
+		container, err = containerBuilder.GetContainerCfg()
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to create shell container: %w", err)
+		}
+
+		container.Args = append(container.Args, p.commad...)
+
+	case BashScript:
+		containerBuilder = pod.NewContainerBuilder(p.containerName, p.image, []string{"/bin/bash"})
+		container, err = containerBuilder.GetContainerCfg()
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to create bash container: %w", err)
+		}
+
+		container.Command = []string{"/bin/bash"}
+		container.Args = []string{"-c", p.script}
+
+	case DirectCommand:
+		if len(p.commad) == 0 {
+			return nil, fmt.Errorf("no command specified for DirectCommand mode")
+		}
+
+		containerBuilder = pod.NewContainerBuilder(p.containerName, p.image, []string{p.commad[0]})
+		container, err = containerBuilder.GetContainerCfg()
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to create direct container: %w", err)
+		}
+
+		container.Command = []string{p.commad[0]}
+		if len(p.commad) > 1 {
+			container.Args = p.commad[1:]
+		}
+
+	default:
+		return nil, fmt.Errorf("unknown execution mode: %v", p.executionMode)
+	}
+
+	// Apply common configuration
+	container.Resources = p.resources.toResourceRequirements()
+
+	// Configure security context
+	if p.privileged {
+		if container.SecurityContext == nil {
+			container.SecurityContext = &corev1.SecurityContext{}
+		}
+
+		container.SecurityContext.Privileged = &p.privileged
+	}
+
+	return container, nil
+}
+
+func (rs *ResourceSettings) toResourceRequirements() corev1.ResourceRequirements {
+	reqs := corev1.ResourceList{}
+	lims := corev1.ResourceList{}
+
+	for k, v := range rs.Requests {
+		reqs[k] = resource.MustParse(v)
+	}
+
+	for k, v := range rs.Limits {
+		lims[k] = resource.MustParse(v)
+	}
+
+	return corev1.ResourceRequirements{
+		Requests: reqs,
+		Limits:   lims,
+	}
+}
+
+func convertToResourceNameMap(input map[string]string) map[corev1.ResourceName]string {
+	result := make(map[corev1.ResourceName]string)
+	for k, v := range input {
+		result[corev1.ResourceName(k)] = v
+	}
+
+	return result
+}
+
+// WithPrivileged sets the privileged flag for the pod.
+func (p *PodCommand) WithPrivileged(privileged bool) *PodCommand {
+	p.privileged = privileged
+
+	return p
+}
+
+// WithHostNetwork sets the host network flag for the pod.
+func (p *PodCommand) WithHostNetwork(hostNetwork bool) *PodCommand {
+	p.hostNetwork = hostNetwork
+
+	return p
+}
+
+// WithHostPID sets the host PID flag for the pod.
+func (p *PodCommand) WithHostPID(hostPID bool) *PodCommand {
+	p.hostPID = hostPID
+
+	return p
+}
+
+// WithNodeName sets the target node for the pod.
+func (p *PodCommand) WithNodeName(nodeName string) *PodCommand {
+	p.nodeName = nodeName
+
+	return p
+}
+
+// WithHostVolume adds a host volume mount to the pod.
+func (p *PodCommand) WithHostVolume(hostPath, containerPath string, readOnly bool) *PodCommand {
+	p.hostVolumes = append(p.hostVolumes, HostVolumeMount{
+		HostPath:      hostPath,
+		ContainerPath: containerPath,
+		ReadOnly:      readOnly,
+	})
+
+	return p
+}
+
+// Execute runs the pod command and returns the output.
+func (p *PodCommand) Execute() (string, error) {
+	err := p.Run()
+	if err != nil {
+		return "", fmt.Errorf("failed to create pod: %w", err)
+	}
+
+	// Wait for pod to be running
+	err = p.ActualPod.WaitUntilRunning(2 * time.Minute)
+	if err != nil {
+		return "", fmt.Errorf("pod failed to start: %w", err)
+	}
+
+	// Execute the command
+	output, err := p.ActualPod.ExecCommand([]string{"sh", "-c", strings.Join(p.commad, " ")})
+	if err != nil {
+		return output.String(), fmt.Errorf("command execution failed: %w", err)
+	}
+
+	return strings.TrimSpace(output.String()), nil
+}
+
+// ExecuteAndCleanup runs the pod command, returns output, and cleans up the pod.
+func (p *PodCommand) ExecuteAndCleanup(timeout time.Duration) (string, error) {
+	err := p.Run()
+	if err != nil {
+		return "", fmt.Errorf("failed to create pod: %w", err)
+	}
+
+	// Ensure cleanup happens even if execution fails
+	defer func() {
+		if cleanupErr := p.Cleanup(timeout); cleanupErr != nil {
+			glog.Errorf("Failed to cleanup pod %s: %v", p.name, cleanupErr)
+		}
+	}()
+
+	// Wait for pod completion (for one-shot pods) - wait until it's no longer running
+	err = p.ActualPod.WaitUntilCondition(corev1.PodReady, timeout)
+	if err != nil {
+		glog.V(90).Infof("Pod %s may have failed, retrieving logs", p.name)
+	}
+
+	// Alternative approach: poll for completion status
+	completionErr := p.waitForPodCompletion(timeout)
+
+	// Get the logs regardless of success/failure
+	output, logErr := p.GetPodLogs()
+	if logErr != nil {
+		return "", fmt.Errorf("failed to get pod logs: %w", logErr)
+	}
+
+	if completionErr != nil {
+		return output, fmt.Errorf("pod execution failed: %w", completionErr)
+	}
+
+	return strings.TrimSpace(output), nil
+}
+
+// Cleanup removes the pod and waits for deletion.
+func (p *PodCommand) Cleanup(timeout time.Duration) error {
+	if p.ActualPod == nil {
+		return nil
+	}
+
+	_, err := p.ActualPod.DeleteAndWait(timeout)
+
+	return err
+}
+
+// GetPodLogs retrieves logs from the pod.
+func (p *PodCommand) GetPodLogs() (string, error) {
+	if p.ActualPod == nil {
+		return "", fmt.Errorf("pod not created yet")
+	}
+
+	// Use the simplified approach similar to original implementation
+	logs, err := p.apiClient.CoreV1Interface.Pods(p.nsname).GetLogs(
+		p.name, &corev1.PodLogOptions{}).DoRaw(context.TODO())
+	if err != nil {
+		return "", fmt.Errorf("failed to get pod logs: %w", err)
+	}
+
+	return strings.TrimSpace(string(logs)), nil
+}
+
+// waitForPodCompletion waits for a pod to complete (succeed or fail).
+func (p *PodCommand) waitForPodCompletion(timeout time.Duration) error {
+	if p.ActualPod == nil {
+		return fmt.Errorf("pod not created yet")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			podStatus, err := p.apiClient.CoreV1Interface.Pods(p.nsname).Get(
+				ctx, p.name, metav1.GetOptions{})
+			if err != nil {
+				time.Sleep(5 * time.Second)
+
+				continue
+			}
+
+			if podStatus.Status.Phase == corev1.PodSucceeded || podStatus.Status.Phase == corev1.PodFailed {
+				if podStatus.Status.Phase == corev1.PodFailed {
+					return fmt.Errorf("pod failed with phase: %s", podStatus.Status.Phase)
+				}
+
+				return nil
+			}
+
+			time.Sleep(5 * time.Second)
+		}
+	}
+}

--- a/tests/hw-accel/internal/deploy/nfd-cleaner.go
+++ b/tests/hw-accel/internal/deploy/nfd-cleaner.go
@@ -7,11 +7,8 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
-	nodefeature "github.com/openshift-kni/eco-goinfra/pkg/nfd"
+	"github.com/openshift-kni/eco-goinfra/pkg/nfd"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NFDCustomResourceCleaner implements CustomResourceCleaner for NFD operators.
@@ -37,7 +34,6 @@ func NewNFDCustomResourceCleaner(
 func (n *NFDCustomResourceCleaner) CleanupCustomResources() error {
 	glog.V(n.LogLevel).Infof("Deleting NodeFeatureDiscovery custom resources in namespace %s", n.Namespace)
 
-	// Delete the specific NFD CR created in the AMD GPU tests
 	nfdCRName := "amd-gpu-nfd-instance"
 	deletedCount := 0
 
@@ -47,7 +43,6 @@ func (n *NFDCustomResourceCleaner) CleanupCustomResources() error {
 		deletedCount++
 	}
 
-	// Also cleanup AMD GPU FeatureRule
 	if err := n.cleanupAMDGPUFeatureRule(); err != nil {
 		glog.V(n.LogLevel).Infof("AMD GPU FeatureRule cleanup: %v", err)
 	}
@@ -65,8 +60,7 @@ func (n *NFDCustomResourceCleaner) CleanupCustomResources() error {
 func (n *NFDCustomResourceCleaner) deleteNFDCRByName(crName string) error {
 	glog.V(n.LogLevel).Infof("Attempting to delete NFD CR: %s", crName)
 
-	// Use Pull to get existing NFD CR
-	nfdCR, err := nodefeature.Pull(n.APIClient, crName, n.Namespace)
+	nfdCR, err := nfd.Pull(n.APIClient, crName, n.Namespace)
 	if err != nil {
 		if strings.Contains(err.Error(), "does not exist") {
 			glog.V(n.LogLevel).Infof("NFD CR %s does not exist", crName)
@@ -79,7 +73,6 @@ func (n *NFDCustomResourceCleaner) deleteNFDCRByName(crName string) error {
 		return fmt.Errorf("failed to pull NFD CR %s: %w", crName, err)
 	}
 
-	// Remove finalizers if present
 	if len(nfdCR.Object.GetFinalizers()) > 0 {
 		glog.V(n.LogLevel).Infof("Removing finalizers from NFD CR %s", crName)
 		nfdCR.Object.SetFinalizers([]string{})
@@ -109,23 +102,13 @@ func (n *NFDCustomResourceCleaner) deleteNFDCRByName(crName string) error {
 
 // cleanupAMDGPUFeatureRule cleans up the AMD GPU FeatureRule.
 func (n *NFDCustomResourceCleaner) cleanupAMDGPUFeatureRule() error {
-	featureRuleGVK := schema.GroupVersionKind{
-		Group:   "nfd.openshift.io",
-		Version: "v1alpha1",
-		Kind:    "NodeFeatureRule",
-	}
-
-	featureRule := &unstructured.Unstructured{}
-	featureRule.SetGroupVersionKind(featureRuleGVK)
+	nodeFeaturRuleBuilder, err := nfd.PullFeatureRule(n.APIClient, "amd-gpu-feature-rule", "openshift-amd-gpu")
 
 	ctx := context.Background()
-	err := n.APIClient.Client.Get(ctx,
-		client.ObjectKey{Name: "amd-gpu-feature-rule", Namespace: "openshift-amd-gpu"},
-		featureRule)
 
 	if err == nil {
 		glog.V(n.LogLevel).Info("Deleting AMD GPU FeatureRule")
-		err = n.APIClient.Client.Delete(ctx, featureRule)
+		err = n.APIClient.Client.Delete(ctx, nodeFeaturRuleBuilder.Object)
 
 		if err != nil {
 			glog.V(n.LogLevel).Infof("Error deleting AMD GPU FeatureRule: %v", err)

--- a/tests/hw-accel/internal/deploy/operator-installer.go
+++ b/tests/hw-accel/internal/deploy/operator-installer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/olm"
+	operatorsV1alpha1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/olm/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,8 +34,9 @@ type OperatorInstallConfig struct {
 	Channel                string
 	SkipNamespaceCreation  bool
 	SkipOperatorGroup      bool
-	TargetNamespaces       []string // Custom targetNamespaces for OperatorGroup
+	TargetNamespaces       []string
 	LogLevel               glog.Level
+	InstallPlanApproval    string
 }
 
 // OperatorInstaller provides generic operator installation functionality.
@@ -291,7 +293,9 @@ func (o *OperatorInstaller) createSubscription() error {
 		o.config.CatalogSource,
 		o.config.CatalogSourceNamespace,
 		o.config.PackageName)
+
 	sub.WithChannel(o.config.Channel)
+	sub.WithInstallPlanApproval(convertToInstallPlanApproval(o.config.InstallPlanApproval))
 
 	if sub.Exists() {
 		glog.V(o.config.LogLevel).Infof("Subscription %s already exists", o.config.SubscriptionName)
@@ -313,4 +317,15 @@ func (o *OperatorInstaller) createSubscription() error {
 	}
 
 	return nil
+}
+
+func convertToInstallPlanApproval(approval string) operatorsV1alpha1.Approval {
+	switch strings.ToLower(approval) {
+	case "automatic":
+		return operatorsV1alpha1.ApprovalAutomatic
+	case "manual":
+		return operatorsV1alpha1.ApprovalManual
+	default:
+		return operatorsV1alpha1.ApprovalAutomatic
+	}
 }


### PR DESCRIPTION
Adding multiple utils and configuration for handling operators deployment before tests, cleanups, adding basic test to check if all configured correctly and also checking deployment and relevant pods