### PR TITLE
system-tests: Whereabouts testing with deployments

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-deployment.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-deployment.go
@@ -1,0 +1,682 @@
+package rdscorecommon
+
+import (
+	"fmt"
+	"maps"
+	"strconv"
+	"time"
+
+	"github.com/golang/glog"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/rdscore/internal/rdscoreinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/rdscore/internal/rdscoreparams"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// WhereaboutsDeploymentConfig holds configuration for creating whereabouts deployments.
+type WhereaboutsDeploymentConfig struct {
+	Name                string
+	Label               string
+	Port                string
+	Image               string
+	Command             []string
+	NAD                 string
+	ServiceAccount      string
+	RBACRole            string
+	TopologyKey         string
+	Replicas            int32
+	UseAntiAffinity     bool
+	UseRequiredAffinity bool
+	AffinityLabels      string
+	Description         string
+}
+
+const (
+	myDeploymentOne                    = "rds-whereabouts-one"
+	myDeploymentOneLabel               = "app=rds-whereabouts-one"
+	myDeploymentOneSA                  = "rds-whereabouts-one-sa"
+	myDeploymentOneRBACRole            = "system:openshift:scc:nonroot-v2"
+	myDeploymentOneTopologyKey         = "kubernetes.io/hostname"
+	myDeploymentOneReplicas            = 1
+	myDeploymentOneUseAntiAffinity     = false
+	myDeploymentOneUseRequiredAffinity = false
+	myDeploymentOneAffinityLabels      = "app=rds-whereabouts-two"
+
+	myDeploymentTwo                    = "rds-whereabouts-two"
+	myDeploymentTwoLabel               = "app=rds-whereabouts-two"
+	myDeploymentTwoSA                  = "rds-whereabouts-two-sa"
+	myDeploymentTwoRBACRole            = "system:openshift:scc:nonroot-v2"
+	myDeploymentTwoTopologyKey         = "kubernetes.io/hostname"
+	myDeploymentTwoReplicas            = 1
+	myDeploymentTwoUseAntiAffinity     = false
+	myDeploymentTwoUseRequiredAffinity = true
+	myDeploymentTwoAffinityLabels      = "app=rds-whereabouts-one"
+
+	// DefaultAffinityWeight value for the weight of the pod affinity or anti-affinity.
+	DefaultAffinityWeight = 100
+	// DefaultDeploymentTimeout value for the timeout of the deployment creation.
+	DefaultDeploymentTimeout = 5 * time.Minute
+	// DefaultCleanupPollingInterval value for the polling interval of the cleanup.
+	DefaultCleanupPollingInterval = 15 * time.Second
+	// DefaultCleanupTimeout value for the timeout of the cleanup.
+	DefaultCleanupTimeout = 5 * time.Minute
+
+	waDeployment3                    = "rds-whereabouts-3"
+	waDeployment3Label               = "app=rds-whereabouts-3"
+	waDeployment3SA                  = "rds-whereabouts-3-sa"
+	waDeployment3RBACRole            = "system:openshift:scc:nonroot-v2"
+	waDeployment3TopologyKey         = "kubernetes.io/hostname"
+	waDeployment3Replicas            = 1
+	waDeployment3UseAntiAffinity     = true
+	waDeployment3UseRequiredAffinity = false
+	waDeployment3AffinityLabels      = "app=rds-whereabouts-4"
+
+	waDeployment4                    = "rds-whereabouts-4"
+	waDeployment4Label               = "app=rds-whereabouts-4"
+	waDeployment4SA                  = "rds-whereabouts-4-sa"
+	waDeployment4RBACRole            = "system:openshift:scc:nonroot-v2"
+	waDeployment4TopologyKey         = "kubernetes.io/hostname"
+	waDeployment4Replicas            = 1
+	waDeployment4UseAntiAffinity     = true
+	waDeployment4UseRequiredAffinity = true
+	waDeployment4AffinityLabels      = "app=rds-whereabouts-3"
+)
+
+// Pre-defined configurations.
+var (
+	SameNodeDeploymentOneConfig = WhereaboutsDeploymentConfig{
+		Name:                myDeploymentOne,
+		Label:               myDeploymentOneLabel,
+		Port:                "",  // Will be set from RDSCoreConfig
+		Image:               "",  // Will be set from RDSCoreConfig
+		Command:             nil, // Will be set from RDSCoreConfig
+		NAD:                 "",  // Will be set from RDSCoreConfig
+		ServiceAccount:      myDeploymentOneSA,
+		RBACRole:            myDeploymentOneRBACRole,
+		TopologyKey:         myDeploymentOneTopologyKey,
+		Replicas:            myDeploymentOneReplicas,
+		UseAntiAffinity:     myDeploymentOneUseAntiAffinity,
+		UseRequiredAffinity: myDeploymentOneUseRequiredAffinity,
+		AffinityLabels:      myDeploymentOneAffinityLabels,
+		Description:         "pods from 1st deployment running on the same node",
+	}
+
+	SameNodeDeploymentTwoConfig = WhereaboutsDeploymentConfig{
+		Name:                myDeploymentTwo,
+		Label:               myDeploymentTwoLabel,
+		Port:                "",  // Will be set from RDSCoreConfig
+		Image:               "",  // Will be set from RDSCoreConfig
+		Command:             nil, // Will be set from RDSCoreConfig
+		NAD:                 "",  // Will be set from RDSCoreConfig
+		ServiceAccount:      myDeploymentTwoSA,
+		RBACRole:            myDeploymentTwoRBACRole,
+		TopologyKey:         myDeploymentTwoTopologyKey,
+		Replicas:            myDeploymentTwoReplicas,
+		UseAntiAffinity:     myDeploymentTwoUseAntiAffinity,
+		UseRequiredAffinity: myDeploymentTwoUseRequiredAffinity,
+		AffinityLabels:      myDeploymentTwoAffinityLabels,
+		Description:         "pods from 2nd deployment running on the same node",
+	}
+
+	DiffNodeDeploymentOneConfig = WhereaboutsDeploymentConfig{
+		Name:                waDeployment3,
+		Label:               waDeployment3Label,
+		Port:                "",  // Will be set from RDSCoreConfig
+		Image:               "",  // Will be set from RDSCoreConfig
+		Command:             nil, // Will be set from RDSCoreConfig
+		NAD:                 "",  // Will be set from RDSCoreConfig
+		ServiceAccount:      waDeployment3SA,
+		RBACRole:            waDeployment3RBACRole,
+		TopologyKey:         waDeployment3TopologyKey,
+		Replicas:            waDeployment3Replicas,
+		UseAntiAffinity:     waDeployment3UseAntiAffinity,
+		UseRequiredAffinity: waDeployment3UseRequiredAffinity,
+		AffinityLabels:      waDeployment3AffinityLabels,
+		Description:         "pods from 1st deployment running on different nodes",
+	}
+
+	DiffNodeDeploymentTwoConfig = WhereaboutsDeploymentConfig{
+		Name:                waDeployment4,
+		Label:               waDeployment4Label,
+		Port:                "",  // Will be set from RDSCoreConfig
+		Image:               "",  // Will be set from RDSCoreConfig
+		Command:             nil, // Will be set from RDSCoreConfig
+		NAD:                 "",  // Will be set from RDSCoreConfig
+		ServiceAccount:      waDeployment4SA,
+		RBACRole:            waDeployment4RBACRole,
+		TopologyKey:         waDeployment4TopologyKey,
+		Replicas:            waDeployment4Replicas,
+		UseAntiAffinity:     waDeployment4UseAntiAffinity,
+		UseRequiredAffinity: waDeployment4UseRequiredAffinity,
+		AffinityLabels:      waDeployment4AffinityLabels,
+		Description:         "pods from 2nd deployment running on different nodes",
+	}
+)
+
+// defineWhereaboutsDeploymentContainer defines the container configuration for whereabouts deployment.
+func defineWhereaboutsDeploymentContainer(
+	cName, cImage string,
+	cCmd []string,
+	cRequests, cLimits map[string]string) *pod.ContainerBuilder {
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Defining container %q with %q image and command %q",
+		cName, cImage, cCmd)
+
+	cBuilder := pod.NewContainerBuilder(cName, cImage, cCmd)
+
+	if cRequests != nil {
+		containerRequests := corev1.ResourceList{}
+
+		for key, val := range cRequests {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Parsing container's request: %q - %q", key, val)
+
+			containerRequests[corev1.ResourceName(key)] = resource.MustParse(val)
+		}
+
+		cBuilder = cBuilder.WithCustomResourcesRequests(containerRequests)
+	}
+
+	if cLimits != nil {
+		containerLimits := corev1.ResourceList{}
+
+		for key, val := range cLimits {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Parsing container's limit: %q - %q", key, val)
+
+			containerLimits[corev1.ResourceName(key)] = resource.MustParse(val)
+		}
+
+		cBuilder = cBuilder.WithCustomResourcesLimits(containerLimits)
+	}
+
+	return cBuilder
+}
+
+// createDeploymentBuilder creates and configures the basic deployment.
+func createDeploymentBuilder(config WhereaboutsDeploymentConfig) *deployment.Builder {
+	By("Defining whereabouts deployment container")
+
+	waContainer := defineWhereaboutsDeploymentContainer("whereabouts-container", config.Image, config.Command, nil, nil)
+	Expect(waContainer).ToNot(BeNil(), "Failed to define whereabouts deployment container")
+
+	By("Getting whereabouts deployment container config")
+
+	waContainerCfg, err := waContainer.GetContainerCfg()
+	Expect(err).ToNot(HaveOccurred(), "Failed to get whereabouts deployment container config")
+
+	By("Checking that label is set")
+
+	Expect(config.Label).ToNot(BeEmpty(), "Label is not set")
+
+	svcLabelsMap := parseLabelsMap(config.Label)
+
+	By("Defining deployment")
+
+	waBuilder := deployment.NewBuilder(APIClient, config.Name, RDSCoreConfig.WhereaboutNS, svcLabelsMap, *waContainerCfg)
+
+	By("Adding pod annotations")
+
+	Expect(config.NAD).ToNot(BeEmpty(), "NAD(network attachment definition) is not set")
+
+	nadMap := map[string]string{"k8s.v1.cni.cncf.io/networks": config.NAD}
+
+	if waBuilder.Definition.Spec.Template.Annotations == nil {
+		waBuilder.Definition.Spec.Template.Annotations = make(map[string]string)
+	}
+
+	maps.Copy(waBuilder.Definition.Spec.Template.Annotations, nadMap)
+
+	By("Setting replicas")
+
+	waBuilder.Definition.Spec.Replicas = &config.Replicas
+
+	return waBuilder
+}
+
+func cleanupDeployment(waName, namespace, waLabel string) {
+	By(fmt.Sprintf("Checking that deployment %q doesn't exist in %q namespace",
+		waName, namespace))
+
+	var ctx SpecContext
+
+	waOne, err := deployment.Pull(APIClient, waName, namespace)
+
+	if err != nil {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to get deployment %q in %q namespace: %s",
+			waName, namespace, err)
+	} else {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Deleting deployment %q in %q namespace",
+			waName, namespace)
+
+		delError := waOne.Delete()
+
+		Expect(delError).ToNot(HaveOccurred(), "Failed to delete deployment %q in %q namespace",
+			waName, namespace)
+
+		// wait for pods to be deleted
+		By(fmt.Sprintf("Waiting for pods from %q deployment in %q namespace to be deleted",
+			waName, namespace))
+
+		Eventually(func() bool {
+			pods, err := pod.List(APIClient, namespace, metav1.ListOptions{
+				LabelSelector: waLabel,
+			})
+
+			if err != nil {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to list pods from %q deployment in %q namespace: %s",
+					waName, namespace, err)
+
+				return false
+			}
+
+			return len(pods) == 0
+		}).WithContext(ctx).WithPolling(DefaultCleanupPollingInterval).WithTimeout(DefaultCleanupTimeout).Should(BeTrue(),
+			"Pods from %q deployment in %q namespace are not deleted", waName, namespace)
+	}
+}
+
+func withDeploymentRequiredLabelPodAntiAffinity(
+	waBuilder *deployment.Builder,
+	matchLabels map[string]string,
+	nsNames []string,
+	topologyKey string) error {
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Adding required pod anti-affinity to deployment %q",
+		waBuilder.Definition.Name)
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("RequiredPodAntiAffinity 'matchLabels': %q", matchLabels)
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("RequiredPodAntiAffinity 'namespaces': %q", nsNames)
+
+	if matchLabels == nil {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Option 'matchLabels' is not set")
+
+		return fmt.Errorf("option 'matchLabels' is not set")
+	}
+
+	if topologyKey == "" {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Option 'topologyKey' is not set")
+
+		return fmt.Errorf("option 'topologyKey' is not set")
+	}
+
+	if len(nsNames) == 0 {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Option 'namespaces' is not set")
+
+		return fmt.Errorf("option 'namespaces' is not set")
+	}
+
+	waBuilder.Definition.Spec.Template.Spec.Affinity = &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: matchLabels,
+					},
+					TopologyKey: topologyKey,
+					Namespaces:  nsNames,
+				},
+			},
+		},
+	}
+
+	return nil
+}
+
+func withDeploymentRequiredLabelPodAffinity(
+	waBuilder *deployment.Builder,
+	matchLabels map[string]string,
+	nsNames []string,
+	topologyKey string) error {
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Adding required pod affinity to deployment %q",
+		waBuilder.Definition.Name)
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("RequiredLabelPodAffinity 'matchLabels': %q", matchLabels)
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("RequiredLabelPodAffinity 'namespaces': %q", nsNames)
+
+	if matchLabels == nil {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Option 'matchLabels' is not set")
+
+		return fmt.Errorf("option 'matchLabels' is not set")
+	}
+
+	if topologyKey == "" {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Option 'topologyKey' is not set")
+
+		return fmt.Errorf("option 'topologyKey' is not set")
+	}
+
+	if len(nsNames) == 0 {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Option 'namespaces' is not set")
+
+		return fmt.Errorf("option 'namespaces' is not set")
+	}
+
+	waBuilder.Definition.Spec.Template.Spec.Affinity = &corev1.Affinity{
+		PodAffinity: &corev1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: matchLabels,
+					},
+					TopologyKey: topologyKey,
+					Namespaces:  nsNames,
+				},
+			},
+		},
+	}
+
+	return nil
+}
+
+func withDeploymentPreferredLabelPodAffinity(
+	waBuilder *deployment.Builder,
+	matchLabels map[string]string,
+	nsNames []string,
+	topologyKey string,
+	weight int32) error {
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Adding preferred pod affinity to deployment %q",
+		waBuilder.Definition.Name)
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("PreferredPodAffinity 'matchLabels': %q", matchLabels)
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("PreferredPodAffinity 'namespaces': %q", nsNames)
+
+	if matchLabels == nil {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Option 'matchLabels' is not set")
+
+		return fmt.Errorf("option 'matchLabels' is not set")
+	}
+
+	if topologyKey == "" {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Option 'topologyKey' is not set")
+
+		return fmt.Errorf("option 'topologyKey' is not set")
+	}
+
+	if len(nsNames) == 0 {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Option 'namespaces' is not set")
+
+		return fmt.Errorf("option 'namespaces' is not set")
+	}
+
+	if weight < 1 || weight > 100 {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Option 'weight' is invalid: %d. Must be between 1 and 100", weight)
+
+		return fmt.Errorf("option 'weight' is invalid: %d. Must be between 1 and 100", weight)
+	}
+
+	waBuilder.Definition.Spec.Template.Spec.Affinity = &corev1.Affinity{
+		PodAffinity: &corev1.PodAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+				{
+					Weight: weight,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: matchLabels,
+						},
+						TopologyKey: topologyKey,
+						Namespaces:  nsNames,
+					},
+				},
+			},
+		},
+	}
+
+	return nil
+}
+
+func withDeploymentPreferredLabelPodAntiAffinity(
+	waBuilder *deployment.Builder,
+	matchLabels map[string]string,
+	nsNames []string,
+	topologyKey string,
+	weight int32) error {
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Adding preferred pod anti-affinity to deployment %q",
+		waBuilder.Definition.Name)
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("PreferredPodAntiAffinity 'matchLabels': %q", matchLabels)
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("PreferredPodAntiAffinity 'namespaces': %q", nsNames)
+
+	if matchLabels == nil {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Option 'matchLabels' is not set")
+
+		return fmt.Errorf("option 'matchLabels' is not set")
+	}
+
+	if topologyKey == "" {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Option 'topologyKey' is not set")
+
+		return fmt.Errorf("option 'topologyKey' is not set")
+	}
+
+	if len(nsNames) == 0 {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Option 'namespaces' is not set")
+
+		return fmt.Errorf("option 'namespaces' is not set")
+	}
+
+	if weight < 1 || weight > 100 {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Option 'weight' is invalid: %d. Must be between 1 and 100", weight)
+
+		return fmt.Errorf("option 'weight' is invalid: %d. Must be between 1 and 100", weight)
+	}
+
+	waBuilder.Definition.Spec.Template.Spec.Affinity = &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+				{
+					Weight: weight,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: matchLabels,
+						},
+						TopologyKey: topologyKey,
+						Namespaces:  nsNames,
+					},
+				},
+			},
+		},
+	}
+
+	return nil
+}
+
+// configureAffinity sets up pod affinity or anti-affinity based on configuration.
+func configureDeploymentAffinity(waBuilder *deployment.Builder, config WhereaboutsDeploymentConfig) {
+	By(fmt.Sprintf("Adding pod %s to deployment %q",
+		map[bool]string{true: "anti-affinity", false: "affinity"}[config.UseAntiAffinity],
+		config.Name))
+
+	var err error
+
+	svcLabelsMap := parseLabelsMap(config.AffinityLabels)
+
+	if config.UseAntiAffinity {
+		if config.UseRequiredAffinity {
+			err = withDeploymentRequiredLabelPodAntiAffinity(waBuilder, svcLabelsMap,
+				[]string{RDSCoreConfig.WhereaboutNS}, config.TopologyKey)
+		} else {
+			err = withDeploymentPreferredLabelPodAntiAffinity(waBuilder, svcLabelsMap,
+				[]string{RDSCoreConfig.WhereaboutNS}, config.TopologyKey, DefaultAffinityWeight)
+		}
+	} else {
+		if config.UseRequiredAffinity {
+			err = withDeploymentRequiredLabelPodAffinity(waBuilder, svcLabelsMap,
+				[]string{RDSCoreConfig.WhereaboutNS}, config.TopologyKey)
+		} else {
+			err = withDeploymentPreferredLabelPodAffinity(waBuilder, svcLabelsMap,
+				[]string{RDSCoreConfig.WhereaboutNS}, config.TopologyKey, DefaultAffinityWeight)
+		}
+	}
+
+	Expect(err).ToNot(HaveOccurred(), "Failed to configure pod affinity for deployment %q", config.Name)
+}
+
+// CreateWhereaboutsDeployment creates a deployment with whereabouts IPAM based on configuration.
+func CreateWhereaboutsDeployment(ctx SpecContext, config WhereaboutsDeploymentConfig) {
+	By("Validating deployment configuration")
+
+	Expect(config.Name).ToNot(BeEmpty(), "Deployment name must be set")
+
+	Expect(config.Image).ToNot(BeEmpty(), "Image must be set for deployment %q", config.Name)
+
+	Expect(len(config.Command)).To(BeNumerically(">", 0),
+		"At least one command must be specified for deployment %q", config.Name)
+
+	Expect(config.NAD).ToNot(BeEmpty(),
+		fmt.Sprintf("NetworkAttachmentDefinition must be set for deployment %q", config.Name))
+
+	if config.Port != "" {
+		_, perr := strconv.Atoi(config.Port)
+		Expect(perr).ToNot(HaveOccurred(),
+			"Port %q is not a valid integer for deployment %q", config.Port, config.Name)
+	}
+
+	By(fmt.Sprintf("Setting up deployment with %s", config.Description))
+
+	cleanupDeployment(config.Name, RDSCoreConfig.WhereaboutNS, config.Label)
+
+	waBuilder := createDeploymentBuilder(config)
+
+	configureDeploymentAffinity(waBuilder, config)
+
+	By(fmt.Sprintf("Setting up service account %q", config.ServiceAccount))
+
+	// Delete existing service account
+	deleteServiceAccount(config.ServiceAccount, RDSCoreConfig.WhereaboutNS)
+
+	// Create new service account
+	createServiceAccount(config.ServiceAccount, RDSCoreConfig.WhereaboutNS)
+
+	By(fmt.Sprintf("Setting up cluster role binding %q", config.RBACRole))
+
+	// Delete existing cluster role binding
+	deleteClusterRBAC(config.RBACRole)
+
+	// Create new cluster role binding
+	createClusterRBAC(config.ServiceAccount, config.RBACRole, config.ServiceAccount, RDSCoreConfig.WhereaboutNS)
+
+	By(fmt.Sprintf("Assigning service account %q to deployment %q", config.ServiceAccount, config.Name))
+
+	waBuilder = waBuilder.WithServiceAccountName(config.ServiceAccount)
+
+	_, err := waBuilder.CreateAndWaitUntilReady(DefaultDeploymentTimeout)
+	Expect(err).ToNot(HaveOccurred(), "Failed to create deployment %q", config.Name)
+}
+
+// CreateDeploymentsOnSameNode creates deployments with pods scheduled on the same node.
+func CreateDeploymentsOnSameNode(ctx SpecContext) {
+	configOne := SameNodeDeploymentOneConfig
+	// Set runtime configuration values
+	configOne.Port = RDSCoreConfig.WhereaboutsDeployOnePort
+	configOne.Image = RDSCoreConfig.WhereaboutsDeployImageOne
+	configOne.Command = RDSCoreConfig.WhereaboutsDeployOneCMD
+	configOne.NAD = RDSCoreConfig.WhereaboutsDeployOneNAD
+
+	CreateWhereaboutsDeployment(ctx, configOne)
+
+	configTwo := SameNodeDeploymentTwoConfig
+	// Set runtime configuration values
+	configTwo.Port = RDSCoreConfig.WhereaboutsDeployTwoPort
+	configTwo.Image = RDSCoreConfig.WhereaboutsDeployImageTwo
+	configTwo.Command = RDSCoreConfig.WhereaboutsDeployTwoCMD
+	configTwo.NAD = RDSCoreConfig.WhereaboutsDeployTwoNAD
+
+	CreateWhereaboutsDeployment(ctx, configTwo)
+}
+
+// VerifyWhereaboutsInterDeploymentPodCommunication verifies inter pod communication between two deployments.
+func VerifyWhereaboutsInterDeploymentPodCommunication(
+	ctx SpecContext,
+	configOne, configTwo WhereaboutsDeploymentConfig) {
+	By("Getting list of active pods from both deployments")
+
+	activePods := getActivePods(configOne.Label, RDSCoreConfig.WhereaboutNS)
+
+	Expect(len(activePods)).To(Equal(int(configOne.Replicas)),
+		"Number of active pods is not equal to number of replicas")
+
+	twoActivePods := getActivePods(configTwo.Label, RDSCoreConfig.WhereaboutNS)
+
+	Expect(len(twoActivePods)).To(Equal(int(configTwo.Replicas)),
+		"Number of active pods is not equal to number of replicas")
+
+	activePods = append(activePods, twoActivePods...)
+
+	By("Checking pods IP addresses")
+
+	podWhereaboutsIPs := getPodWhereaboutsIPs(activePods, interfaceName)
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("PodWhereaboutsIPs: %+v", podWhereaboutsIPs)
+
+	podOneName := activePods[0].Object.Name
+	podTwoName := activePods[len(activePods)-1].Object.Name
+
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Pod one %q", podOneName)
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Pod two %q", podTwoName)
+
+	podsMapping := make(map[string]string)
+
+	podsMapping[podOneName] = podTwoName
+	podsMapping[podTwoName] = podOneName
+
+	By("Parsing port number")
+
+	Expect(configOne.Port).ToNot(BeEmpty(), "Port is not set")
+	Expect(configTwo.Port).ToNot(BeEmpty(), "Port is not set")
+
+	Expect(configOne.Port).To(Equal(configTwo.Port), "Ports are not equal")
+
+	parsedPort, err := strconv.Atoi(configOne.Port)
+
+	Expect(err).ToNot(HaveOccurred(),
+		fmt.Sprintf("Failed to parse port number: %v", configOne.Port))
+
+	verifyInterPodCommunication(activePods, podWhereaboutsIPs, podsMapping, parsedPort)
+}
+
+// VerifyWhereaboutsInterDeploymentPodCommunicationOnTheSameNode creates two deployments
+// with pods scheduled on the same node and verifies inter pod communication between them.
+func VerifyWhereaboutsInterDeploymentPodCommunicationOnTheSameNode(ctx SpecContext) {
+	configOne := SameNodeDeploymentOneConfig
+	// Set runtime configuration values
+	configOne.Port = RDSCoreConfig.WhereaboutsDeployOnePort
+	configOne.Image = RDSCoreConfig.WhereaboutsDeployImageOne
+	configOne.Command = RDSCoreConfig.WhereaboutsDeployOneCMD
+	configOne.NAD = RDSCoreConfig.WhereaboutsDeployOneNAD
+
+	configTwo := SameNodeDeploymentTwoConfig
+	// Set runtime configuration values
+	configTwo.Port = RDSCoreConfig.WhereaboutsDeployTwoPort
+	configTwo.Image = RDSCoreConfig.WhereaboutsDeployImageTwo
+	configTwo.Command = RDSCoreConfig.WhereaboutsDeployTwoCMD
+	configTwo.NAD = RDSCoreConfig.WhereaboutsDeployTwoNAD
+
+	CreateWhereaboutsDeployment(ctx, configOne)
+
+	CreateWhereaboutsDeployment(ctx, configTwo)
+
+	VerifyWhereaboutsInterDeploymentPodCommunication(ctx, configOne, configTwo)
+}
+
+// VerifyWhereaboutsInterDeploymentPodCommunicationOnDifferentNodes creates two deployments
+// with pods scheduled on different nodes and verifies inter pod communication between them.
+func VerifyWhereaboutsInterDeploymentPodCommunicationOnDifferentNodes(ctx SpecContext) {
+	configOne := DiffNodeDeploymentOneConfig
+	// Set runtime configuration values
+	configOne.Port = RDSCoreConfig.WhereaboutsDeploy3Port
+	configOne.Image = RDSCoreConfig.WhereaboutsDeployImage3
+	configOne.Command = RDSCoreConfig.WhereaboutsDeploy3CMD
+	configOne.NAD = RDSCoreConfig.WhereaboutsDeploy3NAD
+
+	configTwo := DiffNodeDeploymentTwoConfig
+	// Set runtime configuration values
+	configTwo.Port = RDSCoreConfig.WhereaboutsDeploy4Port
+	configTwo.Image = RDSCoreConfig.WhereaboutsDeployImage4
+	configTwo.Command = RDSCoreConfig.WhereaboutsDeploy4CMD
+	configTwo.NAD = RDSCoreConfig.WhereaboutsDeploy4NAD
+
+	CreateWhereaboutsDeployment(ctx, configOne)
+
+	CreateWhereaboutsDeployment(ctx, configTwo)
+
+	VerifyWhereaboutsInterDeploymentPodCommunication(ctx, configOne, configTwo)
+}

