### PR TITLE
IBU: Fixed quotes in grep command in ValidateSeedHostnameRefLogs()

### DIFF
--- a/tests/lca/imagebasedupgrade/cnf/internal/validations/post_ibu_validations.go
+++ b/tests/lca/imagebasedupgrade/cnf/internal/validations/post_ibu_validations.go
@@ -224,7 +224,7 @@ func ValidateSeedHostnameRefLogs() {
 			// Seed refs from garbage-collector-controller are expected during IBU; exclude them from this check.
 			logCmd := fmt.Sprintf(
 				`grep -Ri %q /var/log/pods | `+
-					`grep -vE 'lifecycle-agent-controller-manager|garbage-collector-controller' | wc -l`,
+					`grep -vE "lifecycle-agent-controller-manager|garbage-collector-controller" | wc -l`,
 				seedInfo.SNOHostname,
 			)
 			logRes, err := cluster.ExecCmdWithStdout(TargetSNOAPIClient, logCmd)


### PR DESCRIPTION
This change fixes the quoting error which casues this test to fail with a "command not found" error.

This branch has been tested successfully: [https://jenkins-csb-kniqe-ci.dno.corp.redhat.com/job/CI/job/far-edge-vran-ibu/1074/](https://jenkins-csb-kniqe-ci.dno.corp.redhat.com/job/CI/job/far-edge-vran-ibu/1074/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted quoting in a regex-based validation within test scripts to improve reliability across environments.
  * Enhances stability of automated test runs without altering application behavior.

* **Chores**
  * No user-facing changes; internal test improvements only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->