### PR TITLE
lca/ibi: add HostFirmwareSettings support for BIOS config during deploy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -299,4 +299,3 @@ replace (
 	sigs.k8s.io/cluster-api-provider-azure => github.com/mboersma/cluster-api-provider-azure v0.3.1-0.20251030205607-3161b9cc8d3e
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.22.5
 )
-

--- a/go.mod
+++ b/go.mod
@@ -299,3 +299,4 @@ replace (
 	sigs.k8s.io/cluster-api-provider-azure => github.com/mboersma/cluster-api-provider-azure v0.3.1-0.20251030205607-3161b9cc8d3e
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.22.5
 )
+

--- a/tests/lca/imagebasedinstall/mgmt/README.md
+++ b/tests/lca/imagebasedinstall/mgmt/README.md
@@ -15,3 +15,4 @@
 | `ECO_LCA_IBI_MGMT_EXTRA_PARTITION_SIZE` | `50000` | Size of extra disk partition in MiB |
 | `ECO_LCA_IBI_REINSTALL_GENERATION` | `generate1` | Reinstall generation label for reinstall tests |
 | `ECO_LCA_IBI_ADDITIONAL_NTP_SOURCES` | _(empty)_ | Additional NTP sources for the cluster |
+| `ECO_LCA_IBI_MGMT_HFS_SETTINGS` | _(empty)_ | HostFirmwareSettings to apply after BMH creation. Comma-separated `key:value` pairs, e.g. `SecureBoot:Enabled,TpmSecurity:On` |

--- a/tests/lca/imagebasedinstall/mgmt/deploy/tests/common.go
+++ b/tests/lca/imagebasedinstall/mgmt/deploy/tests/common.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	bmhv1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/bmh"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/configmap"
@@ -187,6 +188,7 @@ func createIBIOResouces(addressFamily string) {
 
 			Eventually(func() error {
 				var pullErr error
+
 				hfsBuilder, pullErr = bmh.PullHFS(APIClient, host, MGMTConfig.Cluster.Info.ClusterName)
 
 				return pullErr
@@ -197,6 +199,10 @@ func createIBIOResouces(addressFamily string) {
 
 			_, err = hfsBuilder.WithSettings(MGMTConfig.HFSSettings).Update()
 			Expect(err).NotTo(HaveOccurred(), "error updating HostFirmwareSettings")
+
+			By("Wait for HostFirmwareSettings to be validated by BMO for " + host)
+
+			waitForHFSValidation(host, MGMTConfig.Cluster.Info.ClusterName)
 		}
 	}
 
@@ -325,6 +331,24 @@ func iciCompletionTimeout() time.Duration {
 	}
 
 	return time.Minute * 25
+}
+
+func waitForHFSValidation(host, namespace string) {
+	Eventually(func() (bool, error) {
+		refreshed, pullErr := bmh.PullHFS(APIClient, host, namespace)
+		if pullErr != nil {
+			return false, pullErr
+		}
+
+		for _, cond := range refreshed.Object.Status.Conditions {
+			if cond.Type == string(bmhv1alpha1.FirmwareSettingsValid) {
+				return cond.Status == metav1.ConditionTrue, nil
+			}
+		}
+
+		return false, nil
+	}).WithTimeout(time.Minute*5).WithPolling(time.Second*10).Should(
+		BeTrue(), "HostFirmwareSettings Valid condition not True")
 }
 
 //nolint:funlen

--- a/tests/lca/imagebasedinstall/mgmt/deploy/tests/common.go
+++ b/tests/lca/imagebasedinstall/mgmt/deploy/tests/common.go
@@ -179,6 +179,25 @@ func createIBIOResouces(addressFamily string) {
 
 		_, err = hostBMH.Create()
 		Expect(err).NotTo(HaveOccurred(), "error creating baremetalhost")
+
+		if len(MGMTConfig.HFSSettings) > 0 {
+			By("Wait for HostFirmwareSettings for " + host)
+
+			var hfsBuilder *bmh.HFSBuilder
+
+			Eventually(func() error {
+				var pullErr error
+				hfsBuilder, pullErr = bmh.PullHFS(APIClient, host, MGMTConfig.Cluster.Info.ClusterName)
+
+				return pullErr
+			}).WithTimeout(time.Minute*5).WithPolling(time.Second*10).Should(
+				BeNil(), "error waiting for HostFirmwareSettings to be created by BMO")
+
+			By("Update HostFirmwareSettings for " + host)
+
+			_, err = hfsBuilder.WithSettings(MGMTConfig.HFSSettings).Update()
+			Expect(err).NotTo(HaveOccurred(), "error updating HostFirmwareSettings")
+		}
 	}
 
 	var snoNodeName string

--- a/tests/lca/imagebasedinstall/mgmt/deploy/tests/common.go
+++ b/tests/lca/imagebasedinstall/mgmt/deploy/tests/common.go
@@ -315,8 +315,16 @@ func createIBIOResouces(addressFamily string) {
 		}
 
 		return condition.Status == trueStatus && condition.Reason == ibiv1alpha1.InstallSucceededReason, nil
-	}).WithTimeout(time.Minute*20).WithPolling(time.Second*5).Should(
+	}).WithTimeout(iciCompletionTimeout()).WithPolling(time.Second*5).Should(
 		BeTrue(), "error waiting for imageclusterinstall to complete")
+}
+
+func iciCompletionTimeout() time.Duration {
+	if len(MGMTConfig.HFSSettings) > 0 {
+		return time.Minute * 45
+	}
+
+	return time.Minute * 25
 }
 
 //nolint:funlen