--- a/tests/system-tests/rdscore/internal/rdscoreconfig/config.go
+++ b/tests/system-tests/rdscore/internal/rdscoreconfig/config.go
@@ -541,8 +541,42 @@ type CoreConfig struct {
 	//nolint:lll,nolintlint
 	WhereaboutsSTTwoPort string `yaml:"rdscore_whereabouts_st_two_port" envconfig:"ECO_RDSCORE_WHEREABOUTS_ST_TWO_PORT"`
 	//nolint:lll,nolintlint
-	WhereaboutsSTOneNAD   string `yaml:"rdscore_whereabouts_st_one_nad" envconfig:"ECO_RDSCORE_WHEREABOUTS_ST_ONE_NAD"`
-	WhereaboutsSTTwoNAD   string `yaml:"rdscore_whereabouts_st_two_nad" envconfig:"ECO_RDSCORE_WHEREABOUTS_ST_TWO_NAD"`
+	WhereaboutsSTOneNAD string `yaml:"rdscore_whereabouts_st_one_nad" envconfig:"ECO_RDSCORE_WHEREABOUTS_ST_ONE_NAD"`
+	WhereaboutsSTTwoNAD string `yaml:"rdscore_whereabouts_st_two_nad" envconfig:"ECO_RDSCORE_WHEREABOUTS_ST_TWO_NAD"`
+
+	//nolint:lll,nolintlint
+	WhereaboutsDeployImageOne string `yaml:"rdscore_whereabouts_deploy_image_one" envconfig:"ECO_RDSCORE_WHEREABOUTS_DEPLOY_IMAGE_ONE"`
+	//nolint:lll,nolintlint
+	WhereaboutsDeployImageTwo string `yaml:"rdscore_whereabouts_deploy_image_two" envconfig:"ECO_RDSCORE_WHEREABOUTS_DEPLOY_IMAGE_TWO"`
+	//nolint:lll,nolintlint
+	WhereaboutsDeployOneCMD EnvSliceString `yaml:"rdscore_whereabouts_deploy_one_cmd" envconfig:"ECO_RDSCORE_WHEREABOUTS_DEPLOY_ONE_CMD"`
+	//nolint:lll,nolintlint
+	WhereaboutsDeployTwoCMD EnvSliceString `yaml:"rdscore_whereabouts_deploy_two_cmd" envconfig:"ECO_RDSCORE_WHEREABOUTS_DEPLOY_TWO_CMD"`
+	//nolint:lll,nolintlint
+	WhereaboutsDeployOnePort string `yaml:"rdscore_whereabouts_deploy_one_port" envconfig:"ECO_RDSCORE_WHEREABOUTS_DEPLOY_ONE_PORT"`
+	//nolint:lll,nolintlint
+	WhereaboutsDeployTwoPort string `yaml:"rdscore_whereabouts_deploy_two_port" envconfig:"ECO_RDSCORE_WHEREABOUTS_DEPLOY_TWO_PORT"`
+	//nolint:lll,nolintlint
+	WhereaboutsDeployOneNAD string `yaml:"rdscore_whereabouts_deploy_one_nad" envconfig:"ECO_RDSCORE_WHEREABOUTS_DEPLOY_ONE_NAD"`
+	//nolint:lll,nolintlint
+	WhereaboutsDeployTwoNAD string `yaml:"rdscore_whereabouts_deploy_two_nad" envconfig:"ECO_RDSCORE_WHEREABOUTS_DEPLOY_TWO_NAD"`
+
+	//nolint:lll,nolintlint
+	WhereaboutsDeployImage3 string `yaml:"rdscore_whereabouts_deploy_image_3" envconfig:"ECO_RDSCORE_WHEREABOUTS_DEPLOY_IMAGE_3"`
+	//nolint:lll,nolintlint
+	WhereaboutsDeployImage4 string `yaml:"rdscore_whereabouts_deploy_image_4" envconfig:"ECO_RDSCORE_WHEREABOUTS_DEPLOY_IMAGE_4"`
+	//nolint:lll,nolintlint
+	WhereaboutsDeploy3CMD EnvSliceString `yaml:"rdscore_whereabouts_deploy_3_cmd" envconfig:"ECO_RDSCORE_WHEREABOUTS_DEPLOY_3_CMD"`
+	//nolint:lll,nolintlint
+	WhereaboutsDeploy4CMD EnvSliceString `yaml:"rdscore_whereabouts_deploy_4_cmd" envconfig:"ECO_RDSCORE_WHEREABOUTS_DEPLOY_4_CMD"`
+	//nolint:lll,nolintlint
+	WhereaboutsDeploy3Port string `yaml:"rdscore_whereabouts_deploy_3_port" envconfig:"ECO_RDSCORE_WHEREABOUTS_DEPLOY_3_PORT"`
+	//nolint:lll,nolintlint
+	WhereaboutsDeploy4Port string `yaml:"rdscore_whereabouts_deploy_4_port" envconfig:"ECO_RDSCORE_WHEREABOUTS_DEPLOY_4_PORT"`
+	//nolint:lll,nolintlint
+	WhereaboutsDeploy3NAD string `yaml:"rdscore_whereabouts_deploy_3_nad" envconfig:"ECO_RDSCORE_WHEREABOUTS_DEPLOY_3_NAD"`
+	//nolint:lll,nolintlint
+	WhereaboutsDeploy4NAD string `yaml:"rdscore_whereabouts_deploy_4_nad" envconfig:"ECO_RDSCORE_WHEREABOUTS_DEPLOY_4_NAD"`
 	WorkerLabelListOption metav1.ListOptions
 }
 

