### PR TITLE
Realtime preflight cleanup

### DIFF
--- a/tests/hw-accel/kmm/internal/get/get.go
+++ b/tests/hw-accel/kmm/internal/get/get.go
@@ -139,6 +139,19 @@ func PreflightImage(arch string) string {
 	return kmmparams.PreflightDTKImageX86
 }
 
+func PreflightKernel(arch string, realtime bool) string {
+	if arch == "arm64" || arch == "aarch64" {
+		if realtime {
+			return kmmparams.KernelForDTKArm64Realtime
+		}
+		return kmmparams.KernelForDTKArm64
+	}
+	if realtime {
+		return kmmparams.KernelForDTKX86Realtime
+	}
+	return kmmparams.KernelForDTKX86
+}
+
 // ModuleLoadedMessage returns message for a module loaded event.
 func ModuleLoadedMessage(module, nsname string) string {
 	message := fmt.Sprintf("Module %s/%s loaded into the kernel", nsname, module)

--- a/tests/hw-accel/kmm/internal/get/get.go
+++ b/tests/hw-accel/kmm/internal/get/get.go
@@ -139,16 +139,20 @@ func PreflightImage(arch string) string {
 	return kmmparams.PreflightDTKImageX86
 }
 
+// PreflightKernel returns predefined kernel version string based on architecture and realtime flag.
 func PreflightKernel(arch string, realtime bool) string {
 	if arch == "arm64" || arch == "aarch64" {
 		if realtime {
 			return kmmparams.KernelForDTKArm64Realtime
 		}
+
 		return kmmparams.KernelForDTKArm64
 	}
+
 	if realtime {
 		return kmmparams.KernelForDTKX86Realtime
 	}
+
 	return kmmparams.KernelForDTKX86
 }
 

--- a/tests/hw-accel/kmm/internal/kmmparams/const.go
+++ b/tests/hw-accel/kmm/internal/kmmparams/const.go
@@ -227,6 +227,14 @@ const (
 	// Compatible with OpenShift Container Platform 4.18.
 	PreflightDTKImageARM64 = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:" +
 		"ada767898092f36e8d965292843f9a772b2df449aeda06580430162696bd5ddf"
+	// KernelForDTKArm64 represents kernel string for arm64 dtk image
+	KernelForDTKArm64 = "5.14.0-284.52.1.el9_2.aarch64"
+	// KernelForDTKArm64Realtime represents kernel string for arm64 realtime dtk image
+	KernelForDTKArm64Realtime = "not supported"
+	// KernelForDTKX86 represents kernel string for x86 dtk image
+	KernelForDTKX86 = "5.14.0-427.81.1.el9_4.x86_64"
+	// KernelForDTKX86Realtime represents kernel string for x86 realtime dtk image
+	KernelForDTKX86Realtime = "5.14.0-427.81.1.el9_4.x86_64+rt"
 	// PreflightName represents preflightvalidation ocp object name.
 	PreflightName = "preflight"
 	// ScannerTestNamespace represents test case namespace name.

--- a/tests/hw-accel/kmm/internal/kmmparams/const.go
+++ b/tests/hw-accel/kmm/internal/kmmparams/const.go
@@ -227,13 +227,13 @@ const (
 	// Compatible with OpenShift Container Platform 4.18.
 	PreflightDTKImageARM64 = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:" +
 		"ada767898092f36e8d965292843f9a772b2df449aeda06580430162696bd5ddf"
-	// KernelForDTKArm64 represents kernel string for arm64 dtk image
+	// KernelForDTKArm64 represents kernel string for arm64 dtk image.
 	KernelForDTKArm64 = "5.14.0-284.52.1.el9_2.aarch64"
-	// KernelForDTKArm64Realtime represents kernel string for arm64 realtime dtk image
+	// KernelForDTKArm64Realtime represents kernel string for arm64 realtime dtk image.
 	KernelForDTKArm64Realtime = "not supported"
-	// KernelForDTKX86 represents kernel string for x86 dtk image
+	// KernelForDTKX86 represents kernel string for x86 dtk image.
 	KernelForDTKX86 = "5.14.0-427.81.1.el9_4.x86_64"
-	// KernelForDTKX86Realtime represents kernel string for x86 realtime dtk image
+	// KernelForDTKX86Realtime represents kernel string for x86 realtime dtk image.
 	KernelForDTKX86Realtime = "5.14.0-427.81.1.el9_4.x86_64+rt"
 	// PreflightName represents preflightvalidation ocp object name.
 	PreflightName = "preflight"

--- a/tests/hw-accel/kmm/modules/tests/realtime-test.go
+++ b/tests/hw-accel/kmm/modules/tests/realtime-test.go
@@ -231,10 +231,6 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelLong
 				kmmparams.RealtimeKernelNamespace)
 			Expect(strings.Contains(status, "Verification successful")).
 				To(BeTrue(), "expected realtime preflight success message not found")
-
-			By("Delete realtime preflight validation")
-			_, err = pre.Delete()
-			Expect(err).ToNot(HaveOccurred(), "error deleting realtime preflightvalidation")
 		})
 	})
 })

