### PR TITLE
cnf network: add-cni-sysctrl

### DIFF
--- a/tests/cnf/core/network/cni/cni_suite_test.go
+++ b/tests/cnf/core/network/cni/cni_suite_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/cni/internal/tsparams"
+	_ "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/cni/tests/sysctl"
 	_ "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/cni/tests/tap"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/cluster"

--- a/tests/cnf/core/network/cni/internal/tsparams/cnivars.go
+++ b/tests/cnf/core/network/cni/internal/tsparams/cnivars.go
@@ -1,10 +1,30 @@
 package tsparams
 
 import (
+	"fmt"
+
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	"github.com/openshift-kni/k8sreporter"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netparam"
+)
+
+const (
+	// MultusFirstInterfaceName is the default name of the first secondary network interface.
+	MultusFirstInterfaceName = "net1"
+	// ClientIPv4 is the sysctl client address on the secondary network.
+	ClientIPv4 = "10.100.100.210"
+	// ServerIPv4 is the sysctl server address on the secondary network.
+	ServerIPv4 = "10.100.100.200"
+	// RedirectIPv4 is the sysctl redirect-pod address on the secondary network.
+	RedirectIPv4 = "10.100.100.1"
+	// ClientIPv4CIDR is ClientIPv4 with the secondary-network prefix.
+	ClientIPv4CIDR = ClientIPv4 + "/24"
+	// ServerIPv4CIDR is ServerIPv4 with the secondary-network prefix.
+	ServerIPv4CIDR = ServerIPv4 + "/24"
+	// RedirectIPv4CIDR is RedirectIPv4 with the secondary-network prefix.
+	RedirectIPv4CIDR = RedirectIPv4 + "/24"
 )
 
 var (
@@ -12,14 +32,60 @@ var (
 	Labels = append(netparam.Labels, LabelSuite)
 	// LabelTapTestCases tap test cases label.
 	LabelTapTestCases = "tap"
+	// LabelSysctlTestCases sysctl test cases label.
+	LabelSysctlTestCases = "sysctl"
 	// TestNamespaceName cni namespace where all test cases are performed.
 	TestNamespaceName = "cni-tests"
 	// ReporterNamespacesToDump tells to the reporter from where to collect logs.
 	ReporterNamespacesToDump = map[string]string{
-		NetConfig.MultusNamesapce: NetConfig.MultusNamesapce,
-		TestNamespaceName:         "other",
+		NetConfig.MultusNamesapce:        NetConfig.MultusNamesapce,
+		NetConfig.SriovOperatorNamespace: NetConfig.SriovOperatorNamespace,
+		TestNamespaceName:                "other",
 	}
 	// ReporterCRDsToDump tells to the reporter what CRs to dump.
 	ReporterCRDsToDump = []k8sreporter.CRData{
-		{Cr: &nadv1.NetworkAttachmentDefinitionList{}}}
+		{Cr: &nadv1.NetworkAttachmentDefinitionList{}},
+		{Cr: &sriovv1.SriovNetworkList{}},
+		{Cr: &sriovv1.SriovNetworkNodePolicyList{}},
+	}
+	// NetworkWithSysctlMutation is the NAD name with accept_redirects sysctl mutation.
+	NetworkWithSysctlMutation = "test-sysct-mutation"
+	// NetworkWithoutSysctlMutation is the NAD name without sysctl mutation.
+	NetworkWithoutSysctlMutation = "test-no-sysct-mutation"
+	// FirstSysctlNetworkName is the primary NAD name used by sysctl API tests.
+	FirstSysctlNetworkName = "test-nad-sysctl-first"
+	// AllFlagsSysctlPluginConfig contains all valid interface-level sysctl flags.
+	AllFlagsSysctlPluginConfig = map[string]string{
+		"net.ipv4.conf.IFNAME.accept_redirects":        "0",
+		"net.ipv4.conf.IFNAME.accept_source_route":     "0",
+		"net.ipv4.conf.IFNAME.disable_policy":          "1",
+		"net.ipv4.conf.IFNAME.secure_redirects":        "0",
+		"net.ipv4.conf.IFNAME.send_redirects":          "0",
+		"net.ipv6.conf.IFNAME.accept_redirects":        "0",
+		"net.ipv6.conf.IFNAME.accept_source_route":     "1",
+		"net.ipv6.neigh.IFNAME.base_reachable_time_ms": "20000",
+		"net.ipv6.neigh.IFNAME.retrans_time_ms":        "2000",
+	}
+	// GlobalSysctlFlag is a global kernel sysctl that is not permitted via the tuning CNI.
+	GlobalSysctlFlag = "kernel.shm_rmid_forced"
+	// SingleSysctlFlag sets accept_redirects=0 on the pod interface.
+	SingleSysctlFlag = map[string]string{
+		"net.ipv4.conf.IFNAME.accept_redirects": "0",
+	}
+	// SingleAcceptRedirectSysctlFlag is the default accept_redirects value when mutation is not applied.
+	SingleAcceptRedirectSysctlFlag = map[string]string{
+		"net.ipv4.conf.IFNAME.accept_redirects": "1",
+	}
+	// SrvLopIPAddr is the server loopback destination address used for ICMP redirect tests.
+	SrvLopIPAddr = "4.4.4.4"
+	// SrvInitCMD configures the server pod routing for redirect tests.
+	SrvInitCMD = fmt.Sprintf(
+		"ip addr add %s/32 dev lo && ip route add blackhole %s/32", SrvLopIPAddr, RedirectIPv4)
+	// RdrInitCMD is the redirect-pod init script body for createSysctlPod's bash -c.
+	RdrInitCMD = fmt.Sprintf("echo 1 > /proc/sys/net/ipv4/ip_forward 2>/dev/null || true;"+
+		" ip route add %s/32 via %s", SrvLopIPAddr, ServerIPv4)
+	// ClientInitCMD is the client-pod init script body for createSysctlPod's bash -c.
+	ClientInitCMD = fmt.Sprintf("echo 1 > /proc/sys/net/ipv4/ip_forward 2>/dev/null || true;"+
+		" sysctl -w net.ipv4.conf.all.accept_redirects=1 && ip route add %s/32 via %s",
+		SrvLopIPAddr, RedirectIPv4)
 )