--- a/tests/system-tests/rdscore/internal/rdscoreconfig/default.yaml
+++ b/tests/system-tests/rdscore/internal/rdscoreconfig/default.yaml
@@ -182,3 +182,21 @@ rdscore_whereabouts_st_one_port: '1111'
 rdscore_whereabouts_st_two_port: '1111'
 rdscore_whereabouts_st_one_nad: ''
 rdscore_whereabouts_st_two_nad: ''
+
+rdscore_whereabouts_deploy_image_one: ''
+rdscore_whereabouts_deploy_image_two: ''
+rdscore_whereabouts_deploy_one_cmd: []
+rdscore_whereabouts_deploy_two_cmd: []
+rdscore_whereabouts_deploy_one_port: '1111'
+rdscore_whereabouts_deploy_two_port: '1111'
+rdscore_whereabouts_deploy_one_nad: ''
+rdscore_whereabouts_deploy_two_nad: ''
+
+rdscore_whereabouts_deploy_image_3: ''
+rdscore_whereabouts_deploy_image_4: ''
+rdscore_whereabouts_deploy_3_cmd: []
+rdscore_whereabouts_deploy_4_cmd: []
+rdscore_whereabouts_deploy_3_port: '1111'
+rdscore_whereabouts_deploy_4_port: '1111'
+rdscore_whereabouts_deploy_3_nad: ''
+rdscore_whereabouts_deploy_4_nad: ''