--- a/tests/lca/imagebasedinstall/mgmt/internal/mgmtconfig/config.go
+++ b/tests/lca/imagebasedinstall/mgmt/internal/mgmtconfig/config.go
@@ -79,8 +79,9 @@ type MGMTConfig struct {
 	SiteConfig               bool   `envconfig:"ECO_LCA_IBI_SITECONFIG" default:"true"`
 	ExtraPartName            string `envconfig:"ECO_LCA_IBI_MGMT_EXTRA_PARTITION_NAME" default:""`
 	ExtraPartSizeMib         string `envconfig:"ECO_LCA_IBI_MGMT_EXTRA_PARTITION_SIZE" default:"50000"`
-	ReinstallGenerationLabel string `envconfig:"ECO_LCA_IBI_REINSTALL_GENERATION" default:"generate1"`
-	AdditionalNTPSources     string `envconfig:"ECO_LCA_IBI_ADDITIONAL_NTP_SOURCES" default:""`
+	ReinstallGenerationLabel string            `envconfig:"ECO_LCA_IBI_REINSTALL_GENERATION" default:"generate1"`
+	AdditionalNTPSources     string            `envconfig:"ECO_LCA_IBI_ADDITIONAL_NTP_SOURCES" default:""`
+	HFSSettings              map[string]string `envconfig:"ECO_LCA_IBI_MGMT_HFS_SETTINGS"`
 }
 
 // ReinstallConfig is used to collect info for performing resinstall test.

--- a/tests/lca/imagebasedinstall/mgmt/internal/mgmtconfig/config.go
+++ b/tests/lca/imagebasedinstall/mgmt/internal/mgmtconfig/config.go
@@ -73,12 +73,12 @@ type MGMTConfig struct {
 	SeedClusterInfo          *seedimage.SeedImageContent
 	SSHKeyPath               string `envconfig:"ECO_LCA_IBI_MGMT_SSHKEY_PATH"`
 	PublicSSHKey             string
-	StaticNetworking         bool   `envconfig:"ECO_LCA_IBI_MGMT_STATIC_NETWORK" default:"false"`
-	ExtraManifests           bool   `envconfig:"ECO_LCA_IBI_EXTRA_MANIFESTS" default:"true"`
-	CABundle                 bool   `envconfig:"ECO_LCA_IBI_CA_BUNDLE" default:"true"`
-	SiteConfig               bool   `envconfig:"ECO_LCA_IBI_SITECONFIG" default:"true"`
-	ExtraPartName            string `envconfig:"ECO_LCA_IBI_MGMT_EXTRA_PARTITION_NAME" default:""`
-	ExtraPartSizeMib         string `envconfig:"ECO_LCA_IBI_MGMT_EXTRA_PARTITION_SIZE" default:"50000"`
+	StaticNetworking         bool              `envconfig:"ECO_LCA_IBI_MGMT_STATIC_NETWORK" default:"false"`
+	ExtraManifests           bool              `envconfig:"ECO_LCA_IBI_EXTRA_MANIFESTS" default:"true"`
+	CABundle                 bool              `envconfig:"ECO_LCA_IBI_CA_BUNDLE" default:"true"`
+	SiteConfig               bool              `envconfig:"ECO_LCA_IBI_SITECONFIG" default:"true"`
+	ExtraPartName            string            `envconfig:"ECO_LCA_IBI_MGMT_EXTRA_PARTITION_NAME" default:""`
+	ExtraPartSizeMib         string            `envconfig:"ECO_LCA_IBI_MGMT_EXTRA_PARTITION_SIZE" default:"50000"`
 	ReinstallGenerationLabel string            `envconfig:"ECO_LCA_IBI_REINSTALL_GENERATION" default:"generate1"`
 	AdditionalNTPSources     string            `envconfig:"ECO_LCA_IBI_ADDITIONAL_NTP_SOURCES" default:""`
 	HFSSettings              map[string]string `envconfig:"ECO_LCA_IBI_MGMT_HFS_SETTINGS"`


### PR DESCRIPTION
## Summary

- Add optional HostFirmwareSettings (HFS) configuration to the IBI deploy test, enabling firmware-level changes (e.g. SecureBoot, TPM) on BareMetalHost nodes before image-based installation
- After BMH creation, if `ECO_LCA_IBI_MGMT_HFS_SETTINGS` is set, the test waits for BMO to create the HostFirmwareSettings resource and updates it with the desired settings
- Increase ImageClusterInstall completion timeout from 25m to 45m when HFS is active, to account for the BMO reboot cycle triggered by firmware changes

## Details

Some IBI deployment scenarios require firmware-level configuration (e.g. enabling Secure Boot or TPM) before the cluster installation proceeds. The Bare Metal Operator (BMO) automatically creates a `HostFirmwareSettings` resource for each `BareMetalHost`. This PR leverages eco-goinfra's `HFSBuilder` to wait for that resource and patch it with the desired BIOS settings.

The new `ECO_LCA_IBI_MGMT_HFS_SETTINGS` environment variable accepts comma-separated `key:value` pairs:

```
ECO_LCA_IBI_MGMT_HFS_SETTINGS=SecureBoot:Enabled
ECO_LCA_IBI_MGMT_HFS_SETTINGS=SecureBoot:Enabled,TpmSecurity:On
```

When unset or empty, the existing behavior is unchanged — no HFS interaction occurs and the 20-minute ICI timeout is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Test Improvements**
  * Image-based installation test deployments can now apply optional host firmware settings after bare-metal host creation, including automated retrieval, update, and validation.
  * Installation completion waits now allow additional time when firmware settings are configured, while retaining the standard timeout otherwise.
* **Documentation**
  * Documented `ECO_LCA_IBI_MGMT_HFS_SETTINGS` as an optional setting using comma-separated `key:value` pairs.
  * Added guidance that firmware settings are applied after bare-metal host creation and validated before installation completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->