### PR TITLE
CAPOA api version conversion tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -158,6 +158,8 @@ linters:
         - github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/o-cloud/internal/ocloudcommon
         - github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/sriov/internal/ocpsriovinittools
         - github.com/rh-ecosystem-edge/eco-gotests/tests/lca/seedgeneration/internal/seedgenerationinittools
+        - github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/capoa-tls/internal/inittools
+        - github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/capoa-conversion/internal/inittools
     wsl:
       strict-append: false
   exclusions:
@@ -227,6 +229,12 @@ linters:
       - linters:
           - gochecknoinits
         path: tests/lca/imagebasedinstall/mgmt/internal/mgmtinittools
+      - linters:
+          - gochecknoinits
+        path: tests/assisted/ztp/capoa-tls/internal/inittools
+      - linters:
+          - gochecknoinits
+        path: tests/assisted/ztp/capoa-conversion/internal/inittools
       - linters:
           - gochecknoinits
         path: tests/internal/reporter

--- a/tests/assisted/ztp/capoa-conversion/capoa_conversion_suite_test.go
+++ b/tests/assisted/ztp/capoa-conversion/capoa_conversion_suite_test.go
@@ -1,0 +1,45 @@
+package capoa_conversion_test
+
+import (
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/capoa-conversion/internal/inittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/capoa-conversion/internal/tsparams"
+	_ "github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/capoa-conversion/tests"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/reporter"
+)
+
+var _, currentFile, _, _ = runtime.Caller(0)
+
+func TestCAPOAConversion(t *testing.T) {
+	_, reporterConfig := GinkgoConfiguration()
+	reporterConfig.JUnitReport = GeneralConfig.GetJunitReportPath(currentFile)
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CAPOA Conversion Suite", Label(tsparams.Labels...), reporterConfig)
+}
+
+var _ = BeforeSuite(func() {
+	By("Check if hub has valid apiClient")
+
+	if HubAPIClient == nil {
+		Skip("Cannot run CAPOA Conversion suite when hub has nil api client")
+	}
+})
+
+var _ = ReportAfterSuite("", func(report Report) {
+	reportxml.Create(report, GeneralConfig.GetReportPath(), GeneralConfig.TCPrefix)
+})
+
+var _ = JustAfterEach(func() {
+	reporter.ReportIfFailed(
+		CurrentSpecReport(),
+		currentFile,
+		tsparams.ReporterNamespacesToDump,
+		tsparams.ReporterCRDsToDump)
+})

