### PR TITLE
coderabbit: fix path filters

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -27,7 +27,7 @@ reviews:
   in_progress_fortune: true
   poem: false
   labeling_instructions: []
-  path_filters: ['!vendor/']
+  path_filters: ['!vendor/**']
   path_instructions: []
   abort_on_close: true
   disable_cache: false


### PR DESCRIPTION
Noticed on #848 that unless you add the double asterisks, coderabbit will still include files under the directory.

Related-to: rh-ecosystem-edge/eco-goinfra#1156