--- a/tests/hw-accel/kmm/modules/tests/realtime-test.go
+++ b/tests/hw-accel/kmm/modules/tests/realtime-test.go
@@ -59,6 +59,12 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelLong
 		})
 
 		AfterAll(func() {
+			By("Delete preflight validation")
+			pre, _ := kmm.PullPreflightValidationOCP(APIClient, kmmparams.PreflightName, kmmparams.RealtimeKernelNamespace)
+			if pre != nil {
+				_, _ = pre.Delete()
+			}
+
 			By("Delete Module")
 			_, _ = kmm.NewModuleBuilder(APIClient, moduleName, kmmparams.RealtimeKernelNamespace).Delete()
 
@@ -199,21 +205,20 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelLong
 		})
 
 		It("should be able to run preflightvalidation for realtime kernel", reportxml.ID("84177"), func() {
-			By("Get kernel version from cluster")
-			kernelVersion, err := get.KernelFullVersion(APIClient, GeneralConfig.WorkerLabelMap)
-			if err != nil {
-				Skip("could not get cluster kernel version")
-			}
-
 			By("Detecting cluster architecture")
 			arch, err := get.ClusterArchitecture(APIClient, GeneralConfig.WorkerLabelMap)
 			if err != nil {
 				Skip("could not detect cluster architecture")
 			}
+
+			By("Get kernel version from cluster")
+			kernelVersion := get.PreflightKernel(arch, true)
+
+			By("Get the DTK Image for preflight test")
 			dtkImage := get.PreflightImage(arch)
 
 			By("Create preflightvalidationocp for realtime kernel")
-			pre, err := kmm.NewPreflightValidationOCPBuilder(APIClient, kmmparams.PreflightName,
+			_, err = kmm.NewPreflightValidationOCPBuilder(APIClient, kmmparams.PreflightName,
 				kmmparams.RealtimeKernelNamespace).
 				WithKernelVersion(kernelVersion).
 				WithDtkImage(dtkImage).

--- a/tests/hw-accel/kmm/modules/tests/signing-test.go
+++ b/tests/hw-accel/kmm/modules/tests/signing-test.go
@@ -196,17 +196,16 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 			Expect(reasonSignListLength).To(Equal(foundEvents), "Expected number of events not found")
 		})
 		It("should be able to run preflightvalidation with no push", reportxml.ID("56329"), func() {
-			By("Get kernel version from cluster")
-			kernelVersion, err := get.KernelFullVersion(APIClient, GeneralConfig.WorkerLabelMap)
-			if err != nil {
-				Skip("could not get cluster kernel version")
-			}
-
 			By("Detecting cluster architecture")
 			arch, err := get.ClusterArchitecture(APIClient, GeneralConfig.WorkerLabelMap)
 			if err != nil {
 				Skip("could not detect cluster architecture")
 			}
+
+			By("Get kernel version from cluster")
+			kernelVersion := get.PreflightKernel(arch, false)
+
+			By("Get the DTK Image for preflight test")
 			dtkImage := get.PreflightImage(arch)
 
 			By("Create preflightvalidationocp")
@@ -239,17 +238,16 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 		})
 
 		It("should be able to run preflightvalidation and push to registry", reportxml.ID("56327"), func() {
-			By("Get kernel version from cluster")
-			kernelVersion, err := get.KernelFullVersion(APIClient, GeneralConfig.WorkerLabelMap)
-			if err != nil {
-				Skip("could not get cluster kernel version")
-			}
-
 			By("Detecting cluster architecture")
 			arch, err := get.ClusterArchitecture(APIClient, GeneralConfig.WorkerLabelMap)
 			if err != nil {
 				Skip("could not detect cluster architecture")
 			}
+
+			By("Get kernel version from cluster")
+			kernelVersion := get.PreflightKernel(arch, false)
+
+			By("Get the DTK Image for preflight test")
 			dtkImage := get.PreflightImage(arch)
 
 			By("Create preflightvalidationocp")

--- a/tests/hw-accel/kmm/modules/tests/use-dtk-auto-test.go
+++ b/tests/hw-accel/kmm/modules/tests/use-dtk-auto-test.go
@@ -188,17 +188,16 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 		})
 
 		It("should be able to run preflightvalidation with no push to registry", reportxml.ID("56330"), func() {
-			By("Get kernel version from cluster")
-			kernelVersion, err := get.KernelFullVersion(APIClient, GeneralConfig.WorkerLabelMap)
-			if err != nil {
-				Skip("could not get cluster kernel version")
-			}
-
 			By("Detecting cluster architecture")
 			arch, err := get.ClusterArchitecture(APIClient, GeneralConfig.WorkerLabelMap)
 			if err != nil {
 				Skip("could not detect cluster architecture")
 			}
+
+			By("Get kernel version from cluster")
+			kernelVersion := get.PreflightKernel(arch, true)
+
+			By("Get the DTK Image for preflight test")
 			dtkImage := get.PreflightImage(arch)
 
 			By("Wait for module to be fully deployed before creating preflight")
@@ -239,17 +238,16 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 		})
 
 		It("should be able to run preflightvalidation and push to registry", reportxml.ID("56328"), func() {
-			By("Get kernel version from cluster")
-			kernelVersion, err := get.KernelFullVersion(APIClient, GeneralConfig.WorkerLabelMap)
-			if err != nil {
-				Skip("could not get cluster kernel version")
-			}
-
 			By("Detecting cluster architecture")
 			arch, err := get.ClusterArchitecture(APIClient, GeneralConfig.WorkerLabelMap)
 			if err != nil {
 				Skip("could not detect cluster architecture")
 			}
+
+			By("Get kernel version from cluster")
+			kernelVersion := get.PreflightKernel(arch, false)
+
+			By("Get the DTK Image for preflight test")
 			dtkImage := get.PreflightImage(arch)
 
 			By("Create preflightvalidationocp")

--- a/tests/hw-accel/kmm/modules/tests/use-dtk-auto-test.go
+++ b/tests/hw-accel/kmm/modules/tests/use-dtk-auto-test.go
@@ -195,7 +195,7 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 			}
 
 			By("Get kernel version from cluster")
-			kernelVersion := get.PreflightKernel(arch, true)
+			kernelVersion := get.PreflightKernel(arch, false)
 
 			By("Get the DTK Image for preflight test")
 			dtkImage := get.PreflightImage(arch)


### PR DESCRIPTION
- move deletion of preflight to afterAll instead of part of the test
- Added PreflightKernel() function to return predefined kernel versions based on architecture and   
 realtime flag                                                                                  
- Added kernel version constants for ARM64, ARM64 realtime, x86, and x86 realtime           
- Updated all preflight validation tests to use a consistent kernel selection pattern:             
    PreflightKernel(arch, true) for realtime tests only                                  
    PreflightKernel(arch, false) for all other tests      