--- a/tests/assisted/ztp/capoa-conversion/capoa_conversion_suite_test.go
+++ b/tests/assisted/ztp/capoa-conversion/capoa_conversion_suite_test.go
@@ -18,7 +18,7 @@ var _, currentFile, _, _ = runtime.Caller(0)
 
 func TestCAPOAConversion(t *testing.T) {
 	_, reporterConfig := GinkgoConfiguration()
-	reporterConfig.JUnitReport = GeneralConfig.GetJunitReportPath(currentFile)
+	reporterConfig.JUnitReport = ZTPConfig.GetJunitReportPath(currentFile)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CAPOA Conversion Suite", Label(tsparams.Labels...), reporterConfig)
@@ -33,7 +33,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = ReportAfterSuite("", func(report Report) {
-	reportxml.Create(report, GeneralConfig.GetReportPath(), GeneralConfig.TCPrefix)
+	reportxml.Create(report, ZTPConfig.GetReportPath(), ZTPConfig.TCPrefix)
 })
 
 var _ = JustAfterEach(func() {

--- a/tests/assisted/ztp/capoa-conversion/internal/inittools/inittools.go
+++ b/tests/assisted/ztp/capoa-conversion/internal/inittools/inittools.go
@@ -1,0 +1,18 @@
+package inittools
+
+import (
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/config"
+)
+
+var (
+	// HubAPIClient provides API access to hub cluster via KUBECONFIG env var.
+	HubAPIClient *clients.Settings
+	// GeneralConfig provides access to general configuration parameters.
+	GeneralConfig *config.GeneralConfig
+)
+
+func init() {
+	HubAPIClient = clients.New("")
+	GeneralConfig = config.NewConfig()
+}

--- a/tests/assisted/ztp/capoa-conversion/internal/inittools/inittools.go
+++ b/tests/assisted/ztp/capoa-conversion/internal/inittools/inittools.go
@@ -2,17 +2,18 @@ package inittools
 
 import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/config"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/internal/ztpconfig"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/internal/ztpinittools"
 )
 
 var (
-	// HubAPIClient provides API access to hub cluster via KUBECONFIG env var.
+	// HubAPIClient provides API access to hub cluster.
 	HubAPIClient *clients.Settings
-	// GeneralConfig provides access to general configuration parameters.
-	GeneralConfig *config.GeneralConfig
+	// ZTPConfig provides access to general configuration parameters.
+	ZTPConfig *ztpconfig.ZTPConfig
 )
 
 func init() {
-	HubAPIClient = clients.New("")
-	GeneralConfig = config.NewConfig()
+	HubAPIClient = ztpinittools.HubAPIClient
+	ZTPConfig = ztpinittools.ZTPConfig
 }

--- a/tests/assisted/ztp/capoa-conversion/internal/inittools/inittools.go
+++ b/tests/assisted/ztp/capoa-conversion/internal/inittools/inittools.go
@@ -14,6 +14,10 @@ var (
 )
 
 func init() {
-	HubAPIClient = ztpinittools.HubAPIClient
 	ZTPConfig = ztpinittools.ZTPConfig
+	HubAPIClient = ztpinittools.HubAPIClient
+
+	if HubAPIClient == nil {
+		HubAPIClient = clients.New("")
+	}
 }

--- a/tests/assisted/ztp/capoa-conversion/internal/tsparams/capoa-conversion-vars.go
+++ b/tests/assisted/ztp/capoa-conversion/internal/tsparams/capoa-conversion-vars.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Labels represents the range of labels that can be used for test cases selection.
-	Labels = append(append([]string{}, ztpparams.Labels...), LabelSuite)
+	Labels = append(ztpparams.Labels, LabelSuite)
 
 	// ReporterNamespacesToDump tells to the reporter from where to collect logs.
 	ReporterNamespacesToDump = map[string]string{

--- a/tests/assisted/ztp/capoa-conversion/internal/tsparams/capoa-conversion-vars.go
+++ b/tests/assisted/ztp/capoa-conversion/internal/tsparams/capoa-conversion-vars.go
@@ -1,0 +1,22 @@
+package tsparams
+
+import (
+	"github.com/openshift-kni/k8sreporter"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/internal/ztpparams"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+	// Labels represents the range of labels that can be used for test cases selection.
+	Labels = append(append([]string{}, ztpparams.Labels...), LabelSuite)
+
+	// ReporterNamespacesToDump tells to the reporter from where to collect logs.
+	ReporterNamespacesToDump = map[string]string{
+		"multicluster-engine": "mce",
+	}
+
+	// ReporterCRDsToDump tells to the reporter what CRs to dump.
+	ReporterCRDsToDump = []k8sreporter.CRData{
+		{Cr: &corev1.PodList{}},
+	}
+)

--- a/tests/assisted/ztp/capoa-conversion/internal/tsparams/const.go
+++ b/tests/assisted/ztp/capoa-conversion/internal/tsparams/const.go
@@ -1,0 +1,12 @@
+package tsparams
+
+const (
+	// LabelSuite represents capoa-conversion label that can be used for test cases selection.
+	LabelSuite = "capoa-conversion"
+
+	// LabelBootstrapConversion represents label for bootstrap API version conversion tests.
+	LabelBootstrapConversion = "bootstrap-conversion"
+
+	// LabelControlPlaneConversion represents label for controlplane API version conversion tests.
+	LabelControlPlaneConversion = "controlplane-conversion"
+)

--- a/tests/assisted/ztp/capoa-conversion/tests/bootstrap-conversion.go
+++ b/tests/assisted/ztp/capoa-conversion/tests/bootstrap-conversion.go
@@ -73,7 +73,7 @@ var _ = Describe(
 		})
 
 		It("Verifies spec fields survive v1alpha1 to v1alpha2 round-trip conversion",
-			reportxml.ID("00001"), func() {
+			reportxml.ID("88915"), func() {
 				resourceName := "conv-spec-roundtrip"
 
 				By("Creating OpenshiftAssistedConfig via v1alpha1 API with populated spec")
@@ -130,7 +130,7 @@ var _ = Describe(
 			})
 
 		It("Verifies v1alpha2-only fields are preserved when read back via v1alpha1",
-			reportxml.ID("00002"), func() {
+			reportxml.ID("88916"), func() {
 				resourceName := "conv-v2-extra-fields"
 
 				By("Creating OpenshiftAssistedConfig via v1alpha2 API with v1alpha2-only fields")
@@ -173,7 +173,7 @@ var _ = Describe(
 			})
 
 		It("Verifies OpenshiftAssistedConfigTemplate spec round-trip conversion",
-			reportxml.ID("00003"), func() {
+			reportxml.ID("88917"), func() {
 				resourceName := "conv-template-roundtrip"
 
 				By("Creating OpenshiftAssistedConfigTemplate via v1alpha1 API")

--- a/tests/assisted/ztp/capoa-conversion/tests/bootstrap-conversion.go
+++ b/tests/assisted/ztp/capoa-conversion/tests/bootstrap-conversion.go
@@ -1,0 +1,311 @@
+package capoa_conversion_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/capoa-conversion/internal/inittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/capoa-conversion/internal/tsparams"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	bootstrapTestNS = "capoa-conv-bootstrap"
+)
+
+var (
+	bootstrapV1Alpha1GVK = schema.GroupVersionKind{
+		Group:   "bootstrap.cluster.x-k8s.io",
+		Version: "v1alpha1",
+		Kind:    "OpenshiftAssistedConfig",
+	}
+	bootstrapV1Alpha2GVK = schema.GroupVersionKind{
+		Group:   "bootstrap.cluster.x-k8s.io",
+		Version: "v1alpha2",
+		Kind:    "OpenshiftAssistedConfig",
+	}
+	bootstrapTemplateV1Alpha1GVK = schema.GroupVersionKind{
+		Group:   "bootstrap.cluster.x-k8s.io",
+		Version: "v1alpha1",
+		Kind:    "OpenshiftAssistedConfigTemplate",
+	}
+	bootstrapTemplateV1Alpha2GVK = schema.GroupVersionKind{
+		Group:   "bootstrap.cluster.x-k8s.io",
+		Version: "v1alpha2",
+		Kind:    "OpenshiftAssistedConfigTemplate",
+	}
+)
+
+var _ = Describe(
+	"BootstrapConversion",
+	Ordered, ContinueOnFailure,
+	Label(tsparams.LabelBootstrapConversion), func() {
+		BeforeAll(func() {
+			By("Verifying hub API client is available")
+
+			if HubAPIClient == nil {
+				Skip("Hub API client is nil")
+			}
+
+			By("Verifying bootstrap CRD serves v1alpha1")
+
+			assertCRDServesVersion("openshiftassistedconfigs.bootstrap.cluster.x-k8s.io", "v1alpha1")
+
+			By(fmt.Sprintf("Creating test namespace %s", bootstrapTestNS))
+
+			nsBuilder := namespace.NewBuilder(HubAPIClient, bootstrapTestNS)
+
+			_ = nsBuilder.DeleteAndWait(2 * time.Minute)
+
+			_, err := namespace.NewBuilder(HubAPIClient, bootstrapTestNS).Create()
+			Expect(err).ToNot(HaveOccurred(), "failed to create namespace %s", bootstrapTestNS)
+
+			DeferCleanup(func() {
+				nsBuilder := namespace.NewBuilder(HubAPIClient, bootstrapTestNS)
+				_ = nsBuilder.DeleteAndWait(2 * time.Minute)
+			})
+		})
+
+		It("Verifies spec fields survive v1alpha1 to v1alpha2 round-trip conversion",
+			reportxml.ID("00001"), func() {
+				resourceName := "conv-spec-roundtrip"
+
+				By("Creating OpenshiftAssistedConfig via v1alpha1 API with populated spec")
+
+				oac := newBootstrapV1Alpha1(resourceName, bootstrapTestNS, map[string]interface{}{
+					"cpuArchitecture":      "x86_64",
+					"sshAuthorizedKey":     "ssh-rsa AAAA...",
+					"additionalNTPSources": []interface{}{"ntp1.example.com", "ntp2.example.com"},
+					"nodeRegistration": map[string]interface{}{
+						"name":               "test-node",
+						"kubeletExtraLabels": []interface{}{"label1=val1", "label2=val2"},
+					},
+				})
+
+				err := HubAPIClient.Create(context.TODO(), oac)
+				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedConfig via v1alpha1")
+
+				DeferCleanup(func() {
+					_ = HubAPIClient.Delete(context.TODO(), oac)
+				})
+
+				By("Reading the resource back via v1alpha2 API")
+
+				v2Obj := readResource(bootstrapV1Alpha2GVK, resourceName, bootstrapTestNS)
+
+				By("Verifying spec fields are preserved after v1alpha1 -> v1alpha2 conversion")
+
+				arch, _, _ := unstructured.NestedString(v2Obj.Object, "spec", "cpuArchitecture")
+				Expect(arch).To(Equal("x86_64"), "cpuArchitecture should be preserved")
+
+				sshKey, _, _ := unstructured.NestedString(v2Obj.Object, "spec", "sshAuthorizedKey")
+				Expect(sshKey).To(Equal("ssh-rsa AAAA..."), "sshAuthorizedKey should be preserved")
+
+				ntpSources, _, _ := unstructured.NestedStringSlice(v2Obj.Object, "spec", "additionalNTPSources")
+				Expect(ntpSources).To(Equal([]string{"ntp1.example.com", "ntp2.example.com"}),
+					"additionalNTPSources should be preserved")
+
+				nodeName, _, _ := unstructured.NestedString(v2Obj.Object, "spec", "nodeRegistration", "name")
+				Expect(nodeName).To(Equal("test-node"), "nodeRegistration.name should be preserved")
+
+				labels, _, _ := unstructured.NestedStringSlice(v2Obj.Object, "spec", "nodeRegistration", "kubeletExtraLabels")
+				Expect(labels).To(Equal([]string{"label1=val1", "label2=val2"}),
+					"nodeRegistration.kubeletExtraLabels should be preserved")
+
+				By("Reading the resource back via v1alpha1 API (reverse conversion)")
+
+				v1Obj := readResource(bootstrapV1Alpha1GVK, resourceName, bootstrapTestNS)
+
+				archV1, _, _ := unstructured.NestedString(v1Obj.Object, "spec", "cpuArchitecture")
+				Expect(archV1).To(Equal("x86_64"), "cpuArchitecture should survive round-trip")
+
+				sshKeyV1, _, _ := unstructured.NestedString(v1Obj.Object, "spec", "sshAuthorizedKey")
+				Expect(sshKeyV1).To(Equal("ssh-rsa AAAA..."), "sshAuthorizedKey should survive round-trip")
+			})
+
+		It("Verifies v1alpha2-only fields are preserved when read back via v1alpha1",
+			reportxml.ID("00002"), func() {
+				resourceName := "conv-v2-extra-fields"
+
+				By("Creating OpenshiftAssistedConfig via v1alpha2 API with v1alpha2-only fields")
+
+				oac := newBootstrapV1Alpha2(resourceName, bootstrapTestNS, map[string]interface{}{
+					"cpuArchitecture":      "x86_64",
+					"preBootstrapCommands": []interface{}{"/usr/bin/pre-cmd"},
+					"nodeRegistration": map[string]interface{}{
+						"providerID": "nutanix://test-provider-id",
+					},
+				})
+
+				err := HubAPIClient.Create(context.TODO(), oac)
+				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedConfig via v1alpha2")
+
+				DeferCleanup(func() {
+					_ = HubAPIClient.Delete(context.TODO(), oac)
+				})
+
+				By("Reading the resource back via v1alpha1 API")
+
+				v1Obj := readResource(bootstrapV1Alpha1GVK, resourceName, bootstrapTestNS)
+
+				By("Verifying common fields are preserved")
+
+				arch, _, _ := unstructured.NestedString(v1Obj.Object, "spec", "cpuArchitecture")
+				Expect(arch).To(Equal("x86_64"), "cpuArchitecture should be preserved in v1alpha1 view")
+
+				By("Reading back via v1alpha2 to confirm v1alpha2-only fields survived round-trip via MarshalData")
+
+				v2Obj := readResource(bootstrapV1Alpha2GVK, resourceName, bootstrapTestNS)
+
+				preCommands, _, _ := unstructured.NestedStringSlice(v2Obj.Object, "spec", "preBootstrapCommands")
+				Expect(preCommands).To(Equal([]string{"/usr/bin/pre-cmd"}),
+					"preBootstrapCommands should survive v1alpha2 -> v1alpha1 -> v1alpha2 round-trip")
+
+				providerID, _, _ := unstructured.NestedString(v2Obj.Object, "spec", "nodeRegistration", "providerID")
+				Expect(providerID).To(Equal("nutanix://test-provider-id"),
+					"nodeRegistration.providerID should survive round-trip via MarshalData annotation")
+			})
+
+		It("Verifies OpenshiftAssistedConfigTemplate spec round-trip conversion",
+			reportxml.ID("00003"), func() {
+				resourceName := "conv-template-roundtrip"
+
+				By("Creating OpenshiftAssistedConfigTemplate via v1alpha1 API")
+
+				tmpl := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha1",
+						"kind":       "OpenshiftAssistedConfigTemplate",
+						"metadata": map[string]interface{}{
+							"name":      resourceName,
+							"namespace": bootstrapTestNS,
+						},
+						"spec": map[string]interface{}{
+							"template": map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"labels": map[string]interface{}{
+										"test-label": "conversion-test",
+									},
+								},
+								"spec": map[string]interface{}{
+									"cpuArchitecture":  "aarch64",
+									"sshAuthorizedKey": "ssh-ed25519 AAAA...",
+								},
+							},
+						},
+					},
+				}
+
+				err := HubAPIClient.Create(context.TODO(), tmpl)
+				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedConfigTemplate via v1alpha1")
+
+				DeferCleanup(func() {
+					_ = HubAPIClient.Delete(context.TODO(), tmpl)
+				})
+
+				By("Reading the template back via v1alpha2 API")
+
+				v2Tmpl := readResource(bootstrapTemplateV1Alpha2GVK, resourceName, bootstrapTestNS)
+
+				arch, _, _ := unstructured.NestedString(v2Tmpl.Object,
+					"spec", "template", "spec", "cpuArchitecture")
+				Expect(arch).To(Equal("aarch64"),
+					"template spec cpuArchitecture should be preserved")
+
+				labels, _, _ := unstructured.NestedStringMap(v2Tmpl.Object,
+					"spec", "template", "metadata", "labels")
+				Expect(labels).To(HaveKeyWithValue("test-label", "conversion-test"),
+					"template metadata labels should be preserved")
+
+				By("Reading the template back via v1alpha1 to verify round-trip")
+
+				v1Tmpl := readResource(bootstrapTemplateV1Alpha1GVK, resourceName, bootstrapTestNS)
+
+				archV1, _, _ := unstructured.NestedString(v1Tmpl.Object,
+					"spec", "template", "spec", "cpuArchitecture")
+				Expect(archV1).To(Equal("aarch64"),
+					"template spec cpuArchitecture should survive round-trip")
+			})
+	})
+
+func newBootstrapV1Alpha1(name, namespace string, spec map[string]interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha1",
+			"kind":       "OpenshiftAssistedConfig",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": spec,
+		},
+	}
+}
+
+func newBootstrapV1Alpha2(name, namespace string, spec map[string]interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha2",
+			"kind":       "OpenshiftAssistedConfig",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": spec,
+		},
+	}
+}
+
+func readResource(gvk schema.GroupVersionKind, name, namespace string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+
+	err := HubAPIClient.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, obj)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(),
+		"failed to read %s/%s as %s", namespace, name, gvk.Version)
+
+	return obj
+}
+
+func assertCRDServesVersion(crdName, version string) {
+	crd := &unstructured.Unstructured{}
+	crd.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apiextensions.k8s.io",
+		Version: "v1",
+		Kind:    "CustomResourceDefinition",
+	})
+
+	err := HubAPIClient.Get(context.TODO(), types.NamespacedName{Name: crdName}, crd)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "CRD %s not found", crdName)
+
+	versions, found, _ := unstructured.NestedSlice(crd.Object, "spec", "versions")
+	ExpectWithOffset(1, found).To(BeTrue(), "CRD %s has no spec.versions", crdName)
+
+	served := false
+
+	for _, v := range versions {
+		vMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		vName, _, _ := unstructured.NestedString(vMap, "name")
+		vServed, _, _ := unstructured.NestedBool(vMap, "served")
+
+		if vName == version && vServed {
+			served = true
+
+			break
+		}
+	}
+
+	ExpectWithOffset(1, served).To(BeTrue(),
+		"CRD %s does not serve version %s", crdName, version)
+}