--- a/tests/cnf/core/network/cni/tests/sysctl/api.go
+++ b/tests/cnf/core/network/cni/tests/sysctl/api.go
@@ -1,0 +1,44 @@
+package tests
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/cni/internal/tsparams"
+)
+
+var _ = Describe("CNF Sysctl API", Ordered, Label(tsparams.LabelSysctlTestCases), ContinueOnFailure, func() {
+	var validMacVlanInterfaces []nodeInterface
+
+	BeforeAll(func() {
+		_, validMacVlanInterfaces = ensureSysctlMacVlanSetup()
+	})
+
+	BeforeEach(func() {
+		cleanSysctlTestNamespace()
+	})
+
+	Context("pod one secondary interface,", func() {
+		It("one NAD, forward all valid interface level flags one global kernel flag", reportxml.ID("50342"), func() {
+			By("Define and create NAD with invalid sysctl flag")
+
+			nadWithInvalidSysctlFlag := copySysctlMap(tsparams.AllFlagsSysctlPluginConfig)
+			nadWithInvalidSysctlFlag[tsparams.GlobalSysctlFlag] = "1"
+			createSysctlTuningNad(
+				tsparams.FirstSysctlNetworkName,
+				nadWithInvalidSysctlFlag,
+				validMacVlanInterfaces[0].Name)
+
+			By("Define and create pod")
+			// Static IP is required so macvlan/IPAM succeeds and tuning CNI can reject the global sysctl.
+			defineCreatePodWithNetworksAndWaitUntilPending(
+				pod.StaticIPAnnotationWithNamespace(
+					tsparams.FirstSysctlNetworkName,
+					tsparams.TestNamespaceName,
+					[]string{tsparams.ClientIPv4CIDR}))
+
+			By("Wait until sysctl failed event")
+			waitUntilEventListContainsSysctlFailedCreatePodSandBoxMessage(tsparams.GlobalSysctlFlag)
+		})
+	})
+})

