### PR TITLE
CNF-17455   QE Automation: improve basic ptp sync test case

### DIFF
--- a/tests/cnf/ran/ptp/internal/metrics/ensurelocked.go
+++ b/tests/cnf/ran/ptp/internal/metrics/ensurelocked.go
@@ -3,17 +3,58 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/tsparams"
+	"k8s.io/klog/v2"
 )
+
+// ensureLockedConfig holds the configuration for EnsureClocksAreLocked and EnsureClocksAreStable.
+type ensureLockedConfig struct {
+	expectedClockStates []ExpectedClockState
+}
+
+// EnsureLockedOption configures optional behavior for EnsureClocksAreLocked and EnsureClocksAreStable.
+type EnsureLockedOption func(*ensureLockedConfig)
+
+// WithExpectedClockStates configures the presence check phase. When provided, EnsureClocksAreLocked will first
+// verify that all expected clock state metrics are present (at least one sample returned per entry) before
+// proceeding to the locked assertion. This ensures that missing metrics (e.g., a dpll or gnss process that
+// never started) are caught rather than silently passing.
+func WithExpectedClockStates(expected []ExpectedClockState) EnsureLockedOption {
+	return func(cfg *ensureLockedConfig) {
+		cfg.expectedClockStates = expected
+	}
+}
 
 // EnsureClocksAreLocked ensures that all PTP clocks are locked across all nodes covered by the Prometheus API client.
 // It is designed to be used as a BeforeEach/AfterEach check to ensure the cluster is in a stable state.
 //
 // It ensures that clocks are locked for 10 seconds with a timeout of 5 minutes. It does not check the clock state of
 // the chronyd process, as it will be FREERUN when PTP is working correctly.