--- a/tests/assisted/ztp/capoa-conversion/tests/bootstrap-conversion.go
+++ b/tests/assisted/ztp/capoa-conversion/tests/bootstrap-conversion.go
@@ -13,7 +13,6 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/capoa-conversion/internal/tsparams"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -79,7 +78,7 @@ var _ = Describe(
 
 				By("Creating OpenshiftAssistedConfig via v1alpha1 API with populated spec")
 
-				oac := newBootstrapV1Alpha1(resourceName, bootstrapTestNS, map[string]interface{}{
+				oac := newBootstrapV1Alpha1(resourceName, map[string]interface{}{
 					"cpuArchitecture":      "x86_64",
 					"sshAuthorizedKey":     "ssh-rsa AAAA...",
 					"additionalNTPSources": []interface{}{"ntp1.example.com", "ntp2.example.com"},
@@ -136,7 +135,7 @@ var _ = Describe(
 
 				By("Creating OpenshiftAssistedConfig via v1alpha2 API with v1alpha2-only fields")
 
-				oac := newBootstrapV1Alpha2(resourceName, bootstrapTestNS, map[string]interface{}{
+				oac := newBootstrapV1Alpha2(resourceName, map[string]interface{}{
 					"cpuArchitecture":      "x86_64",
 					"preBootstrapCommands": []interface{}{"/usr/bin/pre-cmd"},
 					"nodeRegistration": map[string]interface{}{
@@ -235,77 +234,30 @@ var _ = Describe(
 			})
 	})
 
-func newBootstrapV1Alpha1(name, namespace string, spec map[string]interface{}) *unstructured.Unstructured {
+func newBootstrapV1Alpha1(name string, spec map[string]interface{}) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha1",
 			"kind":       "OpenshiftAssistedConfig",
 			"metadata": map[string]interface{}{
 				"name":      name,
-				"namespace": namespace,
+				"namespace": bootstrapTestNS,
 			},
 			"spec": spec,
 		},
 	}
 }
 
-func newBootstrapV1Alpha2(name, namespace string, spec map[string]interface{}) *unstructured.Unstructured {
+func newBootstrapV1Alpha2(name string, spec map[string]interface{}) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha2",
 			"kind":       "OpenshiftAssistedConfig",
 			"metadata": map[string]interface{}{
 				"name":      name,
-				"namespace": namespace,
+				"namespace": bootstrapTestNS,
 			},
 			"spec": spec,
 		},
 	}
-}
-
-func readResource(gvk schema.GroupVersionKind, name, namespace string) *unstructured.Unstructured {
-	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(gvk)
-
-	err := HubAPIClient.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, obj)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred(),
-		"failed to read %s/%s as %s", namespace, name, gvk.Version)
-
-	return obj
-}
-
-func assertCRDServesVersion(crdName, version string) {
-	crd := &unstructured.Unstructured{}
-	crd.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "apiextensions.k8s.io",
-		Version: "v1",
-		Kind:    "CustomResourceDefinition",
-	})
-
-	err := HubAPIClient.Get(context.TODO(), types.NamespacedName{Name: crdName}, crd)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "CRD %s not found", crdName)
-
-	versions, found, _ := unstructured.NestedSlice(crd.Object, "spec", "versions")
-	ExpectWithOffset(1, found).To(BeTrue(), "CRD %s has no spec.versions", crdName)
-
-	served := false
-
-	for _, v := range versions {
-		vMap, ok := v.(map[string]interface{})
-		if !ok {
-			continue
-		}
-
-		vName, _, _ := unstructured.NestedString(vMap, "name")
-		vServed, _, _ := unstructured.NestedBool(vMap, "served")
-
-		if vName == version && vServed {
-			served = true
-
-			break
-		}
-	}
-
-	ExpectWithOffset(1, served).To(BeTrue(),
-		"CRD %s does not serve version %s", crdName, version)
 }

--- a/tests/assisted/ztp/capoa-conversion/tests/bootstrap-conversion.go
+++ b/tests/assisted/ztp/capoa-conversion/tests/bootstrap-conversion.go
@@ -234,6 +234,7 @@ var _ = Describe(
 			})
 	})
 
+// newBootstrapV1Alpha1 builds an OpenshiftAssistedConfig unstructured object using the v1alpha1 API version.
 func newBootstrapV1Alpha1(name string, spec map[string]interface{}) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -248,6 +249,7 @@ func newBootstrapV1Alpha1(name string, spec map[string]interface{}) *unstructure
 	}
 }
 
+// newBootstrapV1Alpha2 builds an OpenshiftAssistedConfig unstructured object using the v1alpha2 API version.
 func newBootstrapV1Alpha2(name string, spec map[string]interface{}) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{

--- a/tests/assisted/ztp/capoa-conversion/tests/bootstrap-conversion.go
+++ b/tests/assisted/ztp/capoa-conversion/tests/bootstrap-conversion.go
@@ -53,6 +53,8 @@ var _ = Describe(
 				Skip("Hub API client is nil")
 			}
 
+			tsparams.ReporterNamespacesToDump[bootstrapTestNS] = "capoa-conv-bootstrap namespace"
+
 			By("Verifying bootstrap CRD serves v1alpha1")
 
 			assertCRDServesVersion("openshiftassistedconfigs.bootstrap.cluster.x-k8s.io", "v1alpha1")
@@ -60,14 +62,12 @@ var _ = Describe(
 			By(fmt.Sprintf("Creating test namespace %s", bootstrapTestNS))
 
 			nsBuilder := namespace.NewBuilder(HubAPIClient, bootstrapTestNS)
-
 			_ = nsBuilder.DeleteAndWait(2 * time.Minute)
 
-			_, err := namespace.NewBuilder(HubAPIClient, bootstrapTestNS).Create()
+			_, err := nsBuilder.Create()
 			Expect(err).ToNot(HaveOccurred(), "failed to create namespace %s", bootstrapTestNS)
 
 			DeferCleanup(func() {
-				nsBuilder := namespace.NewBuilder(HubAPIClient, bootstrapTestNS)
 				_ = nsBuilder.DeleteAndWait(2 * time.Minute)
 			})
 		})