--- a/tests/system-tests/rdscore/tests/00_validate_top_level.go
+++ b/tests/system-tests/rdscore/tests/00_validate_top_level.go
@@ -281,6 +281,16 @@ var _ = Describe(
 				reportxml.ID("82799"),
 				rdscorecommon.EnsurePodConnectivityOnSameNodeAfterNodeDrain)
 
+			It("Verify Whereabouts Deployment on the same node",
+				Label("whereabouts", "whereabouts-deployment-same-node", "whereabouts-deployment"),
+				reportxml.ID("82714"),
+				rdscorecommon.VerifyWhereaboutsInterDeploymentPodCommunicationOnTheSameNode)
+
+			It("Verify Whereabouts Deployment on the different nodes",
+				Label("whereabouts", "whereabouts-deployment-different-nodes", "whereabouts-deployment"),
+				reportxml.ID("82713"),
+				rdscorecommon.VerifyWhereaboutsInterDeploymentPodCommunicationOnDifferentNodes)
+
 			AfterEach(func(ctx SpecContext) {
 				By("Ensure rootless DPDK server deployment was deleted")
 				rdscorecommon.CleanupRootlessDPDKServerDeployment()


### PR DESCRIPTION
Tests for inter pod connectivity via IP addresses assigned by _Whereabouts CNI_ plugin #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added configurable support and orchestration for Whereabouts-based test deployments, including topology/affinity controls and lifecycle handling to drive same-node and cross-node scenarios.
- Tests
  - Added system tests verifying inter-pod communication for deployments on the same node and on different nodes.
- Chores
  - Expanded default configuration and runtime settings with placeholders for additional Whereabouts deployments (images, commands, ports, NADs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->