### PR TITLE
hw-accel: enabled mcm tests to use spoke cluster DTK image

### DIFF
--- a/tests/hw-accel/kmm/internal/define/configmap.go
+++ b/tests/hw-accel/kmm/internal/define/configmap.go
@@ -27,6 +27,27 @@ func MultiStageConfigMapContent(module string) map[string]string {
 	return configmapContents
 }
 
+// UserDtkMultiStateConfigMapContents returns the configmap contents for speficied DTK image and module name.
+func UserDtkMultiStateConfigMapContents(module, dtkImage string) map[string]string {
+	data := map[string]interface{}{
+		"Module":   module,
+		"DTKImage": dtkImage,
+	}
+
+	templateInstance := template.Must(template.New("contents").Parse(kmmparams.UserDTKContents))
+	builder := &strings.Builder{}
+
+	if err := templateInstance.Execute(builder, data); err != nil {
+		panic(err)
+	}
+
+	content := builder.String()
+
+	configmapContents := map[string]string{"dockerfile": content}
+
+	return configmapContents
+}
+
 // SimpleKmodConfigMapContents returns the configmap for simple-kmod example.
 func SimpleKmodConfigMapContents() map[string]string {
 	configmapContents := map[string]string{"dockerfile": kmmparams.SimpleKmodContents}

--- a/tests/hw-accel/kmm/internal/get/get.go
+++ b/tests/hw-accel/kmm/internal/get/get.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/go-version"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/imagestream"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/kmm"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/olm"
@@ -207,6 +208,25 @@ func KmmOperatorVersion(apiClient *clients.Settings) (ver *version.Version, err 
 // KmmHubOperatorVersion returns CSV version of the installed KMM-HUB operator.
 func KmmHubOperatorVersion(apiClient *clients.Settings) (ver *version.Version, err error) {
 	return operatorVersion(apiClient, "hub", kmmparams.KmmHubOperatorNamespace)
+}
+
+// DTKImage returns the DockerImage of the drivertoolkit imagestream.
+func DTKImage(apiClient *clients.Settings) (dtkImage string, err error) {
+	dtkIS, err := imagestream.Pull(apiClient, kmmparams.DTKImageStream, kmmparams.DTKImageStreamNamespace)
+
+	if err != nil {
+		return "", err
+	}
+
+	dtkImage, err = dtkIS.GetDockerImage("latest")
+
+	if err != nil {
+		return "", err
+	}
+
+	glog.V(kmmparams.KmmLogLevel).Infof("DTK Image: %s", dtkImage)
+
+	return dtkImage, nil
 }
 
 func operatorVersion(apiClient *clients.Settings, namePattern, namespace string) (ver *version.Version, err error) {

--- a/tests/hw-accel/kmm/internal/kmmparams/kmmvars.go
+++ b/tests/hw-accel/kmm/internal/kmmparams/kmmvars.go
@@ -20,6 +20,12 @@ var (
 	// KmmTestHelperLabelName represents label set on the helper resources.
 	KmmTestHelperLabelName = "kmm-test-helper"
 
+	// DTKImageStream represents DTK imagestream name.
+	DTKImageStream = "driver-toolkit"
+
+	// DTKImageStreamNamespace represents namespace where imagestream is found.
+	DTKImageStreamNamespace = "openshift"
+
 	// DTKImage represents Driver Toolkit image in internal image registry.
 	DTKImage = "image-registry.openshift-image-registry.svc:5000/openshift/driver-toolkit"
 

--- a/tests/hw-accel/kmm/mcm/tests/intree-test.go
+++ b/tests/hw-accel/kmm/mcm/tests/intree-test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/await"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/check"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/define"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/get"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/kmmparams"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/mcm/internal/tsparams"
 	corev1 "k8s.io/api/core/v1"
@@ -79,8 +80,12 @@ var _ = Describe("KMM-Hub", Ordered, Label(tsparams.LabelSuite), func() {
 				kmmparams.KmmOperatorNamespace, corev1.SecretTypeDockerConfigJson).WithData(secretContent).Create()
 			Expect(err).ToNot(HaveOccurred(), "error creating secret on spoke")
 
+			By("Obtain DTK image from the Spoke")
+			dtkImage, err := get.DTKImage(ModulesConfig.SpokeAPIClient)
+			Expect(err).ToNot(HaveOccurred(), "Could not get spoke's DTK image.")
+
 			By("Create ConfigMap")
-			configmapContents := define.MultiStageConfigMapContent(moduleName)
+			configmapContents := define.UserDtkMultiStateConfigMapContents(moduleName, dtkImage)
 			dockerfileConfigMap, err := configmap.
 				NewBuilder(APIClient, moduleName, kmmparams.KmmHubOperatorNamespace).
 				WithData(configmapContents).Create()

--- a/tests/hw-accel/kmm/mcm/tests/multi-stage.go
+++ b/tests/hw-accel/kmm/mcm/tests/multi-stage.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/await"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/check"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/define"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/get"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/kmmparams"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/mcm/internal/tsparams"
 	corev1 "k8s.io/api/core/v1"
@@ -78,8 +79,12 @@ var _ = Describe("KMM-Hub", Ordered, Label(tsparams.LabelSuite), func() {
 				kmmparams.KmmOperatorNamespace, corev1.SecretTypeDockerConfigJson).WithData(secretContent).Create()
 			Expect(err).ToNot(HaveOccurred(), "error creating secret on spoke")
 
+			By("Obtain DTK image from the Spoke")
+			dtkImage, err := get.DTKImage(ModulesConfig.SpokeAPIClient)
+			Expect(err).ToNot(HaveOccurred(), "Could not get spoke's DTK image.")
+
 			By("Create ConfigMap")
-			configmapContents := define.MultiStageConfigMapContent(moduleName)
+			configmapContents := define.UserDtkMultiStateConfigMapContents(moduleName, dtkImage)
 			dockerfileConfigMap, err := configmap.
 				NewBuilder(APIClient, moduleName, kmmparams.KmmHubOperatorNamespace).
 				WithData(configmapContents).Create()


### PR DESCRIPTION
Updated MCM tests to use DTK image from spoke cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support building kernel modules with a selected Driver Toolkit (DTK) image.
  * Multi-stage build now propagates DTK release metadata, installs built modules, and runs depmod for accurate dependencies.
  * Config content generation now embeds the chosen DTK image for consistent builds.

* **Tests**
  * End-to-end flows fetch the DTK image from the cluster and use it in module builds, improving realism and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->