@@ -90,10 +90,6 @@ var _ = Describe(
 
 				err := HubAPIClient.Create(context.TODO(), oac)
 				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedConfig via v1alpha1")
-
-				DeferCleanup(func() {
-					_ = HubAPIClient.Delete(context.TODO(), oac)
-				})
 
 				By("Reading the resource back via v1alpha2 API")
 
@@ -145,10 +141,6 @@ var _ = Describe(
 
 				err := HubAPIClient.Create(context.TODO(), oac)
 				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedConfig via v1alpha2")
-
-				DeferCleanup(func() {
-					_ = HubAPIClient.Delete(context.TODO(), oac)
-				})
 
 				By("Reading the resource back via v1alpha1 API")
 
@@ -204,10 +196,6 @@ var _ = Describe(
 
 				err := HubAPIClient.Create(context.TODO(), tmpl)
 				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedConfigTemplate via v1alpha1")
-
-				DeferCleanup(func() {
-					_ = HubAPIClient.Delete(context.TODO(), tmpl)
-				})
 
 				By("Reading the template back via v1alpha2 API")
 

--- a/tests/assisted/ztp/capoa-conversion/tests/controlplane-conversion.go
+++ b/tests/assisted/ztp/capoa-conversion/tests/controlplane-conversion.go
@@ -528,20 +528,3 @@ func newControlPlaneV1Alpha3(name string, spec map[string]interface{}) *unstruct
 		},
 	}
 }
-
-func nestedNumber(obj map[string]interface{}, fields ...string) int64 {
-	val, found, err := unstructured.NestedFieldNoCopy(obj, fields...)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "error reading %v", fields)
-	ExpectWithOffset(1, found).To(BeTrue(), "%v should exist", fields)
-
-	switch v := val.(type) {
-	case int64:
-		return v
-	case float64:
-		return int64(v)
-	default:
-		Fail(fmt.Sprintf("%v has unexpected type %T (value: %v)", fields, val, val))
-
-		return 0
-	}
-}

