### PR TITLE
Update eco-dast base container

### DIFF
--- a/images/rhwa/dast/Dockerfile
+++ b/images/rhwa/dast/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official RAPIDast image as the base
-FROM quay.io/redhatproductsecurity/rapidast:2.8.0
+FROM quay.io/redhatproductsecurity/rapidast:2.12.1
 
 # Set working directory to the RAPIDast installation
 WORKDIR /opt/rapidast


### PR DESCRIPTION
Update of the base container from 2.8.0 to 2.12.1 for the dast relasted tests in eco-gotest.

After updating this Dockerfile, a new container is to be built and pushed as `quay.io/ocp-edge-qe/eco-dast:latest`