### PR TITLE
ptp: add CLOCK_REALTIME FREERUN assertion to T-BC holdover freerun tests

### DIFF
--- a/tests/cnf/ran/ptp/tests/ptp-gnss-loss.go
+++ b/tests/cnf/ran/ptp/tests/ptp-gnss-loss.go
@@ -31,9 +31,10 @@ import (
 
 var _ = Describe("PTP T-GM GNSS Loss", Label(tsparams.LabelGNSSLoss), func() {
 	var (
-		prometheusAPI   prometheusv1.API
-		savedPtpConfigs []*ptp.PtpConfigBuilder
-		configSupported bool
+		prometheusAPI        prometheusv1.API
+		savedPtpConfigs      []*ptp.PtpConfigBuilder
+		configSupported      bool
+		assertOsClockFreerun bool
 	)
 
 	eventTimeout := 5 * time.Minute
@@ -67,6 +68,9 @@ var _ = Describe("PTP T-GM GNSS Loss", Label(tsparams.LabelGNSSLoss), func() {
 		configSupported, err = version.IsVersionStringInRange(
 			RANConfig.Spoke1OperatorVersions[ranparam.PTP], "4.20.0-0", "")
 		Expect(err).ToNot(HaveOccurred(), "Failed to check PTP config label version range")
+
+		// OsClockSyncStateChange FREERUN event is supported from PTP version 4.20.0
+		assertOsClockFreerun = configSupported
 	})
 
 	AfterEach(func() {
@@ -433,14 +437,16 @@ var _ = Describe("PTP T-GM GNSS Loss", Label(tsparams.LabelGNSSLoss), func() {
 				))
 				Expect(err).ToNot(HaveOccurred(), "Failed to receive clock class 248 event on node %s", nodeName)
 
-				By("waiting for os-clock-sync-state FREERUN event for CLOCK_REALTIME")
+				if assertOsClockFreerun {
+					By("waiting for os-clock-sync-state FREERUN event for CLOCK_REALTIME")
 
-				err = events.WaitForEvent(eventPod, gpsLossTime, eventTimeout, events.All(
-					events.IsType(eventptp.OsClockSyncStateChange),
-					events.HasValue(events.WithSyncState(eventptp.FREERUN), events.OnInterface(iface.ClockRealtime)),
-				))
-				Expect(err).ToNot(HaveOccurred(),
-					"Failed to receive os-clock-sync-state FREERUN event on node %s", nodeName)
+					err = events.WaitForEvent(eventPod, gpsLossTime, eventTimeout, events.All(
+						events.IsType(eventptp.OsClockSyncStateChange),
+						events.HasValue(events.WithSyncState(eventptp.FREERUN), events.OnInterface(iface.ClockRealtime)),
+					))
+					Expect(err).ToNot(HaveOccurred(),
+						"Failed to receive os-clock-sync-state FREERUN event on node %s", nodeName)
+				}
 
 				By("waiting for SYNCHRONIZED GNSS event")
 
@@ -652,14 +658,16 @@ var _ = Describe("PTP T-GM GNSS Loss", Label(tsparams.LabelGNSSLoss), func() {
 				))
 				Expect(err).ToNot(HaveOccurred(), "Failed to receive clock class 248 event on node %s", nodeName)
 
-				By("waiting for os-clock-sync-state FREERUN event for CLOCK_REALTIME")
+				if assertOsClockFreerun {
+					By("waiting for os-clock-sync-state FREERUN event for CLOCK_REALTIME")
 
-				err = events.WaitForEvent(eventPod, gpsLossTime, eventTimeout, events.All(
-					events.IsType(eventptp.OsClockSyncStateChange),
-					events.HasValue(events.WithSyncState(eventptp.FREERUN), events.OnInterface(iface.ClockRealtime)),
-				))
-				Expect(err).ToNot(HaveOccurred(),
-					"Failed to receive os-clock-sync-state FREERUN event on node %s", nodeName)
+					err = events.WaitForEvent(eventPod, gpsLossTime, eventTimeout, events.All(
+						events.IsType(eventptp.OsClockSyncStateChange),
+						events.HasValue(events.WithSyncState(eventptp.FREERUN), events.OnInterface(iface.ClockRealtime)),
+					))
+					Expect(err).ToNot(HaveOccurred(),
+						"Failed to receive os-clock-sync-state FREERUN event on node %s", nodeName)
+				}
 
 				By("waiting for SYNCHRONIZED GNSS event")
 

--- a/tests/cnf/ran/ptp/tests/ptp-holdover.go
+++ b/tests/cnf/ran/ptp/tests/ptp-holdover.go
@@ -566,6 +566,16 @@ func assertFreerunState(
 		Expect(err).ToNot(HaveOccurred(), "Failed to wait for clock class %d event", expectedClockClass)
 	}
 
+	By("waiting for os-clock-sync-state FREERUN event for CLOCK_REALTIME")
+
+	osClockFreerunFilter := events.All(
+		events.IsType(eventptp.OsClockSyncStateChange),
+		events.HasValue(events.WithSyncState(eventptp.FREERUN), events.OnInterface(iface.ClockRealtime)),
+	)
+	err = events.WaitForEvent(eventPod, sinceTime, timeout, osClockFreerunFilter)
+	Expect(err).ToNot(HaveOccurred(),
+		"Failed to wait for os-clock-sync-state FREERUN event for CLOCK_REALTIME on node %s", nodeName)
+
 	By(fmt.Sprintf("validating metrics: clock class %d, clock state FREERUN", expectedClockClass))
 
 	clockStateQuery := metrics.ClockStateQuery{


### PR DESCRIPTION
Adds the os-clock-sync-state FREERUN event assertion for CLOCK_REALTIME to the T-BC holdover freerun tests (83298, 83300), matching the behavior already validated in the T-GM tests (78464, 78465).

The assertion is added inside assertFreerunState, which is shared by:

83298 – T-BC transition from holdover-in-spec to freerun when LocalMaxHoldoverOffset is reached
83300 – T-BC transition from holdover-out-of-spec to freerun when LocalMaxHoldoverOffset is reached
The new step waits for an OsClockSyncStateChange event with state FREERUN on interface CLOCK_REALTIME, placed after the PTP state/clock-class event checks and before Prometheus metrics validation — consistent with the ordering in the T-GM tests.

### Jira
[CNF-23735](https://redhat.atlassian.net/browse/CNF-23735)

### Test plan

- [x]  Run 83298 83300  tests and verify the CLOCK_REALTIME FREERUN assertion passes

### Key Changes
- Version Gating: Added a PTP operator version check (>= 4.20.0-0) to determine if the os-clock-sync-state FREERUN event should be asserted.
- Event Validation: Introduced logic in ptp-gnss-loss.go and ptp-holdover.go to explicitly wait for the os-clock-sync-state to transition to FREERUN for CLOCK_REALTIME.
- Helper Updates: Updated assertFreerunState, assertHoldoverInSpecToFreerun, and assertHoldoverOutOfSpecToFreerun testing helpers to conditionally run this new validation based on the version check.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of PTP holdover and GNSS-loss behavior.
  * Added checks for operating system clock FREERUN events when supported.
  * Updated scenarios to distinguish when FREERUN events are expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->