--- a/tests/assisted/ztp/capoa-conversion/tests/controlplane-conversion.go
+++ b/tests/assisted/ztp/capoa-conversion/tests/controlplane-conversion.go
@@ -1,0 +1,535 @@
+package capoa_conversion_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/capoa-conversion/internal/inittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/capoa-conversion/internal/tsparams"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	controlplaneTestNS = "capoa-conv-ctrlplane"
+)
+
+var (
+	cpV1Alpha2GVK = schema.GroupVersionKind{
+		Group:   "controlplane.cluster.x-k8s.io",
+		Version: "v1alpha2",
+		Kind:    "OpenshiftAssistedControlPlane",
+	}
+	cpV1Alpha3GVK = schema.GroupVersionKind{
+		Group:   "controlplane.cluster.x-k8s.io",
+		Version: "v1alpha3",
+		Kind:    "OpenshiftAssistedControlPlane",
+	}
+)
+
+var _ = Describe(
+	"ControlPlaneConversion",
+	Ordered, ContinueOnFailure,
+	Label(tsparams.LabelControlPlaneConversion), func() {
+		BeforeAll(func() {
+			By("Verifying hub API client is available")
+
+			if HubAPIClient == nil {
+				Skip("Hub API client is nil")
+			}
+
+			By("Verifying controlplane CRD serves v1alpha2")
+
+			assertCRDServesVersion("openshiftassistedcontrolplanes.controlplane.cluster.x-k8s.io", "v1alpha2")
+
+			By(fmt.Sprintf("Creating test namespace %s", controlplaneTestNS))
+
+			nsBuilder := namespace.NewBuilder(HubAPIClient, controlplaneTestNS)
+
+			_ = nsBuilder.DeleteAndWait(2 * time.Minute)
+
+			_, err := namespace.NewBuilder(HubAPIClient, controlplaneTestNS).Create()
+			Expect(err).ToNot(HaveOccurred(), "failed to create namespace %s", controlplaneTestNS)
+
+			DeferCleanup(func() {
+				nsBuilder := namespace.NewBuilder(HubAPIClient, controlplaneTestNS)
+				_ = nsBuilder.DeleteAndWait(2 * time.Minute)
+			})
+		})
+
+		It("Verifies Duration to seconds conversion in MachineTemplate",
+			reportxml.ID("00004"), func() {
+				resourceName := "conv-duration-to-seconds"
+
+				By("Creating OpenshiftAssistedControlPlane via v1alpha2 with Duration fields")
+
+				oacp := newControlPlaneV1Alpha2(resourceName, map[string]interface{}{
+					"distributionVersion": "4.17.0",
+					"replicas":            int64(3),
+					"machineTemplate": map[string]interface{}{
+						"infrastructureRef": map[string]interface{}{
+							"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+							"kind":       "OpenshiftAssistedMachineTemplate",
+							"name":       "test-machine-template",
+							"namespace":  controlplaneTestNS,
+						},
+						"nodeDrainTimeout":        "5m30s",
+						"nodeVolumeDetachTimeout": "2m0s",
+						"nodeDeletionTimeout":     "10m0s",
+					},
+					"config": map[string]interface{}{
+						"baseDomain":  "example.com",
+						"clusterName": "test-cluster",
+					},
+					"openshiftAssistedConfigSpec": map[string]interface{}{
+						"cpuArchitecture": "x86_64",
+					},
+				})
+
+				err := HubAPIClient.Create(context.TODO(), oacp)
+				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedControlPlane via v1alpha2")
+
+				DeferCleanup(func() {
+					_ = HubAPIClient.Delete(context.TODO(), oacp)
+				})
+
+				By("Reading back via v1alpha3 API")
+
+				v3Obj := readResource(cpV1Alpha3GVK, resourceName, controlplaneTestNS)
+
+				By("Verifying Duration fields are converted to seconds in MachineDeletionSpec")
+
+				nodeDrainSeconds, found, _ := unstructured.NestedFloat64(v3Obj.Object,
+					"spec", "machineTemplate", "deletion", "nodeDrainTimeoutSeconds")
+				Expect(found).To(BeTrue(), "nodeDrainTimeoutSeconds should exist in v1alpha3")
+				Expect(int32(nodeDrainSeconds)).To(Equal(int32(330)),
+					"nodeDrainTimeout 5m30s should convert to 330 seconds")
+
+				nodeVolumeSeconds, found, _ := unstructured.NestedFloat64(v3Obj.Object,
+					"spec", "machineTemplate", "deletion", "nodeVolumeDetachTimeoutSeconds")
+				Expect(found).To(BeTrue(), "nodeVolumeDetachTimeoutSeconds should exist in v1alpha3")
+				Expect(int32(nodeVolumeSeconds)).To(Equal(int32(120)),
+					"nodeVolumeDetachTimeout 2m0s should convert to 120 seconds")
+
+				nodeDeletionSeconds, found, _ := unstructured.NestedFloat64(v3Obj.Object,
+					"spec", "machineTemplate", "deletion", "nodeDeletionTimeoutSeconds")
+				Expect(found).To(BeTrue(), "nodeDeletionTimeoutSeconds should exist in v1alpha3")
+				Expect(int32(nodeDeletionSeconds)).To(Equal(int32(600)),
+					"nodeDeletionTimeout 10m0s should convert to 600 seconds")
+			})
+
+		It("Verifies seconds to Duration reverse conversion in MachineTemplate",
+			reportxml.ID("00005"), func() {
+				resourceName := "conv-seconds-to-duration"
+
+				By("Creating OpenshiftAssistedControlPlane via v1alpha3 with seconds fields")
+
+				oacp := newControlPlaneV1Alpha3(resourceName, map[string]interface{}{
+					"distributionVersion": "4.17.0",
+					"replicas":            int64(3),
+					"machineTemplate": map[string]interface{}{
+						"infrastructureRef": map[string]interface{}{
+							"kind":     "OpenshiftAssistedMachineTemplate",
+							"name":     "test-machine-template",
+							"apiGroup": "infrastructure.cluster.x-k8s.io",
+						},
+						"deletion": map[string]interface{}{
+							"nodeDrainTimeoutSeconds":        int64(330),
+							"nodeVolumeDetachTimeoutSeconds": int64(120),
+							"nodeDeletionTimeoutSeconds":     int64(600),
+						},
+					},
+					"config": map[string]interface{}{
+						"baseDomain":  "example.com",
+						"clusterName": "test-cluster",
+					},
+					"openshiftAssistedConfigSpec": map[string]interface{}{
+						"cpuArchitecture": "x86_64",
+					},
+				})
+
+				err := HubAPIClient.Create(context.TODO(), oacp)
+				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedControlPlane via v1alpha3")
+
+				DeferCleanup(func() {
+					_ = HubAPIClient.Delete(context.TODO(), oacp)
+				})
+
+				By("Reading back via v1alpha2 API")
+
+				v2Obj := readResource(cpV1Alpha2GVK, resourceName, controlplaneTestNS)
+
+				By("Verifying seconds are converted back to Duration strings")
+
+				nodeDrain, found, _ := unstructured.NestedString(v2Obj.Object,
+					"spec", "machineTemplate", "nodeDrainTimeout")
+				Expect(found).To(BeTrue(), "nodeDrainTimeout should exist in v1alpha2")
+				Expect(nodeDrain).To(Equal("5m30s"),
+					"330 seconds should convert back to 5m30s")
+
+				nodeVolumeDetach, found, _ := unstructured.NestedString(v2Obj.Object,
+					"spec", "machineTemplate", "nodeVolumeDetachTimeout")
+				Expect(found).To(BeTrue(), "nodeVolumeDetachTimeout should exist in v1alpha2")
+				Expect(nodeVolumeDetach).To(Equal("2m0s"),
+					"120 seconds should convert back to 2m0s")
+
+				nodeDeletion, found, _ := unstructured.NestedString(v2Obj.Object,
+					"spec", "machineTemplate", "nodeDeletionTimeout")
+				Expect(found).To(BeTrue(), "nodeDeletionTimeout should exist in v1alpha2")
+				Expect(nodeDeletion).To(Equal("10m0s"),
+					"600 seconds should convert back to 10m0s")
+			})
+
+		It("Verifies InfrastructureRef type conversion between ObjectReference and ContractVersionedObjectReference",
+			reportxml.ID("00006"), func() {
+				resourceName := "conv-infraref-type"
+
+				By("Creating OpenshiftAssistedControlPlane via v1alpha2 with full ObjectReference")
+
+				oacp := newControlPlaneV1Alpha2(resourceName, map[string]interface{}{
+					"distributionVersion": "4.17.0",
+					"replicas":            int64(3),
+					"machineTemplate": map[string]interface{}{
+						"infrastructureRef": map[string]interface{}{
+							"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+							"kind":       "OpenshiftAssistedMachineTemplate",
+							"name":       "infra-ref-test",
+							"namespace":  controlplaneTestNS,
+						},
+					},
+					"config": map[string]interface{}{
+						"baseDomain":  "example.com",
+						"clusterName": "test-cluster",
+					},
+					"openshiftAssistedConfigSpec": map[string]interface{}{
+						"cpuArchitecture": "x86_64",
+					},
+				})
+
+				err := HubAPIClient.Create(context.TODO(), oacp)
+				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedControlPlane via v1alpha2")
+
+				DeferCleanup(func() {
+					_ = HubAPIClient.Delete(context.TODO(), oacp)
+				})
+
+				By("Reading back via v1alpha3 — should be ContractVersionedObjectReference with apiGroup")
+
+				v3Obj := readResource(cpV1Alpha3GVK, resourceName, controlplaneTestNS)
+
+				apiGroup, _, _ := unstructured.NestedString(v3Obj.Object,
+					"spec", "machineTemplate", "infrastructureRef", "apiGroup")
+				Expect(apiGroup).To(Equal("infrastructure.cluster.x-k8s.io"),
+					"apiGroup should be extracted from apiVersion")
+
+				kind, _, _ := unstructured.NestedString(v3Obj.Object,
+					"spec", "machineTemplate", "infrastructureRef", "kind")
+				Expect(kind).To(Equal("OpenshiftAssistedMachineTemplate"),
+					"kind should be preserved")
+
+				name, _, _ := unstructured.NestedString(v3Obj.Object,
+					"spec", "machineTemplate", "infrastructureRef", "name")
+				Expect(name).To(Equal("infra-ref-test"),
+					"name should be preserved")
+
+				By("Reading back via v1alpha2 — should reconstruct ObjectReference with apiVersion")
+
+				v2Obj := readResource(cpV1Alpha2GVK, resourceName, controlplaneTestNS)
+
+				apiVersion, _, _ := unstructured.NestedString(v2Obj.Object,
+					"spec", "machineTemplate", "infrastructureRef", "apiVersion")
+				Expect(apiVersion).To(Equal("infrastructure.cluster.x-k8s.io/v1beta1"),
+					"apiVersion should be reconstructed as group/v1beta1 on reverse conversion")
+			})
+
+		It("Verifies replica pointer boxing between v1alpha2 int32 and v1alpha3 *int32",
+			reportxml.ID("00007"), func() {
+				resourceName := "conv-replica-boxing"
+
+				By("Creating OpenshiftAssistedControlPlane via v1alpha2 with replicas=3")
+
+				oacp := newControlPlaneV1Alpha2(resourceName, map[string]interface{}{
+					"distributionVersion": "4.17.0",
+					"replicas":            int64(3),
+					"machineTemplate": map[string]interface{}{
+						"infrastructureRef": map[string]interface{}{
+							"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+							"kind":       "OpenshiftAssistedMachineTemplate",
+							"name":       "replica-test",
+							"namespace":  controlplaneTestNS,
+						},
+					},
+					"config": map[string]interface{}{
+						"baseDomain":  "example.com",
+						"clusterName": "test-cluster",
+					},
+					"openshiftAssistedConfigSpec": map[string]interface{}{
+						"cpuArchitecture": "x86_64",
+					},
+				})
+
+				err := HubAPIClient.Create(context.TODO(), oacp)
+				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedControlPlane via v1alpha2")
+
+				DeferCleanup(func() {
+					_ = HubAPIClient.Delete(context.TODO(), oacp)
+				})
+
+				By("Reading back via v1alpha3")
+
+				v3Obj := readResource(cpV1Alpha3GVK, resourceName, controlplaneTestNS)
+
+				replicas, found, _ := unstructured.NestedFloat64(v3Obj.Object, "spec", "replicas")
+				Expect(found).To(BeTrue(), "replicas should be present in v1alpha3")
+				Expect(int32(replicas)).To(Equal(int32(3)),
+					"replicas value should be preserved through pointer boxing")
+
+				By("Reading back via v1alpha2")
+
+				v2Obj := readResource(cpV1Alpha2GVK, resourceName, controlplaneTestNS)
+
+				replicasV2, found, _ := unstructured.NestedFloat64(v2Obj.Object, "spec", "replicas")
+				Expect(found).To(BeTrue(), "replicas should be present in v1alpha2")
+				Expect(int32(replicasV2)).To(Equal(int32(3)),
+					"replicas value should survive round-trip")
+			})
+
+		It("Verifies config spec fields survive v1alpha2 to v1alpha3 round-trip",
+			reportxml.ID("00008"), func() {
+				resourceName := "conv-config-roundtrip"
+
+				By("Creating OpenshiftAssistedControlPlane via v1alpha2 with full config")
+
+				oacp := newControlPlaneV1Alpha2(resourceName, map[string]interface{}{
+					"distributionVersion": "4.17.0",
+					"replicas":            int64(3),
+					"machineTemplate": map[string]interface{}{
+						"infrastructureRef": map[string]interface{}{
+							"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+							"kind":       "OpenshiftAssistedMachineTemplate",
+							"name":       "config-test",
+							"namespace":  controlplaneTestNS,
+						},
+					},
+					"config": map[string]interface{}{
+						"baseDomain":         "conv-test.example.com",
+						"clusterName":        "conv-cluster",
+						"sshAuthorizedKey":   "ssh-rsa CONV...",
+						"mastersSchedulable": true,
+						"apiVIPs":            []interface{}{"192.168.1.100"},
+						"ingressVIPs":        []interface{}{"192.168.1.101"},
+					},
+					"openshiftAssistedConfigSpec": map[string]interface{}{
+						"cpuArchitecture":  "x86_64",
+						"sshAuthorizedKey": "ssh-rsa BOOTSTRAP...",
+					},
+				})
+
+				err := HubAPIClient.Create(context.TODO(), oacp)
+				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedControlPlane via v1alpha2")
+
+				DeferCleanup(func() {
+					_ = HubAPIClient.Delete(context.TODO(), oacp)
+				})
+
+				By("Reading back via v1alpha3")
+
+				v3Obj := readResource(cpV1Alpha3GVK, resourceName, controlplaneTestNS)
+
+				baseDomain, _, _ := unstructured.NestedString(v3Obj.Object, "spec", "config", "baseDomain")
+				Expect(baseDomain).To(Equal("conv-test.example.com"),
+					"config.baseDomain should be preserved")
+
+				clusterName, _, _ := unstructured.NestedString(v3Obj.Object, "spec", "config", "clusterName")
+				Expect(clusterName).To(Equal("conv-cluster"),
+					"config.clusterName should be preserved")
+
+				mastersSchedulable, _, _ := unstructured.NestedBool(v3Obj.Object, "spec", "config", "mastersSchedulable")
+				Expect(mastersSchedulable).To(BeTrue(), "config.mastersSchedulable should be preserved")
+
+				apiVIPs, _, _ := unstructured.NestedStringSlice(v3Obj.Object, "spec", "config", "apiVIPs")
+				Expect(apiVIPs).To(Equal([]string{"192.168.1.100"}),
+					"config.apiVIPs should be preserved")
+
+				bootstrapArch, _, _ := unstructured.NestedString(v3Obj.Object,
+					"spec", "openshiftAssistedConfigSpec", "cpuArchitecture")
+				Expect(bootstrapArch).To(Equal("x86_64"),
+					"openshiftAssistedConfigSpec.cpuArchitecture should be preserved")
+
+				By("Reading back via v1alpha2 to verify round-trip")
+
+				v2Obj := readResource(cpV1Alpha2GVK, resourceName, controlplaneTestNS)
+
+				baseDomainV2, _, _ := unstructured.NestedString(v2Obj.Object, "spec", "config", "baseDomain")
+				Expect(baseDomainV2).To(Equal("conv-test.example.com"),
+					"config.baseDomain should survive round-trip")
+			})
+
+		It("Verifies MachineTemplate metadata labels and annotations survive conversion",
+			reportxml.ID("00009"), func() {
+				resourceName := "conv-mt-metadata"
+
+				By("Creating OpenshiftAssistedControlPlane via v1alpha2 with MachineTemplate metadata")
+
+				oacp := newControlPlaneV1Alpha2(resourceName, map[string]interface{}{
+					"distributionVersion": "4.17.0",
+					"replicas":            int64(3),
+					"machineTemplate": map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"env":  "test",
+								"tier": "control-plane",
+							},
+							"annotations": map[string]interface{}{
+								"description": "conversion-test-machines",
+							},
+						},
+						"infrastructureRef": map[string]interface{}{
+							"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+							"kind":       "OpenshiftAssistedMachineTemplate",
+							"name":       "metadata-test",
+							"namespace":  controlplaneTestNS,
+						},
+					},
+					"config": map[string]interface{}{
+						"baseDomain":  "example.com",
+						"clusterName": "test-cluster",
+					},
+					"openshiftAssistedConfigSpec": map[string]interface{}{
+						"cpuArchitecture": "x86_64",
+					},
+				})
+
+				err := HubAPIClient.Create(context.TODO(), oacp)
+				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedControlPlane via v1alpha2")
+
+				DeferCleanup(func() {
+					_ = HubAPIClient.Delete(context.TODO(), oacp)
+				})
+
+				By("Reading back via v1alpha3")
+
+				v3Obj := readResource(cpV1Alpha3GVK, resourceName, controlplaneTestNS)
+
+				labels, _, _ := unstructured.NestedStringMap(v3Obj.Object,
+					"spec", "machineTemplate", "metadata", "labels")
+				Expect(labels).To(HaveKeyWithValue("env", "test"),
+					"MachineTemplate labels should be preserved")
+				Expect(labels).To(HaveKeyWithValue("tier", "control-plane"),
+					"MachineTemplate labels should be preserved")
+
+				annotations, _, _ := unstructured.NestedStringMap(v3Obj.Object,
+					"spec", "machineTemplate", "metadata", "annotations")
+				Expect(annotations).To(HaveKeyWithValue("description", "conversion-test-machines"),
+					"MachineTemplate annotations should be preserved")
+
+				By("Reading back via v1alpha2 to verify round-trip")
+
+				v2Obj := readResource(cpV1Alpha2GVK, resourceName, controlplaneTestNS)
+
+				labelsV2, _, _ := unstructured.NestedStringMap(v2Obj.Object,
+					"spec", "machineTemplate", "metadata", "labels")
+				Expect(labelsV2).To(HaveKeyWithValue("env", "test"),
+					"MachineTemplate labels should survive round-trip")
+			})
+
+		It("Verifies v1alpha2 bootstrap config spec is converted to v1alpha2 format in v1alpha3",
+			reportxml.ID("00010"), func() {
+				resourceName := "conv-bootstrap-spec-upgrade"
+
+				By("Creating OpenshiftAssistedControlPlane via v1alpha2 with v1alpha1-based bootstrap config")
+
+				oacp := newControlPlaneV1Alpha2(resourceName, map[string]interface{}{
+					"distributionVersion": "4.17.0",
+					"replicas":            int64(3),
+					"machineTemplate": map[string]interface{}{
+						"infrastructureRef": map[string]interface{}{
+							"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+							"kind":       "OpenshiftAssistedMachineTemplate",
+							"name":       "bootstrap-spec-test",
+							"namespace":  controlplaneTestNS,
+						},
+					},
+					"config": map[string]interface{}{
+						"baseDomain":  "example.com",
+						"clusterName": "test-cluster",
+					},
+					"openshiftAssistedConfigSpec": map[string]interface{}{
+						"cpuArchitecture":      "x86_64",
+						"sshAuthorizedKey":     "ssh-rsa TEST...",
+						"additionalNTPSources": []interface{}{"pool.ntp.org"},
+						"nodeRegistration": map[string]interface{}{
+							"name": "worker-node",
+						},
+					},
+				})
+
+				err := HubAPIClient.Create(context.TODO(), oacp)
+				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedControlPlane via v1alpha2")
+
+				DeferCleanup(func() {
+					_ = HubAPIClient.Delete(context.TODO(), oacp)
+				})
+
+				By("Reading back via v1alpha3")
+
+				v3Obj := readResource(cpV1Alpha3GVK, resourceName, controlplaneTestNS)
+
+				arch, _, _ := unstructured.NestedString(v3Obj.Object,
+					"spec", "openshiftAssistedConfigSpec", "cpuArchitecture")
+				Expect(arch).To(Equal("x86_64"),
+					"bootstrap cpuArchitecture should be converted to v1alpha2 format in v1alpha3")
+
+				ntp, _, _ := unstructured.NestedStringSlice(v3Obj.Object,
+					"spec", "openshiftAssistedConfigSpec", "additionalNTPSources")
+				Expect(ntp).To(Equal([]string{"pool.ntp.org"}),
+					"bootstrap additionalNTPSources should be preserved")
+
+				nodeName, _, _ := unstructured.NestedString(v3Obj.Object,
+					"spec", "openshiftAssistedConfigSpec", "nodeRegistration", "name")
+				Expect(nodeName).To(Equal("worker-node"),
+					"bootstrap nodeRegistration.name should be preserved")
+
+				By("Reading back via v1alpha2 to verify round-trip")
+
+				v2Obj := readResource(cpV1Alpha2GVK, resourceName, controlplaneTestNS)
+
+				archV2, _, _ := unstructured.NestedString(v2Obj.Object,
+					"spec", "openshiftAssistedConfigSpec", "cpuArchitecture")
+				Expect(archV2).To(Equal("x86_64"),
+					"bootstrap cpuArchitecture should survive round-trip")
+			})
+	})
+
+func newControlPlaneV1Alpha2(name string, spec map[string]interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "controlplane.cluster.x-k8s.io/v1alpha2",
+			"kind":       "OpenshiftAssistedControlPlane",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": controlplaneTestNS,
+			},
+			"spec": spec,
+		},
+	}
+}
+
+func newControlPlaneV1Alpha3(name string, spec map[string]interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "controlplane.cluster.x-k8s.io/v1alpha3",
+			"kind":       "OpenshiftAssistedControlPlane",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": controlplaneTestNS,
+			},
+			"spec": spec,
+		},
+	}
+}

