### PR TITLE
rhwa: Validate number of replicas of FAR controller

### DIFF
--- a/tests/rhwa/far-operator/internal/farparams/farvars.go
+++ b/tests/rhwa/far-operator/internal/farparams/farvars.go
@@ -27,4 +27,7 @@ var (
 	ReporterCRDsToDump = []k8sreporter.CRData{
 		{Cr: &corev1.PodList{}},
 	}
+
+	// ExpectedReplicas defines the expected number of replicas for FAR controller manager.
+	ExpectedReplicas = int32(2)
 )


### PR DESCRIPTION
Migration of existing testcase that verifies the number of replicas of the Fence Agents Remediator controller manager.