-func EnsureClocksAreLocked(prometheusAPI prometheusv1.API) error {
+//
+// When WithExpectedClockStates is provided, the function first verifies that all expected metric series are present
+// before asserting the locked state.
+func EnsureClocksAreLocked(prometheusAPI prometheusv1.API, opts ...EnsureLockedOption) error {
+	cfg := &ensureLockedConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	if len(cfg.expectedClockStates) > 0 {
+		deduped := deduplicateExpectedClockStates(cfg.expectedClockStates)
+
+		klog.V(tsparams.LogLevel).Infof("Ensuring expected clock state metrics are present:\n%s",
+			FormatExpectedClockStates(deduped))
+
+		err := ensureClockStatesPresent(prometheusAPI, deduped, 5*time.Minute)
+		if err != nil {
+			return fmt.Errorf("failed presence check before asserting locked state: %w", err)
+		}
+	}
+
 	query := ClockStateQuery{
 		Process: DoesNotEqual(ProcessChronyd),
 	}
@@ -30,7 +71,27 @@ func EnsureClocksAreLocked(prometheusAPI prometheusv1.API) error {
 
 // EnsureClocksAreStable ensures that all PTP clocks are locked across all nodes for a specific continuous duration.
 // This is useful for waiting for plugins (e.g. DPLL) to build a sufficient history buffer.
-func EnsureClocksAreStable(prometheusAPI prometheusv1.API, stableDuration time.Duration) error {
+//
+// When WithExpectedClockStates is provided, the function first verifies that all expected metric series are present
+// before asserting the stable locked state.
+func EnsureClocksAreStable(prometheusAPI prometheusv1.API, stableDuration time.Duration, opts ...EnsureLockedOption) error {
+	cfg := &ensureLockedConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	if len(cfg.expectedClockStates) > 0 {
+		deduped := deduplicateExpectedClockStates(cfg.expectedClockStates)
+
+		klog.V(tsparams.LogLevel).Infof("Ensuring expected clock state metrics are present:\n%s",
+			FormatExpectedClockStates(deduped))
+
+		err := ensureClockStatesPresent(prometheusAPI, deduped, 5*time.Minute)
+		if err != nil {
+			return fmt.Errorf("failed presence check before asserting stable state: %w", err)
+		}
+	}
+
 	query := ClockStateQuery{
 		Process: DoesNotEqual(ProcessChronyd),
 	}
@@ -43,4 +104,60 @@ func EnsureClocksAreStable(prometheusAPI prometheusv1.API, stableDuration time.D
 	}
 
 	return nil
+}
+
+// ensureClockStatesPresent polls Prometheus until all expected clock state metrics return at least one sample.
+// It retries with a 5-second poll interval until the timeout is exceeded.
+func ensureClockStatesPresent(
+	prometheusAPI prometheusv1.API, expected []ExpectedClockState, timeout time.Duration) error {
+	ctx := context.TODO()
+	deadline := time.Now().Add(timeout)
+	pollInterval := DefaultPollInterval
+
+	for {
+		var missing []ExpectedClockState
+
+		for _, entry := range expected {
+			query := entry.toQuery()
+
+			result, err := ExecuteQuery(ctx, prometheusAPI, query)
+			if err != nil {
+				klog.V(tsparams.LogLevel).Infof("Presence check query error for %s: %v", entry, err)
+
+				missing = append(missing, entry)
+
+				continue
+			}
+
+			if len(result) == 0 {
+				missing = append(missing, entry)
+			}
+		}
+
+		if len(missing) == 0 {
+			klog.V(tsparams.LogLevel).Infof("All %d expected clock state metrics are present", len(expected))
+
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			var sb strings.Builder
+
+			sb.WriteString(fmt.Sprintf("timed out after %s waiting for %d/%d expected clock state metrics:\n",
+				timeout, len(missing), len(expected)))
+
+			for _, m := range missing {
+				sb.WriteString("  - missing: ")
+				sb.WriteString(m.String())
+				sb.WriteString("\n")
+			}
+
+			return fmt.Errorf("%s", sb.String())
+		}
+
+		klog.V(tsparams.LogLevel).Infof("Presence check: %d/%d metrics missing, retrying in %s",
+			len(missing), len(expected), pollInterval)
+
+		time.Sleep(pollInterval)
+	}
 }

--- a/tests/cnf/ran/ptp/internal/metrics/ensurelocked.go
+++ b/tests/cnf/ran/ptp/internal/metrics/ensurelocked.go
@@ -74,7 +74,9 @@ func EnsureClocksAreLocked(prometheusAPI prometheusv1.API, opts ...EnsureLockedO
 //
 // When WithExpectedClockStates is provided, the function first verifies that all expected metric series are present
 // before asserting the stable locked state.
-func EnsureClocksAreStable(prometheusAPI prometheusv1.API, stableDuration time.Duration, opts ...EnsureLockedOption) error {
+func EnsureClocksAreStable(
+	prometheusAPI prometheusv1.API, stableDuration time.Duration, opts ...EnsureLockedOption,
+) error {
 	cfg := &ensureLockedConfig{}
 	for _, opt := range opts {
 		opt(cfg)
@@ -141,18 +143,18 @@ func ensureClockStatesPresent(
 		}
 
 		if time.Now().After(deadline) {
-			var sb strings.Builder
+			var stringBuilder strings.Builder
 
-			sb.WriteString(fmt.Sprintf("timed out after %s waiting for %d/%d expected clock state metrics:\n",
-				timeout, len(missing), len(expected)))
+			fmt.Fprintf(&stringBuilder, "timed out after %s waiting for %d/%d expected clock state metrics:\n",
+				timeout, len(missing), len(expected))
 
 			for _, m := range missing {
-				sb.WriteString("  - missing: ")
-				sb.WriteString(m.String())
-				sb.WriteString("\n")
+				stringBuilder.WriteString("  - missing: ")
+				stringBuilder.WriteString(m.String())
+				stringBuilder.WriteString("\n")
 			}
 
-			return fmt.Errorf("%s", sb.String())
+			return fmt.Errorf("%s", stringBuilder.String())
 		}
 
 		klog.V(tsparams.LogLevel).Infof("Presence check: %d/%d metrics missing, retrying in %s",

--- a/tests/cnf/ran/ptp/internal/metrics/expected.go
+++ b/tests/cnf/ran/ptp/internal/metrics/expected.go
@@ -9,9 +9,10 @@ import (
 // (process, interface, node) tuple that must be present in Prometheus for the configuration to be considered
 // healthy.
 //
-// The Interface field stores the exact iface label value as it appears in Prometheus. For ptp4l this is the
-// raw interface name (e.g., "ens1f0"); for dpll, gnss, and other processes this is the NIC name (e.g.,
-// "ens2fx"); for phc2sys this is "CLOCK_REALTIME".
+// The Interface field stores the exact iface label value as it appears in Prometheus. For ptp4l on simple
+// OC profiles this is the raw interface name (e.g., "ens1f0"); for ptp4l on T-BC receiver profiles and
+// for dpll, gnss, and other processes this is the NIC name (e.g., "ens2fx"); for phc2sys this is
+// "CLOCK_REALTIME".
 type ExpectedClockState struct {
 	Process   PtpProcess
 	Interface string

--- a/tests/cnf/ran/ptp/internal/metrics/expected.go
+++ b/tests/cnf/ran/ptp/internal/metrics/expected.go
@@ -44,27 +44,27 @@ func FormatExpectedClockStates(expected []ExpectedClockState) string {
 		return "(none)"
 	}
 
-	var sb strings.Builder
+	var stringBuilder strings.Builder
 
-	for i, e := range expected {
+	for i, expectedState := range expected {
 		if i > 0 {
-			sb.WriteString("\n")
+			stringBuilder.WriteString("\n")
 		}
 
-		sb.WriteString("  - ")
-		sb.WriteString(e.String())
+		stringBuilder.WriteString("  - ")
+		stringBuilder.WriteString(expectedState.String())
 	}
 
-	return sb.String()
+	return stringBuilder.String()
 }
 
 // deduplicateExpectedClockStates removes duplicate entries from the expected clock states slice. Two entries
 // are considered duplicates if they have the same process, interface, and node.
 func deduplicateExpectedClockStates(expected []ExpectedClockState) []ExpectedClockState {
 	type key struct {
-		process   PtpProcess
-		iface     string
-		node      string
+		process PtpProcess
+		iface   string
+		node    string
 	}
 
 	seen := make(map[key]struct{})
@@ -77,6 +77,7 @@ func deduplicateExpectedClockStates(expected []ExpectedClockState) []ExpectedClo
 		}
 
 		seen[k] = struct{}{}
+
 		result = append(result, entry)
 	}
 

--- a/tests/cnf/ran/ptp/internal/metrics/expected.go
+++ b/tests/cnf/ran/ptp/internal/metrics/expected.go
@@ -1,0 +1,83 @@
+package metrics
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ExpectedClockState represents a single expected openshift_ptp_clock_state metric series. It describes a
+// (process, interface, node) tuple that must be present in Prometheus for the configuration to be considered
+// healthy.
+//
+// The Interface field stores the exact iface label value as it appears in Prometheus. For ptp4l this is the
+// raw interface name (e.g., "ens1f0"); for dpll, gnss, and other processes this is the NIC name (e.g.,
+// "ens2fx"); for phc2sys this is "CLOCK_REALTIME".
+type ExpectedClockState struct {
+	Process   PtpProcess
+	Interface string
+	Node      string
+}
+
+// String returns a human-readable representation of the expected clock state for logging and error messages.
+func (e ExpectedClockState) String() string {
+	return fmt.Sprintf("{process=%s, iface=%s, node=%s}", e.Process, e.Interface, e.Node)
+}
+
+// toQuery builds a MetricQuery for the expected clock state. It constructs the query directly rather than
+// going through ClockStateQuery to avoid the ensureNIC() conversion, since ptp4l metrics use raw interface
+// names while other processes use NIC names.
+func (e ExpectedClockState) toQuery() MetricQuery[PtpClockState] {
+	return MetricQuery[PtpClockState]{
+		Metric: MetricClockState,
+		Labels: map[PtpMetricKey]MetricLabel[any]{
+			KeyProcess:   Equals(e.Process).ToAny(),
+			KeyInterface: Equals(e.Interface).ToAny(),
+			KeyNode:      Equals(e.Node).ToAny(),
+		},
+	}
+}
+
+// FormatExpectedClockStates returns a multi-line summary of the expected clock states for logging.
+func FormatExpectedClockStates(expected []ExpectedClockState) string {
+	if len(expected) == 0 {
+		return "(none)"
+	}
+
+	var sb strings.Builder
+
+	for i, e := range expected {
+		if i > 0 {
+			sb.WriteString("\n")
+		}
+
+		sb.WriteString("  - ")
+		sb.WriteString(e.String())
+	}
+
+	return sb.String()
+}
+
+// deduplicateExpectedClockStates removes duplicate entries from the expected clock states slice. Two entries
+// are considered duplicates if they have the same process, interface, and node.
+func deduplicateExpectedClockStates(expected []ExpectedClockState) []ExpectedClockState {
+	type key struct {
+		process   PtpProcess
+		iface     string
+		node      string
+	}
+
+	seen := make(map[key]struct{})
+	result := make([]ExpectedClockState, 0, len(expected))
+
+	for _, entry := range expected {
+		k := key{process: entry.Process, iface: entry.Interface, node: entry.Node}
+		if _, exists := seen[k]; exists {
+			continue
+		}
+
+		seen[k] = struct{}{}
+		result = append(result, entry)
+	}
+
+	return result
+}

--- a/tests/cnf/ran/ptp/internal/profiles/expectedmetrics.go
+++ b/tests/cnf/ran/ptp/internal/profiles/expectedmetrics.go
@@ -17,7 +17,9 @@ import (
 //
 // The expected metrics are:
 //   - process=phc2sys, iface=CLOCK_REALTIME: for each profile that runs phc2sys (all non-TBCTransmitter profiles)
-//   - process=ptp4l, iface=<raw_interface>: for each slave (client) interface (uses raw names, not NIC names)
+//   - process=ptp4l, iface=<interface>: for each slave (client) interface. Simple OC profiles use raw names
+//     (e.g., "ens1f0"); T-BC receiver profiles use NIC names (e.g., "enox") because boundary_clock_jbod mode
+//     consolidates the ptp4l clock state to the NIC level.
 //   - process=dpll, iface=<nic>: for each DPLL-monitored interface in profiles with DPLL capability
 //   - process=gnss, iface=<nic>: for each GNSS interface (TX/GPS) in GM profiles with Intel plugins
 //
@@ -59,13 +61,22 @@ func getExpectedForProfile(
 		})
 	}
 
-	// ptp4l: expected for each slave (client) interface. Uses raw interface names because ptp4l metrics
-	// report per-port with the actual interface name (e.g., "ens1f0"), not the NIC name (e.g., "ens1fx").
+	// ptp4l: expected for each slave (client) interface. The interface name format depends on the profile
+	// type: simple OC profiles report per-port with raw names (e.g., "ens1f0"), while T-BC receiver
+	// profiles consolidate the clock state to the NIC level (e.g., "enox") due to boundary_clock_jbod mode.
 	clientInterfaces := profileInfo.GetInterfacesByClockType(ClockTypeClient)
 	for _, ifaceInfo := range clientInterfaces {
+		ptp4lIface := string(ifaceInfo.Name)
+
+		if ptp4lUsesNICName(profileInfo.ProfileType) {
+			if nicName := ifaceInfo.Name.GetNIC(); nicName != "" {
+				ptp4lIface = string(nicName)
+			}
+		}
+
 		expected = append(expected, metrics.ExpectedClockState{
 			Process:   metrics.ProcessPTP4L,
-			Interface: string(ifaceInfo.Name),
+			Interface: ptp4lIface,
 			Node:      nodeName,
 		})
 	}
@@ -100,6 +111,18 @@ func getExpectedForProfile(
 func isGMProfile(profileType PtpProfileType) bool {
 	switch profileType {
 	case ProfileTypeGM, ProfileTypeMultiNICGM, ProfileTypeNTPFallback:
+		return true
+	default:
+		return false
+	}
+}
+
+// ptp4lUsesNICName returns true if the profile type reports ptp4l clock state metrics with NIC names rather
+// than raw interface names. T-BC receiver profiles run ptp4l with boundary_clock_jbod mode, which causes the
+// PTP operator to consolidate the ptp4l clock state to the NIC level (e.g., "enox" instead of "eno8403").
+func ptp4lUsesNICName(profileType PtpProfileType) bool {
+	switch profileType {
+	case ProfileTypeTBCReceiver:
 		return true
 	default:
 		return false

--- a/tests/cnf/ran/ptp/internal/profiles/expectedmetrics.go
+++ b/tests/cnf/ran/ptp/internal/profiles/expectedmetrics.go
@@ -1,0 +1,143 @@
+package profiles
+
+import (
+	"fmt"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/iface"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/metrics"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/tsparams"
+	"k8s.io/klog/v2"
+)
+
+// GetExpectedClockStates derives the expected openshift_ptp_clock_state metric series from the PtpConfig
+// configuration on the cluster. It inspects each node's recommended profiles to determine which (process, interface)
+// combinations should be reporting clock state metrics.
+//
+// The expected metrics are:
+//   - process=phc2sys, iface=CLOCK_REALTIME: for each profile that runs phc2sys (all non-TBCTransmitter profiles)
+//   - process=ptp4l, iface=<raw_interface>: for each slave (client) interface (uses raw names, not NIC names)
+//   - process=dpll, iface=<nic>: for each DPLL-monitored interface (RX pins) in GM profiles with Intel plugins
+//   - process=gnss, iface=<nic>: for each GNSS interface (TX/GPS) in GM profiles with Intel plugins
+//
+// The client parameter is used to pull raw PtpProfile specs when plugin inspection is needed for DPLL/GNSS detection.
+func GetExpectedClockStates(client *clients.Settings, nodeInfoMap map[string]*NodeInfo) ([]metrics.ExpectedClockState, error) {
+	var expected []metrics.ExpectedClockState
+
+	for nodeName, nodeInfo := range nodeInfoMap {
+		for _, profileInfo := range nodeInfo.Profiles {
+			profileExpected, err := getExpectedForProfile(client, nodeName, profileInfo)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get expected clock states for profile %s on node %s: %w",
+					profileInfo.Reference.ProfileName, nodeName, err)
+			}
+
+			expected = append(expected, profileExpected...)
+		}
+	}
+
+	return expected, nil
+}
+
+// getExpectedForProfile determines the expected clock state metrics for a single profile on a node.
+func getExpectedForProfile(
+	client *clients.Settings, nodeName string, profileInfo *ProfileInfo) ([]metrics.ExpectedClockState, error) {
+	var expected []metrics.ExpectedClockState
+
+	// phc2sys / CLOCK_REALTIME: expected for all profiles except TBC transmitters (which only transmit time and
+	// do not sync a local clock via phc2sys).
+	if profileInfo.ProfileType != ProfileTypeTBCTransmitter {
+		expected = append(expected, metrics.ExpectedClockState{
+			Process:   metrics.ProcessPHC2SYS,
+			Interface: string(iface.ClockRealtime),
+			Node:      nodeName,
+		})
+	}
+
+	// ptp4l: expected for each slave (client) interface. Uses raw interface names because ptp4l metrics
+	// report per-port with the actual interface name (e.g., "ens1f0"), not the NIC name (e.g., "ens1fx").
+	clientInterfaces := profileInfo.GetInterfacesByClockType(ClockTypeClient)
+	for _, ifaceInfo := range clientInterfaces {
+		expected = append(expected, metrics.ExpectedClockState{
+			Process:   metrics.ProcessPTP4L,
+			Interface: string(ifaceInfo.Name),
+			Node:      nodeName,
+		})
+	}
+
+	// DPLL and GNSS: only applicable to GM/MultiNICGM/NTPFallback profiles that have Intel plugins.
+	if isGMProfile(profileInfo.ProfileType) {
+		dpllExpected, gnssExpected, err := getExpectedForGMPlugins(client, nodeName, profileInfo)
+		if err != nil {
+			klog.V(tsparams.LogLevel).Infof(
+				"Could not determine DPLL/GNSS expected metrics for profile %s on node %s: %v",
+				profileInfo.Reference.ProfileName, nodeName, err)
+		} else {
+			expected = append(expected, dpllExpected...)
+			expected = append(expected, gnssExpected...)
+		}
+	}
+
+	return expected, nil
+}
+
+// isGMProfile returns true if the profile type is a grandmaster variant that may have DPLL/GNSS hardware.
+func isGMProfile(profileType PtpProfileType) bool {
+	switch profileType {
+	case ProfileTypeGM, ProfileTypeMultiNICGM, ProfileTypeNTPFallback:
+		return true
+	default:
+		return false
+	}
+}
+
+// getExpectedForGMPlugins inspects the raw PtpProfile plugins to determine expected DPLL and GNSS metrics.
+func getExpectedForGMPlugins(
+	client *clients.Settings, nodeName string, profileInfo *ProfileInfo,
+) (dpll []metrics.ExpectedClockState, gnss []metrics.ExpectedClockState, err error) {
+	rawProfile, err := profileInfo.PullProfile(client)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to pull raw profile: %w", err)
+	}
+
+	// DPLL: check for Intel plugin with DpllSettings and RX interfaces. DPLL metrics use NIC names.
+	_, plugin, resolveErr := resolveHoldoverPlugin(rawProfile)
+	if resolveErr == nil && plugin != nil && plugin.DpllSettings != nil {
+		rxInterfaces, rxErr := GetRxInterfaces(rawProfile)
+		if rxErr == nil {
+			for _, ifaceName := range rxInterfaces {
+				nicName := ifaceName.GetNIC()
+				if nicName == "" {
+					continue
+				}
+
+				dpll = append(dpll, metrics.ExpectedClockState{
+					Process:   metrics.ProcessDPLL,
+					Interface: string(nicName),
+					Node:      nodeName,
+				})
+			}
+		} else {
+			klog.V(tsparams.LogLevel).Infof("No RX interfaces for DPLL in profile %s: %v",
+				profileInfo.Reference.ProfileName, rxErr)
+		}
+	}
+
+	// GNSS: check for GM interface to GPS (TX pin or device). GNSS metrics use NIC names.
+	gpsInterface, gpsErr := GetGmInterfaceToGPS(rawProfile)
+	if gpsErr == nil {
+		nicName := gpsInterface.GetNIC()
+		if nicName != "" {
+			gnss = append(gnss, metrics.ExpectedClockState{
+				Process:   metrics.ProcessGNSS,
+				Interface: string(nicName),
+				Node:      nodeName,
+			})
+		}
+	} else {
+		klog.V(tsparams.LogLevel).Infof("No GNSS interface in profile %s: %v",
+			profileInfo.Reference.ProfileName, gpsErr)
+	}
+
+	return dpll, gnss, nil
+}

--- a/tests/cnf/ran/ptp/internal/profiles/expectedmetrics.go
+++ b/tests/cnf/ran/ptp/internal/profiles/expectedmetrics.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	ptpv1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/ptp/v1"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/iface"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/metrics"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/tsparams"
@@ -17,8 +18,12 @@ import (
 // The expected metrics are:
 //   - process=phc2sys, iface=CLOCK_REALTIME: for each profile that runs phc2sys (all non-TBCTransmitter profiles)
 //   - process=ptp4l, iface=<raw_interface>: for each slave (client) interface (uses raw names, not NIC names)
-//   - process=dpll, iface=<nic>: for each DPLL-monitored interface (RX pins) in GM profiles with Intel plugins
+//   - process=dpll, iface=<nic>: for each DPLL-monitored interface in profiles with DPLL capability
 //   - process=gnss, iface=<nic>: for each GNSS interface (TX/GPS) in GM profiles with Intel plugins
+//
+// DPLL capability is determined by the presence of Intel plugin DpllSettings or a HardwareConfig CR with DPLL
+// holdover parameters. For GM profiles, DPLL interfaces are discovered from plugin pins (E810 RX) or devices
+// (E825/E830). For other profiles (T-BC, T-TSC, etc.), DPLL interfaces are the client (upstream) interfaces.
 //
 // The client parameter is used to pull raw PtpProfile specs when plugin inspection is needed for DPLL/GNSS detection.
 func GetExpectedClockStates(client *clients.Settings, nodeInfoMap map[string]*NodeInfo) ([]metrics.ExpectedClockState, error) {
@@ -65,15 +70,25 @@ func getExpectedForProfile(
 		})
 	}
 
-	// DPLL and GNSS: only applicable to GM/MultiNICGM/NTPFallback profiles that have Intel plugins.
+	// DPLL: applicable to any profile with DPLL capability (Intel plugin DpllSettings or HardwareConfig
+	// with DPLL holdover parameters).
+	dpllExpected, err := getExpectedDpll(client, nodeName, profileInfo)
+	if err != nil {
+		klog.V(tsparams.LogLevel).Infof(
+			"Could not determine DPLL expected metrics for profile %s on node %s: %v",
+			profileInfo.Reference.ProfileName, nodeName, err)
+	} else {
+		expected = append(expected, dpllExpected...)
+	}
+
+	// GNSS: only applicable to GM variant profiles with Intel plugins.
 	if isGMProfile(profileInfo.ProfileType) {
-		dpllExpected, gnssExpected, err := getExpectedForGMPlugins(client, nodeName, profileInfo)
+		gnssExpected, err := getExpectedGnss(client, nodeName, profileInfo)
 		if err != nil {
 			klog.V(tsparams.LogLevel).Infof(
-				"Could not determine DPLL/GNSS expected metrics for profile %s on node %s: %v",
+				"Could not determine GNSS expected metrics for profile %s on node %s: %v",
 				profileInfo.Reference.ProfileName, nodeName, err)
 		} else {
-			expected = append(expected, dpllExpected...)
 			expected = append(expected, gnssExpected...)
 		}
 	}
@@ -81,7 +96,7 @@ func getExpectedForProfile(
 	return expected, nil
 }
 
-// isGMProfile returns true if the profile type is a grandmaster variant that may have DPLL/GNSS hardware.
+// isGMProfile returns true if the profile type is a grandmaster variant that may have GNSS hardware.
 func isGMProfile(profileType PtpProfileType) bool {
 	switch profileType {
 	case ProfileTypeGM, ProfileTypeMultiNICGM, ProfileTypeNTPFallback:
@@ -91,53 +106,121 @@ func isGMProfile(profileType PtpProfileType) bool {
 	}
 }
 
-// getExpectedForGMPlugins inspects the raw PtpProfile plugins to determine expected DPLL and GNSS metrics.
-func getExpectedForGMPlugins(
+// hasDpllCapability reports whether the profile has DPLL monitoring capability, either through an Intel plugin
+// with DpllSettings or through a HardwareConfig CR with DPLL holdover parameters.
+func hasDpllCapability(profileInfo *ProfileInfo, rawProfile *ptpv1.PtpProfile) bool {
+	_, plugin, err := resolveHoldoverPlugin(rawProfile)
+	if err == nil && plugin != nil && plugin.DpllSettings != nil {
+		return true
+	}
+
+	if profileInfo.HardwareConfig != nil {
+		_, _, hwErr := firstHoldoverParameters(profileInfo.HardwareConfig)
+
+		return hwErr == nil
+	}
+
+	return false
+}
+
+// getExpectedDpll determines the expected DPLL clock state metrics for a profile. It is called for all profile
+// types and returns nil when the profile has no DPLL capability.
+//
+// DPLL interface discovery depends on the profile type:
+//   - GM variants (T-GM, Multi-NIC GM, NTP Fallback): plugin-based discovery via GetDpllInterfaces
+//     (E810 RX pins or E825/E830 Devices).
+//   - All other profiles (T-BC, T-TSC, etc.): client (upstream) interfaces from the parsed profile,
+//     since the DPLL monitors the clock recovery on the time-receiving NIC.
+//
+// When plugin-based discovery fails or returns no interfaces, the function falls back to client interfaces.
+func getExpectedDpll(
 	client *clients.Settings, nodeName string, profileInfo *ProfileInfo,
-) (dpll []metrics.ExpectedClockState, gnss []metrics.ExpectedClockState, err error) {
+) ([]metrics.ExpectedClockState, error) {
 	rawProfile, err := profileInfo.PullProfile(client)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to pull raw profile: %w", err)
+		return nil, fmt.Errorf("failed to pull raw profile: %w", err)
 	}
 
-	// DPLL: check for Intel plugin with DpllSettings and RX interfaces. DPLL metrics use NIC names.
-	_, plugin, resolveErr := resolveHoldoverPlugin(rawProfile)
-	if resolveErr == nil && plugin != nil && plugin.DpllSettings != nil {
-		rxInterfaces, rxErr := GetRxInterfaces(rawProfile)
-		if rxErr == nil {
-			for _, ifaceName := range rxInterfaces {
-				nicName := ifaceName.GetNIC()
-				if nicName == "" {
-					continue
-				}
+	if !hasDpllCapability(profileInfo, rawProfile) {
+		return nil, nil
+	}
 
-				dpll = append(dpll, metrics.ExpectedClockState{
-					Process:   metrics.ProcessDPLL,
-					Interface: string(nicName),
-					Node:      nodeName,
-				})
-			}
-		} else {
-			klog.V(tsparams.LogLevel).Infof("No RX interfaces for DPLL in profile %s: %v",
-				profileInfo.Reference.ProfileName, rxErr)
+	dpllIfaces := getDpllInterfaces(profileInfo, rawProfile)
+	if len(dpllIfaces) == 0 {
+		return nil, nil
+	}
+
+	var expected []metrics.ExpectedClockState
+
+	for _, ifaceName := range dpllIfaces {
+		nicName := ifaceName.GetNIC()
+		if nicName == "" {
+			continue
 		}
+
+		expected = append(expected, metrics.ExpectedClockState{
+			Process:   metrics.ProcessDPLL,
+			Interface: string(nicName),
+			Node:      nodeName,
+		})
 	}
 
-	// GNSS: check for GM interface to GPS (TX pin or device). GNSS metrics use NIC names.
+	return expected, nil
+}
+
+// getDpllInterfaces returns the interfaces that should have DPLL clock state metrics for the given profile.
+// For GM profiles, it tries plugin-based discovery first (E810 RX pins, E825/E830 Devices). For non-GM profiles
+// or when plugin discovery fails, it falls back to the profile's client interfaces.
+func getDpllInterfaces(profileInfo *ProfileInfo, rawProfile *ptpv1.PtpProfile) []iface.Name {
+	pluginIfaces, pluginErr := GetDpllInterfaces(rawProfile)
+	if pluginErr == nil && len(pluginIfaces) > 0 {
+		return pluginIfaces
+	}
+
+	if pluginErr != nil {
+		klog.V(tsparams.LogLevel).Infof("Plugin-based DPLL interface discovery failed for profile %s: %v",
+			profileInfo.Reference.ProfileName, pluginErr)
+	}
+
+	clientInterfaces := profileInfo.GetInterfacesByClockType(ClockTypeClient)
+
+	ifaceNames := make([]iface.Name, 0, len(clientInterfaces))
+	for _, ifaceInfo := range clientInterfaces {
+		ifaceNames = append(ifaceNames, ifaceInfo.Name)
+	}
+
+	return ifaceNames
+}
+
+// getExpectedGnss determines the expected GNSS clock state metrics for a GM profile. It inspects the raw PtpProfile
+// plugins to find the GPS interface (TX pin for E810 or device for E825). Only GM variant profiles have GPS
+// connections, so this function should only be called when isGMProfile returns true.
+func getExpectedGnss(
+	client *clients.Settings, nodeName string, profileInfo *ProfileInfo,
+) ([]metrics.ExpectedClockState, error) {
+	rawProfile, err := profileInfo.PullProfile(client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to pull raw profile: %w", err)
+	}
+
 	gpsInterface, gpsErr := GetGmInterfaceToGPS(rawProfile)
-	if gpsErr == nil {
-		nicName := gpsInterface.GetNIC()
-		if nicName != "" {
-			gnss = append(gnss, metrics.ExpectedClockState{
-				Process:   metrics.ProcessGNSS,
-				Interface: string(nicName),
-				Node:      nodeName,
-			})
-		}
-	} else {
+	if gpsErr != nil {
 		klog.V(tsparams.LogLevel).Infof("No GNSS interface in profile %s: %v",
 			profileInfo.Reference.ProfileName, gpsErr)
+
+		return nil, nil
 	}
 
-	return dpll, gnss, nil
+	nicName := gpsInterface.GetNIC()
+	if nicName == "" {
+		return nil, nil
+	}
+
+	return []metrics.ExpectedClockState{
+		{
+			Process:   metrics.ProcessGNSS,
+			Interface: string(nicName),
+			Node:      nodeName,
+		},
+	}, nil
 }

--- a/tests/cnf/ran/ptp/internal/profiles/expectedmetrics.go
+++ b/tests/cnf/ran/ptp/internal/profiles/expectedmetrics.go
@@ -81,27 +81,25 @@ func getExpectedForProfile(
 		})
 	}
 
-	// DPLL: applicable to any profile with DPLL capability (Intel plugin DpllSettings or HardwareConfig
-	// with DPLL holdover parameters).
-	dpllExpected, err := getExpectedDpll(client, nodeName, profileInfo)
+	// Pull the raw profile once for DPLL and GNSS inspection.
+	rawProfile, err := profileInfo.PullProfile(client)
 	if err != nil {
 		klog.V(tsparams.LogLevel).Infof(
-			"Could not determine DPLL expected metrics for profile %s on node %s: %v",
+			"Could not pull raw profile %s on node %s for DPLL/GNSS inspection: %v",
 			profileInfo.Reference.ProfileName, nodeName, err)
-	} else {
-		expected = append(expected, dpllExpected...)
+
+		return expected, nil
 	}
+
+	// DPLL: applicable to any profile with DPLL capability (Intel plugin DpllSettings or HardwareConfig
+	// with DPLL holdover parameters).
+	dpllExpected := getExpectedDpll(nodeName, profileInfo, rawProfile)
+	expected = append(expected, dpllExpected...)
 
 	// GNSS: only applicable to GM variant profiles with Intel plugins.
 	if isGMProfile(profileInfo.ProfileType) {
-		gnssExpected, err := getExpectedGnss(client, nodeName, profileInfo)
-		if err != nil {
-			klog.V(tsparams.LogLevel).Infof(
-				"Could not determine GNSS expected metrics for profile %s on node %s: %v",
-				profileInfo.Reference.ProfileName, nodeName, err)
-		} else {
-			expected = append(expected, gnssExpected...)
-		}
+		gnssExpected := getExpectedGnss(nodeName, profileInfo, rawProfile)
+		expected = append(expected, gnssExpected...)
 	}
 
 	return expected, nil
@@ -158,20 +156,15 @@ func hasDpllCapability(profileInfo *ProfileInfo, rawProfile *ptpv1.PtpProfile) b
 //
 // When plugin-based discovery fails or returns no interfaces, the function falls back to client interfaces.
 func getExpectedDpll(
-	client *clients.Settings, nodeName string, profileInfo *ProfileInfo,
-) ([]metrics.ExpectedClockState, error) {
-	rawProfile, err := profileInfo.PullProfile(client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to pull raw profile: %w", err)
-	}
-
+	nodeName string, profileInfo *ProfileInfo, rawProfile *ptpv1.PtpProfile,
+) []metrics.ExpectedClockState {
 	if !hasDpllCapability(profileInfo, rawProfile) {
-		return nil, nil
+		return nil
 	}
 
 	dpllIfaces := getDpllInterfaces(profileInfo, rawProfile)
 	if len(dpllIfaces) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	var expected []metrics.ExpectedClockState
@@ -189,7 +182,7 @@ func getExpectedDpll(
 		})
 	}
 
-	return expected, nil
+	return expected
 }
 
 // getDpllInterfaces returns the interfaces that should have DPLL clock state metrics for the given profile.
@@ -220,24 +213,19 @@ func getDpllInterfaces(profileInfo *ProfileInfo, rawProfile *ptpv1.PtpProfile) [
 // plugins to find the GPS interface (TX pin for E810 or device for E825). Only GM variant profiles have GPS
 // connections, so this function should only be called when isGMProfile returns true.
 func getExpectedGnss(
-	client *clients.Settings, nodeName string, profileInfo *ProfileInfo,
-) ([]metrics.ExpectedClockState, error) {
-	rawProfile, err := profileInfo.PullProfile(client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to pull raw profile: %w", err)
-	}
-
+	nodeName string, profileInfo *ProfileInfo, rawProfile *ptpv1.PtpProfile,
+) []metrics.ExpectedClockState {
 	gpsInterface, gpsErr := GetGmInterfaceToGPS(rawProfile)
 	if gpsErr != nil {
 		klog.V(tsparams.LogLevel).Infof("No GNSS interface in profile %s: %v",
 			profileInfo.Reference.ProfileName, gpsErr)
 
-		return nil, nil
+		return nil
 	}
 
 	nicName := gpsInterface.GetNIC()
 	if nicName == "" {
-		return nil, nil
+		return nil
 	}
 
 	return []metrics.ExpectedClockState{
@@ -246,5 +234,5 @@ func getExpectedGnss(
 			Interface: string(nicName),
 			Node:      nodeName,
 		},
-	}, nil
+	}
 }

--- a/tests/cnf/ran/ptp/internal/profiles/expectedmetrics.go
+++ b/tests/cnf/ran/ptp/internal/profiles/expectedmetrics.go
@@ -1,8 +1,6 @@
 package profiles
 
 import (
-	"fmt"
-
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 	ptpv1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/ptp/v1"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/iface"
@@ -28,17 +26,14 @@ import (
 // (E825/E830). For other profiles (T-BC, T-TSC, etc.), DPLL interfaces are the client (upstream) interfaces.
 //
 // The client parameter is used to pull raw PtpProfile specs when plugin inspection is needed for DPLL/GNSS detection.
-func GetExpectedClockStates(client *clients.Settings, nodeInfoMap map[string]*NodeInfo) ([]metrics.ExpectedClockState, error) {
+func GetExpectedClockStates(
+	client *clients.Settings, nodeInfoMap map[string]*NodeInfo,
+) ([]metrics.ExpectedClockState, error) {
 	var expected []metrics.ExpectedClockState
 
 	for nodeName, nodeInfo := range nodeInfoMap {
 		for _, profileInfo := range nodeInfo.Profiles {
-			profileExpected, err := getExpectedForProfile(client, nodeName, profileInfo)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get expected clock states for profile %s on node %s: %w",
-					profileInfo.Reference.ProfileName, nodeName, err)
-			}
-
+			profileExpected := getExpectedForProfile(client, nodeName, profileInfo)
 			expected = append(expected, profileExpected...)
 		}
 	}
@@ -48,7 +43,8 @@ func GetExpectedClockStates(client *clients.Settings, nodeInfoMap map[string]*No
 
 // getExpectedForProfile determines the expected clock state metrics for a single profile on a node.
 func getExpectedForProfile(
-	client *clients.Settings, nodeName string, profileInfo *ProfileInfo) ([]metrics.ExpectedClockState, error) {
+	client *clients.Settings, nodeName string, profileInfo *ProfileInfo,
+) []metrics.ExpectedClockState {
 	var expected []metrics.ExpectedClockState
 
 	// phc2sys / CLOCK_REALTIME: expected for all profiles except TBC transmitters (which only transmit time and
@@ -88,7 +84,7 @@ func getExpectedForProfile(
 			"Could not pull raw profile %s on node %s for DPLL/GNSS inspection: %v",
 			profileInfo.Reference.ProfileName, nodeName, err)
 
-		return expected, nil
+		return expected
 	}
 
 	// DPLL: applicable to any profile with DPLL capability (Intel plugin DpllSettings or HardwareConfig
@@ -102,7 +98,7 @@ func getExpectedForProfile(
 		expected = append(expected, gnssExpected...)
 	}
 
-	return expected, nil
+	return expected
 }
 
 // isGMProfile returns true if the profile type is a grandmaster variant that may have GNSS hardware.
@@ -110,9 +106,12 @@ func isGMProfile(profileType PtpProfileType) bool {
 	switch profileType {
 	case ProfileTypeGM, ProfileTypeMultiNICGM, ProfileTypeNTPFallback:
 		return true
-	default:
+	case ProfileTypeOC, ProfileTypeTwoPortOC, ProfileTypeBC, ProfileTypeHA,
+		ProfileTypeTBCTransmitter, ProfileTypeTBCReceiver, ProfileTypeTTSC:
 		return false
 	}
+
+	return false
 }
 
 // ptp4lUsesNICName returns true if the profile type reports ptp4l clock state metrics with NIC names rather
@@ -123,9 +122,12 @@ func ptp4lUsesNICName(profileType PtpProfileType) bool {
 	switch profileType {
 	case ProfileTypeBC, ProfileTypeTBCReceiver:
 		return true
-	default:
+	case ProfileTypeOC, ProfileTypeTwoPortOC, ProfileTypeHA, ProfileTypeGM,
+		ProfileTypeMultiNICGM, ProfileTypeNTPFallback, ProfileTypeTBCTransmitter, ProfileTypeTTSC:
 		return false
 	}
+
+	return false
 }
 
 // hasDpllCapability reports whether the profile has DPLL monitoring capability, either through an Intel plugin

--- a/tests/cnf/ran/ptp/internal/profiles/expectedmetrics.go
+++ b/tests/cnf/ran/ptp/internal/profiles/expectedmetrics.go
@@ -62,8 +62,8 @@ func getExpectedForProfile(
 	}
 
 	// ptp4l: expected for each slave (client) interface. The interface name format depends on the profile
-	// type: simple OC profiles report per-port with raw names (e.g., "ens1f0"), while T-BC receiver
-	// profiles consolidate the clock state to the NIC level (e.g., "enox") due to boundary_clock_jbod mode.
+	// type: single-port OC profiles report per-port with raw names (e.g., "ens1f0"), while multi-port
+	// profiles (BC, T-BC receiver) consolidate the clock state to the NIC level (e.g., "ens3fx").
 	clientInterfaces := profileInfo.GetInterfacesByClockType(ClockTypeClient)
 	for _, ifaceInfo := range clientInterfaces {
 		ptp4lIface := string(ifaceInfo.Name)
@@ -118,11 +118,12 @@ func isGMProfile(profileType PtpProfileType) bool {
 }
 
 // ptp4lUsesNICName returns true if the profile type reports ptp4l clock state metrics with NIC names rather
-// than raw interface names. T-BC receiver profiles run ptp4l with boundary_clock_jbod mode, which causes the
-// PTP operator to consolidate the ptp4l clock state to the NIC level (e.g., "enox" instead of "eno8403").
+// than raw interface names. When ptp4l manages multiple ports (clock_type BC, or boundary_clock_jbod mode),
+// the PTP operator consolidates the ptp4l clock state to the NIC level (e.g., "ens3fx" instead of "ens3f2").
+// Single-port OC profiles report per-port with raw interface names.
 func ptp4lUsesNICName(profileType PtpProfileType) bool {
 	switch profileType {
-	case ProfileTypeTBCReceiver:
+	case ProfileTypeBC, ProfileTypeTBCReceiver:
 		return true
 	default:
 		return false

--- a/tests/cnf/ran/ptp/internal/profiles/plugins.go
+++ b/tests/cnf/ran/ptp/internal/profiles/plugins.go
@@ -289,6 +289,36 @@ func GetRxInterfaces(profile *ptpv1.PtpProfile) ([]iface.Name, error) {
 	return getInterfacesWithPluginPins(profile, ptp.PluginTypeE810, PinStateRx)
 }
 
+// GetDpllInterfaces returns the interfaces that have DPLL hardware monitoring enabled.
+// The discovery method depends on the Intel plugin type present in the profile:
+//   - E810: interfaces with RX pins (pin state 1), since DPLL monitors the receive path.
+//   - E825/E830: interfaces from the Devices list.
+//
+// Precedence is E810 > E825 > E830, matching the order used by resolveHoldoverPlugin and GetGmInterfaceToGPS.
+func GetDpllInterfaces(profile *ptpv1.PtpProfile) ([]iface.Name, error) {
+	if profile == nil {
+		return nil, fmt.Errorf("profile is nil")
+	}
+
+	if profile.Plugins == nil {
+		return nil, fmt.Errorf("profile has no plugins")
+	}
+
+	if _, ok := profile.Plugins[string(ptp.PluginTypeE810)]; ok {
+		return getInterfacesWithPluginPins(profile, ptp.PluginTypeE810, PinStateRx)
+	}
+
+	if _, ok := profile.Plugins[string(ptp.PluginTypeE825)]; ok {
+		return getInterfacesWithDevices(profile, ptp.PluginTypeE825)
+	}
+
+	if _, ok := profile.Plugins[string(ptp.PluginTypeE830)]; ok {
+		return getInterfacesWithDevices(profile, ptp.PluginTypeE830)
+	}
+
+	return nil, fmt.Errorf("no supported Intel plugin (E810, E825, E830) found for DPLL interface discovery")
+}
+
 // GetSmaPinFromProfile returns the first active SMA pin name and its configuration string for
 // ifaceName from the E810 plugin. A pin is active when its state value (the first field in the
 // "pin-state channel" string) is not "0". Pin names are checked in sorted order so the result

--- a/tests/cnf/ran/ptp/internal/profiles/plugins.go
+++ b/tests/cnf/ran/ptp/internal/profiles/plugins.go
@@ -305,7 +305,7 @@ func GetDpllInterfaces(profile *ptpv1.PtpProfile) ([]iface.Name, error) {
 	}
 
 	if _, ok := profile.Plugins[string(ptp.PluginTypeE810)]; ok {
-		return getInterfacesWithPluginPins(profile, ptp.PluginTypeE810, PinStateRx)
+		return GetRxInterfaces(profile)
 	}
 
 	if _, ok := profile.Plugins[string(ptp.PluginTypeE825)]; ok {

--- a/tests/cnf/ran/ptp/tests/ptp-events-and-metrics.go
+++ b/tests/cnf/ran/ptp/tests/ptp-events-and-metrics.go
@@ -26,8 +26,9 @@ import (
 
 var _ = Describe("PTP Events and Metrics", Label(tsparams.LabelEventsAndMetrics), func() {
 	var (
-		prometheusAPI   prometheusv1.API
-		savedPtpConfigs []*ptp.PtpConfigBuilder
+		prometheusAPI       prometheusv1.API
+		savedPtpConfigs     []*ptp.PtpConfigBuilder
+		expectedClockStates []metrics.ExpectedClockState
 	)
 
 	BeforeEach(func() {
@@ -38,9 +39,18 @@ var _ = Describe("PTP Events and Metrics", Label(tsparams.LabelEventsAndMetrics)
 		prometheusAPI, err = querier.CreatePrometheusAPIForCluster(RANConfig.Spoke1APIClient)
 		Expect(err).ToNot(HaveOccurred(), "Failed to create Prometheus API client")
 
-		By("ensuring clocks are locked before testing")
+		By("deriving expected clock states from PtpConfig")
 
-		err = metrics.EnsureClocksAreLocked(prometheusAPI)
+		nodeInfoMap, err := profiles.GetNodeInfoMap(RANConfig.Spoke1APIClient)
+		Expect(err).ToNot(HaveOccurred(), "Failed to get node info map")
+
+		expectedClockStates, err = profiles.GetExpectedClockStates(RANConfig.Spoke1APIClient, nodeInfoMap)
+		Expect(err).ToNot(HaveOccurred(), "Failed to derive expected clock states from PtpConfig")
+
+		By("ensuring all expected clock state metrics are present and locked before testing")
+
+		err = metrics.EnsureClocksAreLocked(prometheusAPI,
+			metrics.WithExpectedClockStates(expectedClockStates))
 		Expect(err).ToNot(HaveOccurred(), "Failed to assert clock state is locked")
 
 		By("saving PtpConfigs before testing")
@@ -69,17 +79,19 @@ var _ = Describe("PTP Events and Metrics", Label(tsparams.LabelEventsAndMetrics)
 			}
 		}
 
-		By("ensuring clocks are locked after testing")
+		By("ensuring all expected clock state metrics are present and locked after testing")
 
-		err = metrics.EnsureClocksAreLocked(prometheusAPI)
+		err = metrics.EnsureClocksAreLocked(prometheusAPI,
+			metrics.WithExpectedClockStates(expectedClockStates))
 		Expect(err).ToNot(HaveOccurred(), "Failed to assert clock state is locked")
 	})
 
 	// 82480 - Validating [LOCKED] clock state in PTP metrics
 	It("verifies all clocks are LOCKED", reportxml.ID("82480"), func() {
-		By("ensuring all clocks on all nodes are LOCKED")
+		By("ensuring all expected clock state metrics are present and locked")
 
-		err := metrics.EnsureClocksAreLocked(prometheusAPI)
+		err := metrics.EnsureClocksAreLocked(prometheusAPI,
+			metrics.WithExpectedClockStates(expectedClockStates))
 		Expect(err).ToNot(HaveOccurred(), "Failed to assert clock state is locked after 5 minutes")
 	})
 


### PR DESCRIPTION
When checking lock states in metrics, explicitly checks for the presence of metrics expected based on configured ptp profiles.  Explicit checks:

- phc2sys clock state for CLOCK_REALTIME
- ptp4l clock state for each slave interface
- gnss clock state for GM config
- dpll clock state:

DPLL clock state presence is explicitly checked when all of the following are true for a given profile:

DPLL capability exists -- the profile has either:

An Intel plugin (E810/E825/E830) with DpllSettings configured, or
A HardwareConfig CR with DPLL holdover parameters in its ClockChain.
At least one DPLL interface is discoverable -- determined by:

For GM variants (T-GM, Multi-NIC GM, NTP Fallback): plugin-based discovery (E810 RX pins or E825/E830 Devices).
For all other profiles (T-BC, T-TSC, OC, etc.): the profile's client (upstream) interfaces.
Falls back from plugin discovery to client interfaces if the plugin path fails.
The discovered interface has a valid NIC name -- ifaceName.GetNIC() must return a non-empty string, since DPLL metrics are reported at the NIC level.

If all three conditions hold, a process=dpll, iface=<nic> entry is added to the expected clock states list and asserted as LOCKED via EnsureClocksAreLocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced PTP clock-state metric validation to verify expected metrics are present in monitoring systems before running assertions.
  * Improved error reporting with detailed information about missing expected clock-state entries.
  * Updated test suite to automatically compute and validate expected clock states based on cluster configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->