--- a/tests/cnf/core/network/cni/tests/sysctl/common.go
+++ b/tests/cnf/core/network/cni/tests/sysctl/common.go
@@ -1,0 +1,510 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nad"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/cni/internal/tsparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/cmd"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/define"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/ipaddr"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netstatus"
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const (
+	sysctlServerPodName   = "sysctl-server"
+	sysctlRedirectPodName = "sysctl-redirect"
+	sysctlClientPodName   = "sysctl-client"
+	hostNetworkPodName    = "sysctl-host-ifdisc"
+)
+
+type nodeInterface struct {
+	Name     string
+	Physical bool
+	UP       bool
+	Bridge   bool
+	DefRoute bool
+}
+
+var (
+	sysctlMacVlanDiscoveryOnce sync.Once
+	sysctlWorkerNodeName       string
+	sysctlMacVlanInterfaces    []nodeInterface
+	errSysctlMacVlanDiscovery  error
+)
+
+// ensureSysctlMacVlanSetup discovers a worker node and macvlan-capable interface once per suite
+// run so api and e2e Describes do not each pay for a hostNetwork probe pod.
+// Discovery failures are stored and re-asserted outside Once so a failed first caller
+// (with ContinueOnFailure) does not turn a later Describe into Skip on empty results.
+func ensureSysctlMacVlanSetup() (string, []nodeInterface) {
+	sysctlMacVlanDiscoveryOnce.Do(func() {
+		By("Collect node list based on worker label")
+
+		workerNodeList, err := nodes.List(
+			APIClient, metav1.ListOptions{LabelSelector: labels.Set(NetConfig.WorkerLabelMap).String()})
+		if err != nil {
+			errSysctlMacVlanDiscovery = fmt.Errorf("failed to list worker nodes: %w", err)
+
+			return
+		}
+
+		if len(workerNodeList) == 0 {
+			errSysctlMacVlanDiscovery = fmt.Errorf("cluster has no worker nodes for sysctl tests")
+
+			return
+		}
+
+		sysctlWorkerNodeName = workerNodeList[0].Definition.Name
+
+		By("Collect node valid interface for macvlan configuration")
+
+		sysctlMacVlanInterfaces, errSysctlMacVlanDiscovery = getValidMacVlanInterfaces(sysctlWorkerNodeName, 1)
+	})
+
+	Expect(errSysctlMacVlanDiscovery).ToNot(HaveOccurred(), "sysctl macvlan discovery failed")
+
+	if len(sysctlMacVlanInterfaces) < 1 {
+		Skip("cluster doesn't have secondary interfaces available for sysctl test")
+	}
+
+	return sysctlWorkerNodeName, sysctlMacVlanInterfaces
+}
+
+func getValidMacVlanInterfaces(nodeName string, requestNumber int) ([]nodeInterface, error) {
+	By("Select host interface for mac-vlan")
+
+	requestedInterfaceList, err := NetConfig.GetSriovInterfaces(requestNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read requested SR-IOV interfaces from environment: %w", err)
+	}
+
+	hostPod, err := pod.NewBuilder(
+		APIClient, hostNetworkPodName, tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer).
+		DefineOnNode(nodeName).
+		WithPrivilegedFlag().
+		WithHostNetwork().
+		CreateAndWaitUntilRunning(tsparams.DefaultTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create host network pod on node %s: %w", nodeName, err)
+	}
+
+	defer func() {
+		_, _ = hostPod.DeleteAndWait(tsparams.DefaultTimeout)
+	}()
+
+	var validMacVlanInterfaces []nodeInterface
+
+	for _, interfaceName := range requestedInterfaceList {
+		nodeIntf, isMacVlanCapable, checkErr := macVlanCapableInterface(hostPod, interfaceName)
+		if checkErr != nil {
+			return nil, fmt.Errorf("failed to inspect interface %s on node %s: %w", interfaceName, nodeName, checkErr)
+		}
+
+		if isMacVlanCapable {
+			validMacVlanInterfaces = append(validMacVlanInterfaces, nodeIntf)
+
+			if len(validMacVlanInterfaces) >= requestNumber {
+				break
+			}
+		}
+	}
+
+	return validMacVlanInterfaces, nil
+}
+
+func macVlanCapableInterface(hostPod *pod.Builder, interfaceName string) (nodeInterface, bool, error) {
+	_, err := hostPod.ExecCommand([]string{"test", "-e", "/sys/class/net/" + interfaceName})
+	if err != nil {
+		return nodeInterface{}, false, nil
+	}
+
+	operstateOutput, err := hostPod.ExecCommand([]string{"cat", "/sys/class/net/" + interfaceName + "/operstate"})
+	if err != nil {
+		return nodeInterface{}, false, fmt.Errorf("failed to get operstate for %s: %w", interfaceName, err)
+	}
+
+	linkOutput, err := hostPod.ExecCommand([]string{"ip", "-o", "link", "show", "dev", interfaceName})
+	if err != nil {
+		return nodeInterface{}, false, fmt.Errorf("failed to get link status for %s: %w", interfaceName, err)
+	}
+
+	defaultRoute, err := hostPod.ExecCommand([]string{"ip", "route", "show", "0.0.0.0/0"})
+	if err != nil {
+		return nodeInterface{}, false, fmt.Errorf("failed to get default route on node: %w", err)
+	}
+
+	linkStatus := linkOutput.String()
+	nodeIntf := nodeInterface{
+		Name:     interfaceName,
+		Physical: true,
+		UP:       strings.TrimSpace(operstateOutput.String()) == "up",
+		Bridge:   strings.Contains(linkStatus, "master"),
+		DefRoute: isDefaultRouteForInterface(defaultRoute.String(), interfaceName),
+	}
+
+	if !nodeIntf.UP || nodeIntf.Bridge || nodeIntf.DefRoute {
+		return nodeIntf, false, nil
+	}
+
+	return nodeIntf, true, nil
+}
+
+func isDefaultRouteForInterface(defaultRouteOut string, iface string) bool {
+	for _, line := range strings.Split(strings.TrimSpace(defaultRouteOut), "\n") {
+		fields := strings.Fields(line)
+		for i, field := range fields {
+			if field == "dev" && i+1 < len(fields) && fields[i+1] == iface {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func copySysctlMap(src map[string]string) map[string]string {
+	dst := make(map[string]string, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+
+	return dst
+}
+
+func createStaticIpamNad(nadName, macVlanInterfaceName string) {
+	masterPlugin, err := define.MasterNadPlugin(
+		nadName, "bridge", nad.IPAMStatic(), macVlanInterfaceName)
+	Expect(err).ToNot(HaveOccurred(), "Failed to define macvlan master plugin")
+
+	_, err = nad.NewBuilder(APIClient, nadName, tsparams.TestNamespaceName).
+		WithMasterPlugin(masterPlugin).
+		Create()
+	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to create NAD %s", nadName))
+
+	assertSysctlNADConfig(nadName, macVlanInterfaceName, false, nil)
+}
+
+func createSysctlTuningNad(nadName string, sysctlConfig map[string]string, macVlanIf string) {
+	plugins := []nad.Plugin{
+		{
+			Type:   "macvlan",
+			Master: macVlanIf,
+			Mode:   "bridge",
+			Ipam:   nad.IPAMStatic(),
+		},
+		*nad.TuningSysctlPlugin(false, sysctlConfig),
+	}
+
+	_, err := nad.NewBuilder(APIClient, nadName, tsparams.TestNamespaceName).
+		WithPlugins(nadName, &plugins).
+		Create()
+	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to create sysctl NAD %s", nadName))
+
+	assertSysctlNADConfig(nadName, macVlanIf, true, sysctlConfig)
+}
+
+// assertSysctlNADConfig pulls the NAD and unmarshals Spec.Config to verify CNI finished writing
+// a valid JSON object with the expected macvlan (and optional tuning) plugins.
+func assertSysctlNADConfig(
+	nadName, expectedMaster string, expectTuning bool, expectedSysctl map[string]string) {
+	By(fmt.Sprintf("Verifying NAD %s Spec.Config JSON after CNI config write", nadName))
+
+	pulled, err := nad.Pull(APIClient, nadName, tsparams.TestNamespaceName)
+	Expect(err).ToNot(HaveOccurred(), "Failed to pull NAD %s", nadName)
+	Expect(pulled.Definition.Spec.Config).NotTo(BeEmpty(), "NAD %s has empty Spec.Config", nadName)
+
+	var cfg map[string]interface{}
+	Expect(json.Unmarshal([]byte(pulled.Definition.Spec.Config), &cfg)).
+		To(Succeed(), "Failed to unmarshal NAD %s Spec.Config: %s",
+			nadName, pulled.Definition.Spec.Config)
+
+	if expectTuning {
+		Expect(cfg).To(HaveKey("plugins"), "NAD %s missing plugins list", nadName)
+
+		plugins, ok := cfg["plugins"].([]interface{})
+		Expect(ok).To(BeTrue(), "NAD %s plugins is not a list", nadName)
+		Expect(plugins).ToNot(BeEmpty(), "NAD %s plugins list is empty", nadName)
+
+		var foundMacvlan, foundTuning bool
+
+		for _, pluginEntry := range plugins {
+			plugin, ok := pluginEntry.(map[string]interface{})
+			Expect(ok).To(BeTrue(), "NAD %s plugin entry is not an object", nadName)
+
+			switch plugin["type"] {
+			case "macvlan":
+				foundMacvlan = true
+
+				assertMacvlanPluginFields(nadName, plugin, expectedMaster)
+			case "tuning":
+				foundTuning = true
+
+				assertTuningSysctlFields(nadName, plugin, expectedSysctl)
+			}
+		}
+
+		Expect(foundMacvlan).To(BeTrue(), "NAD %s missing macvlan plugin", nadName)
+		Expect(foundTuning).To(BeTrue(), "NAD %s missing tuning plugin", nadName)
+
+		return
+	}
+
+	assertMacvlanPluginFields(nadName, cfg, expectedMaster)
+}
+
+func assertMacvlanPluginFields(nadName string, plugin map[string]interface{}, expectedMaster string) {
+	Expect(plugin["type"]).To(Equal("macvlan"), "NAD %s type mismatch", nadName)
+	Expect(plugin["mode"]).To(Equal("bridge"), "NAD %s mode mismatch", nadName)
+	Expect(plugin["master"]).To(Equal(expectedMaster), "NAD %s master mismatch", nadName)
+
+	ipam, ok := plugin["ipam"].(map[string]interface{})
+	Expect(ok).To(BeTrue(), "NAD %s missing ipam object", nadName)
+	Expect(ipam["type"]).To(Equal("static"), "NAD %s ipam type mismatch", nadName)
+}
+
+// verifySysctlNetworkStatus asserts k8s.v1.cni.cncf.io/network-status after CNI ADD includes
+// the secondary interface with the expected network name and IP.
+func verifySysctlNetworkStatus(
+	podBuilder *pod.Builder, networkName, interfaceName, expectedIP string) {
+	ifaces, _, err := netstatus.ParseByInterface(APIClient, podBuilder)
+	Expect(err).ToNot(HaveOccurred(), "Failed to parse network-status for pod %s",
+		podBuilder.Definition.Name)
+
+	Expect(ifaces).To(HaveKey(interfaceName),
+		"network-status missing interface %s", interfaceName)
+
+	status := ifaces[interfaceName]
+	Expect(status.Name).To(ContainSubstring(networkName),
+		"network-status name %q should reference network %s", status.Name, networkName)
+	Expect(status.Mac).NotTo(BeEmpty(), "network-status missing MAC on %s", interfaceName)
+
+	gotIPs := make([]string, 0, len(status.IPs))
+	for _, ipWithPrefix := range status.IPs {
+		gotIPs = append(gotIPs, ipaddr.RemovePrefix(ipWithPrefix))
+	}
+
+	Expect(gotIPs).To(ContainElement(expectedIP),
+		"network-status IPs %v missing expected %s", gotIPs, expectedIP)
+}
+
+func defineCreatePodWithNetworksAndWaitUntilPending(podNetworks []*types.NetworkSelectionElement) {
+	Expect(sysctlWorkerNodeName).NotTo(BeEmpty(), "sysctl worker node was not discovered")
+
+	createdPod, err := pod.NewBuilder(
+		APIClient, "sysctl-pending", tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer).
+		DefineOnNode(sysctlWorkerNodeName).
+		WithSecondaryNetwork(podNetworks).
+		Create()
+	Expect(err).ToNot(HaveOccurred(), "Failed to create pod with secondary networks")
+
+	err = createdPod.WaitUntilInStatus(corev1.PodPending, tsparams.DefaultTimeout)
+	Expect(err).ToNot(HaveOccurred(), "Pod is not in Pending phase")
+}
+
+func waitUntilEventListContainsSysctlFailedCreatePodSandBoxMessage(sysctlFlag string) {
+	expectedSysctlFailedMessage := fmt.Sprintf(
+		"Sysctl %s is not allowed. Only the following sysctls are allowed", sysctlFlag)
+
+	Eventually(func() bool {
+		eventList, err := APIClient.Events(tsparams.TestNamespaceName).List(
+			context.TODO(), metav1.ListOptions{FieldSelector: "reason=FailedCreatePodSandBox"})
+		Expect(err).ToNot(HaveOccurred(), "Failed to collect events")
+
+		for _, event := range eventList.Items {
+			if strings.Contains(event.Message, expectedSysctlFailedMessage) {
+				return true
+			}
+		}
+
+		return false
+	}, tsparams.DefaultTimeout, time.Second).Should(BeTrue(),
+		fmt.Sprintf("Failed to detect FailedCreatePodSandBox event for sysctl %s", sysctlFlag))
+}
+
+func assertTuningSysctlFields(nadName string, plugin map[string]interface{}, expectedSysctl map[string]string) {
+	if len(expectedSysctl) == 0 {
+		return
+	}
+
+	sysctlRaw, ok := plugin["sysctl"].(map[string]interface{})
+	Expect(ok).To(BeTrue(), "NAD %s tuning plugin missing sysctl object", nadName)
+
+	for key, value := range expectedSysctl {
+		Expect(sysctlRaw).To(HaveKeyWithValue(key, value),
+			"NAD %s tuning sysctl missing %s=%s", nadName, key, value)
+	}
+}
+
+func defineClientNetCfg(networkName string) []*types.NetworkSelectionElement {
+	return pod.StaticIPAnnotation(networkName, []string{tsparams.ClientIPv4CIDR})
+}
+
+func defineServerNetCfg() []*types.NetworkSelectionElement {
+	return pod.StaticIPAnnotation(tsparams.NetworkWithoutSysctlMutation, []string{tsparams.ServerIPv4CIDR})
+}
+
+func defineRedirectNetCfg() []*types.NetworkSelectionElement {
+	return pod.StaticIPAnnotation(tsparams.NetworkWithoutSysctlMutation, []string{tsparams.RedirectIPv4CIDR})
+}
+
+func createServerPod() {
+	createSysctlPod(sysctlServerPodName, defineServerNetCfg(), tsparams.SrvInitCMD, nil)
+}
+
+func createRedirectPod() {
+	createSysctlPod(sysctlRedirectPodName, defineRedirectNetCfg(), tsparams.RdrInitCMD, nil)
+}
+
+func createClientPod(clientNetCfg []*types.NetworkSelectionElement) *pod.Builder {
+	return createSysctlPod(sysctlClientPodName, clientNetCfg, tsparams.ClientInitCMD, []string{"NET_RAW"})
+}
+
+func createSysctlPod(
+	name string,
+	podNetworks []*types.NetworkSelectionElement,
+	initCmd string,
+	containerCapabilities []string,
+) *pod.Builder {
+	initContainer, err := pod.NewContainerBuilder(
+		"init1", NetConfig.CnfNetTestContainer, []string{"bash", "-c", initCmd}).
+		WithSecurityCapabilities([]string{"NET_ADMIN", "NET_RAW", "SYS_ADMIN"}, true).
+		GetContainerCfg()
+	Expect(err).ToNot(HaveOccurred(), "Failed to define init container")
+
+	privileged := true
+	initContainer.SecurityContext.Privileged = &privileged
+
+	containerBuilder := pod.NewContainerBuilder(
+		"test", NetConfig.CnfNetTestContainer, []string{"/bin/bash", "-c", "sleep INF"})
+	if len(containerCapabilities) > 0 {
+		containerBuilder = containerBuilder.WithSecurityCapabilities(containerCapabilities, true)
+	}
+
+	mainContainer, err := containerBuilder.GetContainerCfg()
+	Expect(err).ToNot(HaveOccurred(), "Failed to define main container")
+
+	Expect(sysctlWorkerNodeName).NotTo(BeEmpty(), "sysctl worker node was not discovered")
+
+	podBuilder := pod.NewBuilder(APIClient, name, tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer).
+		DefineOnNode(sysctlWorkerNodeName).
+		WithAdditionalInitContainer(initContainer).
+		RedefineDefaultContainer(*mainContainer).
+		WithSecondaryNetwork(podNetworks)
+
+	createdPod, err := podBuilder.CreateAndWaitUntilRunning(tsparams.DefaultTimeout)
+	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to create pod %s", name))
+
+	return createdPod
+}
+
+func recreateClientPod(
+	runningClientPod *pod.Builder, clientNetCfg []*types.NetworkSelectionElement) *pod.Builder {
+	By("Remove pod")
+
+	_, err := runningClientPod.DeleteAndWait(tsparams.DefaultTimeout)
+	Expect(err).ToNot(HaveOccurred(), "Failed to remove client pod")
+
+	return createClientPod(clientNetCfg)
+}
+
+func checkRouteToDst(client *pod.Builder, destAddress string, negative bool) {
+	logs, err := client.ExecCommand([]string{"ip", "route", "get", destAddress})
+	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to get route to %s", destAddress))
+
+	if negative {
+		Expect(logs.String()).ToNot(ContainSubstring("<redirected>"),
+			"pod's route table has redirected route")
+	} else {
+		Expect(logs.String()).To(ContainSubstring("<redirected>"),
+			"pod's route table doesn't have redirected route")
+	}
+}
+
+func testIcmpRouteSysctlFlag(runningClientPod *pod.Builder, dstAddr, intName string, negative bool) {
+	sysctlConfig := tsparams.SingleAcceptRedirectSysctlFlag
+	if negative {
+		sysctlConfig = tsparams.SingleSysctlFlag
+	}
+
+	Expect(cmd.VerifySysctlKernelParametersConfiguredOnPodInterface(runningClientPod, sysctlConfig, intName)).
+		To(Succeed(), "sysctl kernel params are not in expected state")
+	retryPing(runningClientPod, dstAddr, intName, negative)
+	checkRouteToDst(runningClientPod, dstAddr, negative)
+}
+
+// retryPing verifies ICMP redirect connectivity via testcmd. When negative is true, testcmd is
+// invoked with --negative and a zero exit means the ping correctly failed (accept_redirects=0).
+func retryPing(runningClientPod *pod.Builder, desIP, intName string, negative bool) {
+	Eventually(func() error {
+		return pingIPViaInterface(runningClientPod, intName, desIP, negative)
+	}, tsparams.DefaultTimeout, time.Second).Should(Succeed())
+}
+
+func pingIPViaInterface(clientPod *pod.Builder, interfaceName, destIPAddr string, negative bool) error {
+	command := []string{"testcmd", "-interface", interfaceName, "-server", destIPAddr, "-protocol", "icmp", "-mtu", "100"}
+	if negative {
+		command = append(command, "--negative")
+	}
+
+	_, err := clientPod.ExecCommand(command)
+
+	return err
+}
+
+func cleanSysctlTestNamespace() {
+	By("Clean pods from the namespace")
+
+	err := namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
+		tsparams.DefaultTimeout, pod.GetGVR())
+	Expect(err).ToNot(HaveOccurred(), "Failed to remove pods from test namespace")
+
+	By("Clean NADs from the namespace")
+
+	err = namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
+		tsparams.DefaultTimeout, nad.GetGVR())
+	Expect(err).ToNot(HaveOccurred(), "Failed to clean NetworkAttachmentDefinitions")
+}
+
+func setHostIPForwarding(nodeName, interfaceName string, enabled bool) {
+	err := setHostIPForwardingQuiet(nodeName, interfaceName, enabled)
+	Expect(err).ToNot(HaveOccurred(),
+		fmt.Sprintf("Failed to set IP forwarding on interface %s", interfaceName))
+}
+
+func getHostIPForwardingQuiet(nodeName, interfaceName string) (bool, error) {
+	output, err := cmd.RunCommandOnHostNetworkPod(nodeName, tsparams.TestNamespaceName, fmt.Sprintf(
+		"cat /proc/sys/net/ipv4/conf/%s/forwarding", interfaceName))
+	if err != nil {
+		return false, err
+	}
+
+	return strings.TrimSpace(output) == "1", nil
+}
+
+func setHostIPForwardingQuiet(nodeName, interfaceName string, enabled bool) error {
+	value := "0"
+	if enabled {
+		value = "1"
+	}
+
+	_, err := cmd.RunCommandOnHostNetworkPod(nodeName, tsparams.TestNamespaceName, fmt.Sprintf(
+		"echo %s > /proc/sys/net/ipv4/conf/%s/forwarding", value, interfaceName))
+
+	return err
+}

--- a/tests/cnf/core/network/cni/tests/sysctl/e2e.go
+++ b/tests/cnf/core/network/cni/tests/sysctl/e2e.go
@@ -1,0 +1,100 @@
+package tests
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/cni/internal/tsparams"
+)
+
+var _ = Describe("CNF Sysctl", Ordered, Label(tsparams.LabelSysctlTestCases), ContinueOnFailure, func() {
+	var (
+		workerNodeName                   string
+		validMacVlanInterfaces           []nodeInterface
+		dutInterfaceOriginalIPForwarding bool
+	)
+
+	BeforeAll(func() {
+		var err error
+
+		workerNodeName, validMacVlanInterfaces = ensureSysctlMacVlanSetup()
+
+		By("Enabling IPForwarding on a DUT interface")
+
+		dutInterfaceOriginalIPForwarding, err = getHostIPForwardingQuiet(
+			workerNodeName, validMacVlanInterfaces[0].Name)
+		Expect(err).ToNot(HaveOccurred(),
+			fmt.Sprintf("Failed to read IP forwarding on interface %s", validMacVlanInterfaces[0].Name))
+		setHostIPForwarding(workerNodeName, validMacVlanInterfaces[0].Name, true)
+	})
+
+	AfterAll(func() {
+		if workerNodeName != "" && len(validMacVlanInterfaces) > 0 {
+			By("Restoring IPForwarding on a DUT interface")
+
+			Eventually(func() error {
+				return setHostIPForwardingQuiet(
+					workerNodeName, validMacVlanInterfaces[0].Name, dutInterfaceOriginalIPForwarding)
+			}, tsparams.DefaultTimeout, time.Second).Should(Succeed(),
+				"Failed to restore IP forwarding on DUT interface")
+		}
+	})
+
+	BeforeEach(func() {
+		cleanSysctlTestNamespace()
+	})
+
+	Context("pod one secondary interface,", func() {
+		It("set accept_redirects=0 on one of two NAD macvlans",
+			reportxml.ID("50437"), func() {
+				By("Define and create NAD with sysctl mutation flag accept_redirects=0")
+				createSysctlTuningNad(
+					tsparams.NetworkWithSysctlMutation,
+					tsparams.SingleSysctlFlag,
+					validMacVlanInterfaces[0].Name)
+
+				By("Define and create NAD without sysctl config")
+				createStaticIpamNad(
+					tsparams.NetworkWithoutSysctlMutation, validMacVlanInterfaces[0].Name)
+
+				By("Create server and redirect pod")
+				createServerPod()
+				createRedirectPod()
+
+				By("Create client pod connected to NAD without sysctl mutation")
+
+				clientNetCfg := defineClientNetCfg(tsparams.NetworkWithoutSysctlMutation)
+				runningClientPod := createClientPod(clientNetCfg)
+
+				By("Verifying Multus network-status JSON after CNI ADD")
+				verifySysctlNetworkStatus(
+					runningClientPod,
+					tsparams.NetworkWithoutSysctlMutation,
+					tsparams.MultusFirstInterfaceName,
+					tsparams.ClientIPv4)
+
+				By("Test ping, route and sysctl flag")
+				testIcmpRouteSysctlFlag(
+					runningClientPod, tsparams.SrvLopIPAddr, tsparams.MultusFirstInterfaceName, false)
+
+				By("Recreate client pod connected to NAD with sysctl mutation")
+
+				clientNetCfg = defineClientNetCfg(tsparams.NetworkWithSysctlMutation)
+				runningClientPod = recreateClientPod(runningClientPod, clientNetCfg)
+
+				By("Verifying Multus network-status JSON after CNI ADD with sysctl mutation")
+				verifySysctlNetworkStatus(
+					runningClientPod,
+					tsparams.NetworkWithSysctlMutation,
+					tsparams.MultusFirstInterfaceName,
+					tsparams.ClientIPv4)
+
+				By("Test ping, route and sysctl flag negative")
+				testIcmpRouteSysctlFlag(
+					runningClientPod, tsparams.SrvLopIPAddr, tsparams.MultusFirstInterfaceName, true)
+			})
+	})
+})

--- a/tests/cnf/core/network/cni/tests/tap/tap.go
+++ b/tests/cnf/core/network/cni/tests/tap/tap.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/cni/internal/tsparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/cmd"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/define"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/cluster"
@@ -149,8 +150,12 @@ var _ = Describe("", Ordered,
 				doesTapHasCorrectConfig(runningPod, secondTapInterfaceName, customUserID, customGroupID)
 
 				By("Verifying that devices have correct sysctl flags")
-				verifySysctlKernelParametersConfiguredOnPodInterface(runningPod, enabledSysctlFlags, firstTapInterfaceName)
-				verifySysctlKernelParametersConfiguredOnPodInterface(runningPod, disabledSysctlFlags, secondTapInterfaceName)
+				Expect(cmd.VerifySysctlKernelParametersConfiguredOnPodInterface(
+					runningPod, enabledSysctlFlags, firstTapInterfaceName)).
+					To(Succeed(), "sysctl kernel params are not in expected state")
+				Expect(cmd.VerifySysctlKernelParametersConfiguredOnPodInterface(
+					runningPod, disabledSysctlFlags, secondTapInterfaceName)).
+					To(Succeed(), "sysctl kernel params are not in expected state")
 
 				By("Verifying that devices have correct ip addresses")
 				doesInterfaceHasCorrectMasterAndIPAddress(runningPod, interfaceBasedOnFirstTap, firstNetIPv6)
@@ -213,10 +218,12 @@ var _ = Describe("", Ordered,
 				doesTapHasCorrectConfig(runningPod, secondTapInterfaceName, customUserID, customGroupID)
 
 				By("Verifying that devices have correct sysctl flags")
-				verifySysctlKernelParametersConfiguredOnPodInterface(
-					runningPod, enabledSysctlFlags, firstTapInterfaceName)
-				verifySysctlKernelParametersConfiguredOnPodInterface(
-					runningPod, disabledSysctlFlags, secondTapInterfaceName)
+				Expect(cmd.VerifySysctlKernelParametersConfiguredOnPodInterface(
+					runningPod, enabledSysctlFlags, firstTapInterfaceName)).
+					To(Succeed(), "sysctl kernel params are not in expected state")
+				Expect(cmd.VerifySysctlKernelParametersConfiguredOnPodInterface(
+					runningPod, disabledSysctlFlags, secondTapInterfaceName)).
+					To(Succeed(), "sysctl kernel params are not in expected state")
 
 				By("Verifying that devices have correct ipv4 address")
 				doesInterfaceHasCorrectMasterAndIPAddress(runningPod, interfaceBasedOnFirstTap, firstNetIPv4)
@@ -456,7 +463,9 @@ func testDualStackNetConfigWithTwoTapsTwoIPVLANsTwoVLANsOnTopOfDeploymentWithWhe
 	doesTapHasCorrectConfig(deploymentPod, firstTapInterfaceName, 0, 0)
 
 	By("Verifying that first tap interface have correct sysctl flags")
-	verifySysctlKernelParametersConfiguredOnPodInterface(deploymentPod, enabledSysctlFlags, firstTapInterfaceName)
+	Expect(cmd.VerifySysctlKernelParametersConfiguredOnPodInterface(
+		deploymentPod, enabledSysctlFlags, firstTapInterfaceName)).
+		To(Succeed(), "sysctl kernel params are not in expected state")
 
 	By("Verifying that the first vlan device has correct vlanID and ip addresses")
 	doesVlanHasCorrectConfig(deploymentPod, interfaceBasedOnFirstTap, firstTapInterfaceName, firstVlanID)
@@ -472,7 +481,9 @@ func testDualStackNetConfigWithTwoTapsTwoIPVLANsTwoVLANsOnTopOfDeploymentWithWhe
 	doesTapHasCorrectConfig(deploymentPod, secondTapInterfaceName, customUserID, customGroupID)
 
 	By("Verifying that the second tap interface have correct sysctl flags")
-	verifySysctlKernelParametersConfiguredOnPodInterface(deploymentPod, disabledSysctlFlags, secondTapInterfaceName)
+	Expect(cmd.VerifySysctlKernelParametersConfiguredOnPodInterface(
+		deploymentPod, disabledSysctlFlags, secondTapInterfaceName)).
+		To(Succeed(), "sysctl kernel params are not in expected state")
 
 	By("Verifying that the second vlan device has correct vlanID and ip addresses")
 	doesVlanHasCorrectConfig(deploymentPod, secondInterfaceBasedOnSecondTap, secondTapInterfaceName, secondVlanID)
@@ -499,7 +510,9 @@ func testSingleTapSysctlAdNetworkConfigurationUsingDeployment(
 	doesInterfaceHasCorrectMasterAndIPAddress(deploymentPod, secondInterfaceBasedOnFirstTap, "192.168.100.")
 
 	By("Verifying that devices have correct sysctl flags")
-	verifySysctlKernelParametersConfiguredOnPodInterface(deploymentPod, sysctlExpectedFlags, firstTapInterfaceName)
+	Expect(cmd.VerifySysctlKernelParametersConfiguredOnPodInterface(
+		deploymentPod, sysctlExpectedFlags, firstTapInterfaceName)).
+		To(Succeed(), "sysctl kernel params are not in expected state")
 }
 
 func fetchNewDeploymentPod(waitUntilRunning bool) *pod.Builder {
@@ -595,19 +608,4 @@ func defineAndCreateIPVlanNad(name, intName string, ipam *nad.IPAM) *nad.Builder
 	Expect(err).ToNot(HaveOccurred(), "Fail to create ip-vlan NetworkAttachmentDefinition")
 
 	return ipVlanNad
-}
-
-func verifySysctlKernelParametersConfiguredOnPodInterface(
-	podUnderTest *pod.Builder, sysctlPluginConfig map[string]string, interfaceName string) {
-	for key, value := range sysctlPluginConfig {
-		sysctlKernelParam := strings.Replace(key, "IFNAME", interfaceName, 1)
-
-		By(fmt.Sprintf("Validate sysctl flag: %s has the right value in pod's interface: %s",
-			sysctlKernelParam, interfaceName))
-
-		cmdBuffer, err := podUnderTest.ExecCommand([]string{"sysctl", "-n", sysctlKernelParam})
-		Expect(err).ToNot(HaveOccurred(), "Fail to execute cmd command on the pod")
-		Expect(strings.TrimSpace(cmdBuffer.String())).To(BeIdenticalTo(value),
-			"sysctl kernel param is not in expected state")
-	}
 }

--- a/tests/cnf/core/network/dpdk/tests/rootless.go
+++ b/tests/cnf/core/network/dpdk/tests/rootless.go
@@ -858,21 +858,6 @@ func getPCIAddressListFromSrIovNetworkName(podNetworkStatus string) ([]string, e
 	return pciAddressList, nil
 }
 
-func verifySysctlKernelParametersConfiguredOnPodInterface(
-	podUnderTest *pod.Builder, sysctlPluginConfig map[string]string, interfaceName string) {
-	for key, value := range sysctlPluginConfig {
-		sysctlKernelParam := strings.Replace(key, "IFNAME", interfaceName, 1)
-
-		By(fmt.Sprintf("Validate sysctl flag: %s has the right value in pod's interface: %s",
-			sysctlKernelParam, interfaceName))
-
-		cmdBuffer, err := podUnderTest.ExecCommand([]string{"sysctl", "-n", sysctlKernelParam})
-		Expect(err).ToNot(HaveOccurred(), "Fail to execute cmd command on the pod")
-		Expect(strings.TrimSpace(cmdBuffer.String())).To(BeIdenticalTo(value),
-			"sysctl kernel param is not in expected state")
-	}
-}
-
 func defineRoute(dstNet, nextHop, devName, mode string) []string {
 	return []string{"/bin/bash", "-c", fmt.Sprintf("route %s -net %s gw %s dev %s", mode, dstNet, nextHop, devName)}
 }
@@ -932,8 +917,12 @@ func fetchNewDeploymentPod(deploymentPodPrefix string) *pod.Builder {
 
 func testRouteInjection(clientPod *pod.Builder, nextHopInterface string) {
 	By("Verifying sysctl plugin configuration")
-	verifySysctlKernelParametersConfiguredOnPodInterface(clientPod, enabledSysctlFlags, tapOneInterfaceName)
-	verifySysctlKernelParametersConfiguredOnPodInterface(clientPod, disabledSysctlFlags, tapTwoInterfaceName)
+	Expect(cmd.VerifySysctlKernelParametersConfiguredOnPodInterface(
+		clientPod, enabledSysctlFlags, tapOneInterfaceName)).
+		To(Succeed(), "sysctl kernel params are not in expected state")
+	Expect(cmd.VerifySysctlKernelParametersConfiguredOnPodInterface(
+		clientPod, disabledSysctlFlags, tapTwoInterfaceName)).
+		To(Succeed(), "sysctl kernel params are not in expected state")
 
 	By("Adding route to rootless pod")
 

--- a/tests/cnf/core/network/internal/cmd/sysctl.go
+++ b/tests/cnf/core/network/internal/cmd/sysctl.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"k8s.io/klog/v2"
+)
+
+// VerifySysctlKernelParametersConfiguredOnPodInterface checks that each sysctl key in
+// sysctlPluginConfig matches on the pod interface. Keys may contain the IFNAME placeholder.
+func VerifySysctlKernelParametersConfiguredOnPodInterface(
+	podUnderTest *pod.Builder, sysctlPluginConfig map[string]string, interfaceName string) error {
+	for key, value := range sysctlPluginConfig {
+		sysctlKernelParam := strings.Replace(key, "IFNAME", interfaceName, 1)
+
+		klog.V(90).Infof("Validate sysctl flag: %s has the right value in pod's interface: %s",
+			sysctlKernelParam, interfaceName)
+
+		cmdBuffer, err := podUnderTest.ExecCommand([]string{"sysctl", "-n", sysctlKernelParam})
+		if err != nil {
+			return fmt.Errorf("failed to execute sysctl command on the pod: %w", err)
+		}
+
+		actual := strings.TrimSpace(cmdBuffer.String())
+		if actual != value {
+			return fmt.Errorf("sysctl kernel param %s is not in expected state: got %q, want %q",
+				sysctlKernelParam, actual, value)
+		}
+	}
+
+	return nil
+}

--- a/tests/cnf/core/network/internal/netstatus/netstatus.go
+++ b/tests/cnf/core/network/internal/netstatus/netstatus.go
@@ -1,0 +1,98 @@
+package netstatus
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/ipaddr"
+	"k8s.io/klog/v2"
+)
+
+// AnnotationKey is the Multus network-status pod annotation.
+const AnnotationKey = "k8s.v1.cni.cncf.io/network-status"
+
+// Entry is a minimal Multus network-status object.
+type Entry struct {
+	Name      string   `json:"name"`
+	Interface string   `json:"interface"`
+	IPs       []string `json:"ips"`
+	Mac       string   `json:"mac"`
+}
+
+// ParseByInterface pulls the pod and returns network-status entries keyed by interface name
+// along with the raw annotation string.
+func ParseByInterface(
+	apiClient *clients.Settings, podBuilder *pod.Builder) (map[string]Entry, string, error) {
+	pulled, err := pod.Pull(apiClient, podBuilder.Definition.Name, podBuilder.Definition.Namespace)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to pull pod %s: %w", podBuilder.Definition.Name, err)
+	}
+
+	annotation := pulled.Object.Annotations[AnnotationKey]
+	if annotation == "" {
+		return nil, "", fmt.Errorf("no network-status annotation on pod %s", pulled.Definition.Name)
+	}
+
+	var statuses []Entry
+	if err := json.Unmarshal([]byte(annotation), &statuses); err != nil {
+		return nil, annotation, fmt.Errorf(
+			"failed to parse network-status annotation for pod %s: %w", pulled.Definition.Name, err)
+	}
+
+	ifaces := make(map[string]Entry, len(statuses))
+	for _, status := range statuses {
+		if status.Interface != "" {
+			ifaces[status.Interface] = status
+		}
+	}
+
+	return ifaces, annotation, nil
+}
+
+// InterfaceIPs returns all IPs assigned to an interface from the pod's network-status annotation.
+func InterfaceIPs(
+	apiClient *clients.Settings, podBuilder *pod.Builder, interfaceName string) ([]string, error) {
+	ifaces, _, err := ParseByInterface(apiClient, podBuilder)
+	if err != nil {
+		return nil, err
+	}
+
+	status, ok := ifaces[interfaceName]
+	if !ok {
+		return nil, fmt.Errorf("interface %s not found in network-status annotation", interfaceName)
+	}
+
+	return status.IPs, nil
+}
+
+// PodIPFromInterface retrieves an IP address of a specific interface from a pod's network-status
+// annotation. ipFamily should be "ipv4" or "ipv6". For dual-stack, call twice with each family.
+func PodIPFromInterface(
+	apiClient *clients.Settings, podBuilder *pod.Builder, interfaceName, ipFamily string) (string, error) {
+	klog.V(90).Infof("Getting %s from interface %s on pod %s",
+		ipFamily, interfaceName, podBuilder.Definition.Name)
+
+	ips, err := InterfaceIPs(apiClient, podBuilder, interfaceName)
+	if err != nil {
+		return "", err
+	}
+
+	for _, ip := range ips {
+		ipClean := ipaddr.RemovePrefix(ip)
+		isIPv6 := strings.Contains(ipClean, ":")
+
+		if ipFamily == "ipv4" && !isIPv6 {
+			return ipClean, nil
+		}
+
+		// Skip link-local addresses (fe80::) for IPv6 - return only global/ULA addresses.
+		if ipFamily == "ipv6" && isIPv6 && !strings.HasPrefix(strings.ToLower(ipClean), "fe80") {
+			return ipClean, nil
+		}
+	}
+
+	return "", fmt.Errorf("no %s found for interface %s in network-status annotation", ipFamily, interfaceName)
+}

--- a/tests/cnf/core/network/sriov/internal/sriovenv/sriovenv.go
+++ b/tests/cnf/core/network/sriov/internal/sriovenv/sriovenv.go
@@ -2,7 +2,6 @@ package sriovenv
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -16,6 +15,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/ipaddr"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netparam"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netstatus"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/sriov/internal/tsparams"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/cluster"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/sriovoperator"
@@ -451,61 +451,10 @@ func CreateSriovNetworkWithVLANAndWhereabouts(
 	return CreateSriovNetworkAndWaitForNADCreation(networkBuilder, tsparams.NADWaitTimeout)
 }
 
-// getInterfaceIPs returns all IPs assigned to an interface from the pod's network-status annotation.
-func getInterfaceIPs(podBuilder *pod.Builder, interfaceName string) ([]string, error) {
-	podObj, err := pod.Pull(APIClient, podBuilder.Definition.Name, podBuilder.Definition.Namespace)
-	if err != nil {
-		return nil, fmt.Errorf("failed to pull pod %s: %w", podBuilder.Definition.Name, err)
-	}
-
-	annotation := podObj.Object.Annotations["k8s.v1.cni.cncf.io/network-status"]
-	if annotation == "" {
-		return nil, fmt.Errorf("no network-status annotation on pod %s", podBuilder.Definition.Name)
-	}
-
-	var statuses []struct {
-		Interface string   `json:"interface"`
-		IPs       []string `json:"ips"`
-	}
-
-	if err := json.Unmarshal([]byte(annotation), &statuses); err != nil {
-		return nil, fmt.Errorf("failed to parse network-status annotation: %w", err)
-	}
-
-	for _, status := range statuses {
-		if status.Interface == interfaceName {
-			return status.IPs, nil
-		}
-	}
-
-	return nil, fmt.Errorf("interface %s not found in network-status annotation", interfaceName)
-}
-
 // GetPodIPFromInterface retrieves an IP address of a specific interface from a pod's network-status annotation.
 // ipFamily should be "ipv4" or "ipv6". For dual-stack, call this function twice with each family.
 func GetPodIPFromInterface(podBuilder *pod.Builder, interfaceName, ipFamily string) (string, error) {
-	klog.V(90).Infof("Getting %s from interface %s on pod %s", ipFamily, interfaceName, podBuilder.Definition.Name)
-
-	ips, err := getInterfaceIPs(podBuilder, interfaceName)
-	if err != nil {
-		return "", err
-	}
-
-	for _, ip := range ips {
-		ipClean := strings.Split(ip, "/")[0]
-		isIPv6 := strings.Contains(ipClean, ":")
-
-		if ipFamily == "ipv4" && !isIPv6 {
-			return ipClean, nil
-		}
-
-		// Skip link-local addresses (fe80::) for IPv6 - return only global/ULA addresses.
-		if ipFamily == "ipv6" && isIPv6 && !strings.HasPrefix(strings.ToLower(ipClean), "fe80") {
-			return ipClean, nil
-		}
-	}
-
-	return "", fmt.Errorf("no %s found for interface %s in network-status annotation", ipFamily, interfaceName)
+	return netstatus.PodIPFromInterface(APIClient, podBuilder, interfaceName, ipFamily)
 }
 
 // CreatePodPair creates a client and server pod pair for traffic testing.


### PR DESCRIPTION
Port the cnf-gotests sysctl e2e case "set accept_redirects=0 on one of
two SriovNetworks" (Polarion 50439) into eco-gotests under the CNI suite.
Adds sysctl test helpers, tsparams, and suite wiring. Uses eco-goinfra
builders and sriovoperator for SR-IOV policy setup with MCP wait timeouts
aligned with other network tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an ordered e2e **“CNF Sysctl”** suite validating SR‑IOV + Multus sysctl behavior and ICMP redirect routing via positive/negative expectations, including SR‑IOV policy creation, pod recreation, and automated cleanup.
  * Expanded shared SR‑IOV sysctl/ICMP validation utilities and polling/timeout parameters used by the test suite.
* **Refactor**
  * Centralized pod sysctl verification into a shared helper and updated TAP and rootless DPDK tests to use it.
  * Reused common SR‑IOV helper logic across SR‑IOV-related test components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->