--- a/tests/assisted/ztp/capoa-conversion/tests/controlplane-conversion.go
+++ b/tests/assisted/ztp/capoa-conversion/tests/controlplane-conversion.go
@@ -104,22 +104,19 @@ var _ = Describe(
 
 				By("Verifying Duration fields are converted to seconds in MachineDeletionSpec")
 
-				nodeDrainSeconds, found, _ := unstructured.NestedFloat64(v3Obj.Object,
+				nodeDrainSeconds := nestedNumber(v3Obj.Object,
 					"spec", "machineTemplate", "deletion", "nodeDrainTimeoutSeconds")
-				Expect(found).To(BeTrue(), "nodeDrainTimeoutSeconds should exist in v1alpha3")
-				Expect(int32(nodeDrainSeconds)).To(Equal(int32(330)),
+				Expect(nodeDrainSeconds).To(Equal(int64(330)),
 					"nodeDrainTimeout 5m30s should convert to 330 seconds")
 
-				nodeVolumeSeconds, found, _ := unstructured.NestedFloat64(v3Obj.Object,
+				nodeVolumeSeconds := nestedNumber(v3Obj.Object,
 					"spec", "machineTemplate", "deletion", "nodeVolumeDetachTimeoutSeconds")
-				Expect(found).To(BeTrue(), "nodeVolumeDetachTimeoutSeconds should exist in v1alpha3")
-				Expect(int32(nodeVolumeSeconds)).To(Equal(int32(120)),
+				Expect(nodeVolumeSeconds).To(Equal(int64(120)),
 					"nodeVolumeDetachTimeout 2m0s should convert to 120 seconds")
 
-				nodeDeletionSeconds, found, _ := unstructured.NestedFloat64(v3Obj.Object,
+				nodeDeletionSeconds := nestedNumber(v3Obj.Object,
 					"spec", "machineTemplate", "deletion", "nodeDeletionTimeoutSeconds")
-				Expect(found).To(BeTrue(), "nodeDeletionTimeoutSeconds should exist in v1alpha3")
-				Expect(int32(nodeDeletionSeconds)).To(Equal(int32(600)),
+				Expect(nodeDeletionSeconds).To(Equal(int64(600)),
 					"nodeDeletionTimeout 10m0s should convert to 600 seconds")
 			})
 
@@ -284,18 +281,16 @@ var _ = Describe(
 
 				v3Obj := readResource(cpV1Alpha3GVK, resourceName, controlplaneTestNS)
 
-				replicas, found, _ := unstructured.NestedFloat64(v3Obj.Object, "spec", "replicas")
-				Expect(found).To(BeTrue(), "replicas should be present in v1alpha3")
-				Expect(int32(replicas)).To(Equal(int32(3)),
+				replicas := nestedNumber(v3Obj.Object, "spec", "replicas")
+				Expect(replicas).To(Equal(int64(3)),
 					"replicas value should be preserved through pointer boxing")
 
 				By("Reading back via v1alpha2")
 
 				v2Obj := readResource(cpV1Alpha2GVK, resourceName, controlplaneTestNS)
 
-				replicasV2, found, _ := unstructured.NestedFloat64(v2Obj.Object, "spec", "replicas")
-				Expect(found).To(BeTrue(), "replicas should be present in v1alpha2")
-				Expect(int32(replicasV2)).To(Equal(int32(3)),
+				replicasV2 := nestedNumber(v2Obj.Object, "spec", "replicas")
+				Expect(replicasV2).To(Equal(int64(3)),
 					"replicas value should survive round-trip")
 			})
 
@@ -531,5 +526,22 @@ func newControlPlaneV1Alpha3(name string, spec map[string]interface{}) *unstruct
 			},
 			"spec": spec,
 		},
+	}
+}
+
+func nestedNumber(obj map[string]interface{}, fields ...string) int64 {
+	val, found, err := unstructured.NestedFieldNoCopy(obj, fields...)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "error reading %v", fields)
+	ExpectWithOffset(1, found).To(BeTrue(), "%v should exist", fields)
+
+	switch v := val.(type) {
+	case int64:
+		return v
+	case float64:
+		return int64(v)
+	default:
+		Fail(fmt.Sprintf("%v has unexpected type %T (value: %v)", fields, val, val))
+
+		return 0
 	}
 }

--- a/tests/assisted/ztp/capoa-conversion/tests/controlplane-conversion.go
+++ b/tests/assisted/ztp/capoa-conversion/tests/controlplane-conversion.go
@@ -63,7 +63,7 @@ var _ = Describe(
 		})
 
 		It("Verifies Duration to seconds conversion in MachineTemplate",
-			reportxml.ID("00004"), func() {
+			reportxml.ID("88918"), func() {
 				resourceName := "conv-duration-to-seconds"
 
 				By("Creating OpenshiftAssistedControlPlane via v1alpha2 with Duration fields")
@@ -121,7 +121,7 @@ var _ = Describe(
 			})
 
 		It("Verifies seconds to Duration reverse conversion in MachineTemplate",
-			reportxml.ID("00005"), func() {
+			reportxml.ID("88919"), func() {
 				resourceName := "conv-seconds-to-duration"
 
 				By("Creating OpenshiftAssistedControlPlane via v1alpha3 with seconds fields")
@@ -183,7 +183,7 @@ var _ = Describe(
 			})
 
 		It("Verifies InfrastructureRef type conversion between ObjectReference and ContractVersionedObjectReference",
-			reportxml.ID("00006"), func() {
+			reportxml.ID("88920"), func() {
 				resourceName := "conv-infraref-type"
 
 				By("Creating OpenshiftAssistedControlPlane via v1alpha2 with full ObjectReference")
@@ -245,7 +245,7 @@ var _ = Describe(
 			})
 
 		It("Verifies replica pointer boxing between v1alpha2 int32 and v1alpha3 *int32",
-			reportxml.ID("00007"), func() {
+			reportxml.ID("88921"), func() {
 				resourceName := "conv-replica-boxing"
 
 				By("Creating OpenshiftAssistedControlPlane via v1alpha2 with replicas=3")
@@ -295,7 +295,7 @@ var _ = Describe(
 			})
 
 		It("Verifies config spec fields survive v1alpha2 to v1alpha3 round-trip",
-			reportxml.ID("00008"), func() {
+			reportxml.ID("88922"), func() {
 				resourceName := "conv-config-roundtrip"
 
 				By("Creating OpenshiftAssistedControlPlane via v1alpha2 with full config")
@@ -366,7 +366,7 @@ var _ = Describe(
 			})
 
 		It("Verifies MachineTemplate metadata labels and annotations survive conversion",
-			reportxml.ID("00009"), func() {
+			reportxml.ID("88923"), func() {
 				resourceName := "conv-mt-metadata"
 
 				By("Creating OpenshiftAssistedControlPlane via v1alpha2 with MachineTemplate metadata")
@@ -434,7 +434,7 @@ var _ = Describe(
 			})
 
 		It("Verifies v1alpha2 bootstrap config spec is converted to v1alpha2 format in v1alpha3",
-			reportxml.ID("00010"), func() {
+			reportxml.ID("88924"), func() {
 				resourceName := "conv-bootstrap-spec-upgrade"
 
 				By("Creating OpenshiftAssistedControlPlane via v1alpha2 with v1alpha1-based bootstrap config")

--- a/tests/assisted/ztp/capoa-conversion/tests/controlplane-conversion.go
+++ b/tests/assisted/ztp/capoa-conversion/tests/controlplane-conversion.go
@@ -43,6 +43,8 @@ var _ = Describe(
 				Skip("Hub API client is nil")
 			}
 
+			tsparams.ReporterNamespacesToDump[controlplaneTestNS] = "capoa-conv-ctrlplane namespace"
+
 			By("Verifying controlplane CRD serves v1alpha2")
 
 			assertCRDServesVersion("openshiftassistedcontrolplanes.controlplane.cluster.x-k8s.io", "v1alpha2")
@@ -50,14 +52,12 @@ var _ = Describe(
 			By(fmt.Sprintf("Creating test namespace %s", controlplaneTestNS))
 
 			nsBuilder := namespace.NewBuilder(HubAPIClient, controlplaneTestNS)
-
 			_ = nsBuilder.DeleteAndWait(2 * time.Minute)
 
-			_, err := namespace.NewBuilder(HubAPIClient, controlplaneTestNS).Create()
+			_, err := nsBuilder.Create()
 			Expect(err).ToNot(HaveOccurred(), "failed to create namespace %s", controlplaneTestNS)
 
 			DeferCleanup(func() {
-				nsBuilder := namespace.NewBuilder(HubAPIClient, controlplaneTestNS)
 				_ = nsBuilder.DeleteAndWait(2 * time.Minute)
 			})
 		})
@@ -93,10 +93,6 @@ var _ = Describe(
 
 				err := HubAPIClient.Create(context.TODO(), oacp)
 				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedControlPlane via v1alpha2")
-
-				DeferCleanup(func() {
-					_ = HubAPIClient.Delete(context.TODO(), oacp)
-				})
 
 				By("Reading back via v1alpha3 API")
 
@@ -153,10 +149,6 @@ var _ = Describe(
 				err := HubAPIClient.Create(context.TODO(), oacp)
 				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedControlPlane via v1alpha3")
 
-				DeferCleanup(func() {
-					_ = HubAPIClient.Delete(context.TODO(), oacp)
-				})
-
 				By("Reading back via v1alpha2 API")
 
 				v2Obj := readResource(cpV1Alpha2GVK, resourceName, controlplaneTestNS)
@@ -210,10 +202,6 @@ var _ = Describe(
 
 				err := HubAPIClient.Create(context.TODO(), oacp)
 				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedControlPlane via v1alpha2")
-
-				DeferCleanup(func() {
-					_ = HubAPIClient.Delete(context.TODO(), oacp)
-				})
 
 				By("Reading back via v1alpha3 — should be ContractVersionedObjectReference with apiGroup")
 
@@ -273,10 +261,6 @@ var _ = Describe(
 				err := HubAPIClient.Create(context.TODO(), oacp)
 				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedControlPlane via v1alpha2")
 
-				DeferCleanup(func() {
-					_ = HubAPIClient.Delete(context.TODO(), oacp)
-				})
-
 				By("Reading back via v1alpha3")
 
 				v3Obj := readResource(cpV1Alpha3GVK, resourceName, controlplaneTestNS)
@@ -327,10 +311,6 @@ var _ = Describe(
 
 				err := HubAPIClient.Create(context.TODO(), oacp)
 				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedControlPlane via v1alpha2")
-
-				DeferCleanup(func() {
-					_ = HubAPIClient.Delete(context.TODO(), oacp)
-				})
 
 				By("Reading back via v1alpha3")
 
@@ -403,10 +383,6 @@ var _ = Describe(
 				err := HubAPIClient.Create(context.TODO(), oacp)
 				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedControlPlane via v1alpha2")
 
-				DeferCleanup(func() {
-					_ = HubAPIClient.Delete(context.TODO(), oacp)
-				})
-
 				By("Reading back via v1alpha3")
 
 				v3Obj := readResource(cpV1Alpha3GVK, resourceName, controlplaneTestNS)
@@ -466,10 +442,6 @@ var _ = Describe(
 
 				err := HubAPIClient.Create(context.TODO(), oacp)
 				Expect(err).ToNot(HaveOccurred(), "failed to create OpenshiftAssistedControlPlane via v1alpha2")
-
-				DeferCleanup(func() {
-					_ = HubAPIClient.Delete(context.TODO(), oacp)
-				})
 
 				By("Reading back via v1alpha3")
 

--- a/tests/assisted/ztp/capoa-conversion/tests/controlplane-conversion.go
+++ b/tests/assisted/ztp/capoa-conversion/tests/controlplane-conversion.go
@@ -433,7 +433,7 @@ var _ = Describe(
 					"MachineTemplate labels should survive round-trip")
 			})
 
-		It("Verifies v1alpha2 bootstrap config spec is converted to v1alpha2 format in v1alpha3",
+		It("Verifies v1alpha2 bootstrap config spec is converted to v1alpha3 format",
 			reportxml.ID("88924"), func() {
 				resourceName := "conv-bootstrap-spec-upgrade"
 
@@ -478,7 +478,7 @@ var _ = Describe(
 				arch, _, _ := unstructured.NestedString(v3Obj.Object,
 					"spec", "openshiftAssistedConfigSpec", "cpuArchitecture")
 				Expect(arch).To(Equal("x86_64"),
-					"bootstrap cpuArchitecture should be converted to v1alpha2 format in v1alpha3")
+					"bootstrap cpuArchitecture should be converted to v1alpha3 format")
 
 				ntp, _, _ := unstructured.NestedStringSlice(v3Obj.Object,
 					"spec", "openshiftAssistedConfigSpec", "additionalNTPSources")

--- a/tests/assisted/ztp/capoa-conversion/tests/controlplane-conversion.go
+++ b/tests/assisted/ztp/capoa-conversion/tests/controlplane-conversion.go
@@ -501,6 +501,7 @@ var _ = Describe(
 			})
 	})
 
+// newControlPlaneV1Alpha2 builds an OpenshiftAssistedControlPlane unstructured object using the v1alpha2 API version.
 func newControlPlaneV1Alpha2(name string, spec map[string]interface{}) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -515,6 +516,7 @@ func newControlPlaneV1Alpha2(name string, spec map[string]interface{}) *unstruct
 	}
 }
 
+// newControlPlaneV1Alpha3 builds an OpenshiftAssistedControlPlane unstructured object using the v1alpha3 API version.
 func newControlPlaneV1Alpha3(name string, spec map[string]interface{}) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{

--- a/tests/assisted/ztp/capoa-conversion/tests/helpers.go
+++ b/tests/assisted/ztp/capoa-conversion/tests/helpers.go
@@ -1,0 +1,77 @@
+package capoa_conversion_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/capoa-conversion/internal/inittools"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func readResource(gvk schema.GroupVersionKind, name, namespace string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+
+	err := HubAPIClient.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, obj)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(),
+		"failed to read %s/%s as %s", namespace, name, gvk.Version)
+
+	return obj
+}
+
+func assertCRDServesVersion(crdName, version string) {
+	crd := &unstructured.Unstructured{}
+	crd.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apiextensions.k8s.io",
+		Version: "v1",
+		Kind:    "CustomResourceDefinition",
+	})
+
+	err := HubAPIClient.Get(context.TODO(), types.NamespacedName{Name: crdName}, crd)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "CRD %s not found", crdName)
+
+	versions, found, _ := unstructured.NestedSlice(crd.Object, "spec", "versions")
+	ExpectWithOffset(1, found).To(BeTrue(), "CRD %s has no spec.versions", crdName)
+
+	served := false
+
+	for _, v := range versions {
+		vMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		vName, _, _ := unstructured.NestedString(vMap, "name")
+		vServed, _, _ := unstructured.NestedBool(vMap, "served")
+
+		if vName == version && vServed {
+			served = true
+
+			break
+		}
+	}
+
+	ExpectWithOffset(1, served).To(BeTrue(),
+		"CRD %s does not serve version %s", crdName, version)
+}
+
+func nestedNumber(obj map[string]interface{}, fields ...string) int64 {
+	val, found, err := unstructured.NestedFieldNoCopy(obj, fields...)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "error reading %v", fields)
+	ExpectWithOffset(1, found).To(BeTrue(), "%v should exist", fields)
+
+	switch v := val.(type) {
+	case int64:
+		return v
+	case float64:
+		return int64(v)
+	default:
+		Fail(fmt.Sprintf("%v has unexpected type %T (value: %v)", fields, val, val))
+
+		return 0
+	}
+}

--- a/tests/assisted/ztp/capoa-conversion/tests/helpers.go
+++ b/tests/assisted/ztp/capoa-conversion/tests/helpers.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// readResource fetches a cluster resource as the specified GVK and fails the test if not found.
 func readResource(gvk schema.GroupVersionKind, name, namespace string) *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(gvk)
@@ -23,6 +24,7 @@ func readResource(gvk schema.GroupVersionKind, name, namespace string) *unstruct
 	return obj
 }
 
+// assertCRDServesVersion fails the test if the given CRD does not serve the specified API version.
 func assertCRDServesVersion(crdName, version string) {
 	crd := &unstructured.Unstructured{}
 	crd.SetGroupVersionKind(schema.GroupVersionKind{
@@ -59,6 +61,7 @@ func assertCRDServesVersion(crdName, version string) {
 		"CRD %s does not serve version %s", crdName, version)
 }
 
+// nestedNumber extracts a numeric field from an unstructured object, handling both int64 and float64 JSON representations.
 func nestedNumber(obj map[string]interface{}, fields ...string) int64 {
 	val, found, err := unstructured.NestedFieldNoCopy(obj, fields...)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "error reading %v", fields)

--- a/tests/assisted/ztp/capoa-conversion/tests/helpers.go
+++ b/tests/assisted/ztp/capoa-conversion/tests/helpers.go
@@ -61,7 +61,8 @@ func assertCRDServesVersion(crdName, version string) {
 		"CRD %s does not serve version %s", crdName, version)
 }
 
-// nestedNumber extracts a numeric field from an unstructured object, handling both int64 and float64 JSON representations.
+// nestedNumber extracts a numeric field from an unstructured object,
+// handling both int64 and float64 JSON representations.
 func nestedNumber(obj map[string]interface{}, fields ...string) int64 {
 	val, found, err := unstructured.NestedFieldNoCopy(obj, fields...)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "error reading %v", fields)


### PR DESCRIPTION
This PR introduces a new integration test suite that validates the CAPOA (Cluster API Provider OpenShift Assisted) CRD conversion webhooks. These webhooks implement the Kubernetes [multi-version API conversion pattern](https://book.kubebuilder.io/multiversion-tutorial/conversion-concepts), enabling concurrent serving of multiple API versions for the bootstrap and controlplane providers. This dual-version serving eases user transitions during upgrades from CAPI 1.11 or below to 1.12+, allowing older manifests to continue working without forced migration.

The suite creates resources via one API version and reads them back via another, asserting that all field values are correctly transformed or preserved through the live conversion webhook. This catches regressions in the conversion logic that unit tests alone cannot detect, since it exercises the full webhook path including serialization, admission, and storage.

CAPOA serves multiple API versions concurrently:
- Bootstrap provider: v1alpha1 and v1alpha2 
- Control plane provider: v1alpha2 and v1alpha3

The conversion between these versions involves non-trivial type transformations (Duration strings to seconds, ObjectReference to ContractVersionedObjectReference) and data-preservation mechanisms (MarshalData/UnmarshalData annotations). Any regression in these conversions would silently corrupt resources when accessed via different API versions, making integration-level validation essential.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive CAPOA conversion test suite covering bootstrap and control-plane API version round-trips, with multiple cases validating field preservation and conversions.
  * Introduced test initialization, shared parameters, reporting hooks, and helper utilities to read resources and assert CRD/version behavior.

* **Chores**
  * Updated linting configuration to accommodate test package import patterns and relax an init-related lint rule for specific test paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/eco-gotests/pull/1374)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->