### PR TITLE
cnf network: add sriov bond cni xmitHashPolicy

### DIFF
--- a/tests/cnf/core/network/sriov/internal/sriovenv/bond.go
+++ b/tests/cnf/core/network/sriov/internal/sriovenv/bond.go
@@ -7,8 +7,11 @@ import (
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nad"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/sriov"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/sriov/internal/tsparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/sriovoperator"
+	"k8s.io/klog/v2"
 )
 
 // Bond CNI mode strings for CreateBondNAD. Must match eco-goinfra/pkg/nad validModes
@@ -18,6 +21,11 @@ const (
 	BondModeActiveBackup = "active-backup"
 	BondModeBalanceRR    = "balance-rr"
 	BondModeBalanceXOR   = "balance-xor"
+
+	// Bond xmitHashPolicy values for balance-xor (Bond CNI JSON field xmitHashPolicy).
+	BondXmitHashPolicyLayer2  = "layer2"
+	BondXmitHashPolicyLayer23 = "layer2+3"
+	BondXmitHashPolicyLayer34 = "layer3+4"
 
 	// BondInterfaceName is the default bond master interface created by the Bond CNI plugin.
 	BondInterfaceName = "bond0"
@@ -29,6 +37,25 @@ const (
 	BondActiveSlavePollInterval = 100 * time.Millisecond
 	// BondActiveSlaveChangeTimeout is the maximum wait for bond active_slave or MII state transitions.
 	BondActiveSlaveChangeTimeout = 30 * time.Second
+
+	// BondMTU1280 and BondMTU9000 are the MTUs used by shared bond-mode SR-IOV policies.
+	BondMTU1280 = 1280
+	BondMTU9000 = 9000
+	// BondMTUDefault is the standard L2 MTU used by Bond CNI xmitHashPolicy cases.
+	BondMTUDefault = 1500
+
+	// Shared bond policy resource names (must stay stable across bond-mode and bond-cni).
+	BondResourcePF1Small   = "sriovbondpf1mtu1280"
+	BondResourcePF1Jumbo   = "sriovbondpf1mtu9000"
+	BondResourcePF2Small   = "sriovbondpf2mtu1280"
+	BondResourcePF2Jumbo   = "sriovbondpf2mtu9000"
+	BondResourcePF1Default = "sriovbondpf1mtu1500"
+	BondResourcePF2Default = "sriovbondpf2mtu1500"
+
+	// BondMinVFsPerPF is the minimum total VFs per PF for bond tests on five-VF devices.
+	BondMinVFsPerPF = 5
+	// BondMinVFsStandardLayout is the minimum total VFs per PF for the standard small/jumbo split.
+	BondMinVFsStandardLayout = 10
 )
 
 // CreateBondNAD builds a Bond CNI NAD builder in the SR-IOV test namespace.
@@ -40,7 +67,20 @@ func CreateBondNAD(
 	mtu,
 	slaveCount int,
 ) (*nad.Builder, error) {
-	return createBondNAD(nadName, mode, mtu, slaveCount, &nad.IPAM{Type: ipamType})
+	return createBondNAD(nadName, mode, mtu, slaveCount, &nad.IPAM{Type: ipamType}, "")
+}
+
+// CreateBondNADWithXmitHashPolicy builds a Bond CNI NAD like CreateBondNAD with
+// MasterBondPlugin.WithXmitHashPolicy set (layer2, layer2+3, or layer3+4).
+func CreateBondNADWithXmitHashPolicy(
+	nadName,
+	mode,
+	ipamType string,
+	mtu,
+	slaveCount int,
+	xmitHashPolicy string,
+) (*nad.Builder, error) {
+	return createBondNAD(nadName, mode, mtu, slaveCount, &nad.IPAM{Type: ipamType}, xmitHashPolicy)
 }
 
 // CreateBondNADWithWhereabouts builds a Bond CNI NAD with Whereabouts IPAM on the bond interface.
@@ -58,7 +98,7 @@ func CreateBondNADWithWhereabouts(
 		return nil, err
 	}
 
-	return createBondNAD(nadName, mode, mtu, slaveCount, ipam)
+	return createBondNAD(nadName, mode, mtu, slaveCount, ipam, "")
 }
 
 // bondWhereaboutsIPAM builds Whereabouts IPAM with an explicit alloc pool so the gateway is not
@@ -91,6 +131,7 @@ func createBondNAD(
 	mtu,
 	slaveCount int,
 	ipam *nad.IPAM,
+	xmitHashPolicy string,
 ) (*nad.Builder, error) {
 	if slaveCount < 2 {
 		return nil, fmt.Errorf("slaveCount must be >= 2, got %d", slaveCount)
@@ -109,6 +150,10 @@ func createBondNAD(
 		WithLinks(links).
 		WithCapabilities(&nad.Capability{IPs: true}).
 		WithIPAM(ipam)
+
+	if xmitHashPolicy != "" {
+		plugin = plugin.WithXmitHashPolicy(xmitHashPolicy)
+	}
 
 	masterPlugin, err := plugin.GetMasterPluginConfig()
 	if err != nil {
@@ -136,11 +181,10 @@ func GetBondActiveSlave(clientPod *pod.Builder, bondName string) (string, error)
 
 // WaitForBondActiveSlaveChange polls active_slave until it differs from previousSlave or times out.
 func WaitForBondActiveSlaveChange(clientPod *pod.Builder, bondName, previousSlave string) (string, error) {
-	deadline := time.Now().Add(BondActiveSlaveChangeTimeout)
-
 	var last string
 
-	for {
+	for deadline := time.Now().Add(BondActiveSlaveChangeTimeout); time.Now().Before(deadline); time.Sleep(
+		BondActiveSlavePollInterval) {
 		slave, err := GetBondActiveSlave(clientPod, bondName)
 		if err != nil {
 			return "", err
@@ -151,25 +195,23 @@ func WaitForBondActiveSlaveChange(clientPod *pod.Builder, bondName, previousSlav
 		if slave != "" && slave != previousSlave {
 			return slave, nil
 		}
-
-		if time.Now().After(deadline) {
-			return last, fmt.Errorf(
-				"bond did not switch active slave from %q within %v (last active_slave=%q)",
-				previousSlave, BondActiveSlaveChangeTimeout, last)
-		}
-
-		time.Sleep(BondActiveSlavePollInterval)
 	}
+
+	return last, fmt.Errorf(
+		"bond did not switch active slave from %q within %v (last active_slave=%q)",
+		previousSlave, BondActiveSlaveChangeTimeout, last)
 }
 
 // WaitForBondSlaveMIIDown polls until the given slave is MII-down, the bond is still up,
 // and at least one other slave remains MII-up (degraded but operational).
 func WaitForBondSlaveMIIDown(clientPod *pod.Builder, bondName, downSlave string) error {
-	deadline := time.Now().Add(BondActiveSlaveChangeTimeout)
+	var (
+		lastBondUp bool
+		lastSlaves map[string]string
+	)
 
-	var lastSlaves map[string]string
-
-	for {
+	for deadline := time.Now().Add(BondActiveSlaveChangeTimeout); time.Now().Before(deadline); time.Sleep(
+		BondActiveSlavePollInterval) {
 		bondUp, err := isBondInterfaceUp(clientPod, bondName)
 		if err != nil {
 			return err
@@ -180,29 +222,95 @@ func WaitForBondSlaveMIIDown(clientPod *pod.Builder, bondName, downSlave string)
 			return err
 		}
 
+		lastBondUp = bondUp
 		lastSlaves = slaves
 
 		if bondUp && slaves[downSlave] == "down" && countBondSlavesWithMII(slaves, "up") >= 1 {
 			return nil
 		}
+	}
 
-		if time.Now().After(deadline) {
-			return fmt.Errorf(
-				"bond %q did not stabilize with slave %q MII down within %v (bondUp=%t, slaves=%v)",
-				bondName, downSlave, BondActiveSlaveChangeTimeout, bondUp, lastSlaves)
+	return fmt.Errorf(
+		"bond %q did not stabilize with slave %q MII down within %v (bondUp=%t, slaves=%v)",
+		bondName, downSlave, BondActiveSlaveChangeTimeout, lastBondUp, lastSlaves)
+}
+
+// WaitForBondDegradedOneSlaveDown polls until the bond is up with at least one slave MII-down
+// and one MII-up.
+func WaitForBondDegradedOneSlaveDown(clientPod *pod.Builder, bondName string) error {
+	var (
+		lastStatus bondDegradedStatus
+		lastErr    error
+	)
+
+	for deadline := time.Now().Add(BondActiveSlaveChangeTimeout); time.Now().Before(deadline); time.Sleep(
+		BondActiveSlavePollInterval) {
+		status, err := checkBondDegradedOneSlaveDown(clientPod, bondName)
+		if err != nil {
+			lastErr = err
+
+			continue
 		}
 
-		time.Sleep(BondActiveSlavePollInterval)
+		lastErr = nil
+		lastStatus = status
+
+		if !status.degraded {
+			continue
+		}
+
+		return nil
 	}
+
+	if lastErr != nil {
+		return fmt.Errorf(
+			"bond %q did not degrade to at least one slave MII down within %v "+
+				"(bondUp=%t, slaves=%v, lastErr=%w)",
+			bondName, BondActiveSlaveChangeTimeout, lastStatus.bondUp, lastStatus.slaves, lastErr)
+	}
+
+	return fmt.Errorf(
+		"bond %q did not degrade to at least one slave MII down within %v (bondUp=%t, slaves=%v)",
+		bondName, BondActiveSlaveChangeTimeout, lastStatus.bondUp, lastStatus.slaves)
+}
+
+type bondDegradedStatus struct {
+	degraded bool
+	bondUp   bool
+	slaves   map[string]string
+}
+
+func checkBondDegradedOneSlaveDown(
+	clientPod *pod.Builder, bondName string,
+) (bondDegradedStatus, error) {
+	bondUp, err := isBondInterfaceUp(clientPod, bondName)
+	if err != nil {
+		return bondDegradedStatus{}, err
+	}
+
+	slaves, err := getBondSlaveMIIStatuses(clientPod, bondName)
+	if err != nil {
+		return bondDegradedStatus{bondUp: bondUp}, err
+	}
+
+	return bondDegradedStatus{
+		degraded: bondUp &&
+			countBondSlavesWithMII(slaves, "down") >= 1 &&
+			countBondSlavesWithMII(slaves, "up") >= 1,
+		bondUp: bondUp,
+		slaves: slaves,
+	}, nil
 }
 
 // WaitForBondSlavesMIIUp polls until all bond slaves report MII up and the bond is up.
 func WaitForBondSlavesMIIUp(clientPod *pod.Builder, bondName string) error {
-	deadline := time.Now().Add(BondActiveSlaveChangeTimeout)
+	var (
+		lastBondUp bool
+		lastSlaves map[string]string
+	)
 
-	var lastSlaves map[string]string
-
-	for {
+	for deadline := time.Now().Add(BondActiveSlaveChangeTimeout); time.Now().Before(deadline); time.Sleep(
+		BondActiveSlavePollInterval) {
 		bondUp, err := isBondInterfaceUp(clientPod, bondName)
 		if err != nil {
 			return err
@@ -213,6 +321,7 @@ func WaitForBondSlavesMIIUp(clientPod *pod.Builder, bondName string) error {
 			return err
 		}
 
+		lastBondUp = bondUp
 		lastSlaves = slaves
 
 		if bondUp &&
@@ -221,15 +330,11 @@ func WaitForBondSlavesMIIUp(clientPod *pod.Builder, bondName string) error {
 			countBondSlavesWithMII(slaves, "down") == 0 {
 			return nil
 		}
-
-		if time.Now().After(deadline) {
-			return fmt.Errorf(
-				"bond %q did not recover all slaves to MII up within %v (bondUp=%t, slaves=%v)",
-				bondName, BondActiveSlaveChangeTimeout, bondUp, lastSlaves)
-		}
-
-		time.Sleep(BondActiveSlavePollInterval)
 	}
+
+	return fmt.Errorf(
+		"bond %q did not recover all slaves to MII up within %v (bondUp=%t, slaves=%v)",
+		bondName, BondActiveSlaveChangeTimeout, lastBondUp, lastSlaves)
 }
 
 // SetLinkStatus sets a network interface operstate to up or down inside a pod.
@@ -240,6 +345,25 @@ func SetLinkStatus(podBuilder *pod.Builder, nic, status string) error {
 	}
 
 	return nil
+}
+
+// VerifyBondXmitHashPolicy checks sysfs xmit_hash_policy for the expected token (field match).
+func VerifyBondXmitHashPolicy(podBuilder *pod.Builder, bondName, expectedPolicy string) error {
+	out, err := podBuilder.ExecCommand([]string{"bash", "-c",
+		fmt.Sprintf("cat /sys/class/net/%s/bonding/xmit_hash_policy", bondName)})
+	if err != nil {
+		return fmt.Errorf("failed to read bond xmit_hash_policy: %w (out=%s)", err, out.String())
+	}
+
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	for _, field := range fields {
+		if field == expectedPolicy {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("bond xmit_hash_policy mismatch: expected %q, got %q",
+		expectedPolicy, strings.TrimSpace(out.String()))
 }
 
 // VerifyBondInterfaceState checks that the bond interface is up, has the expected mode, and slave count.
@@ -335,4 +459,170 @@ func countBondSlavesWithMII(slaves map[string]string, status string) int {
 	}
 
 	return count
+}
+
+// BondFunctionalPolicyNames is the policy name list used by SetupBondStack.
+var BondFunctionalPolicyNames = []string{
+	"bond-policy-pf1-mtu1280",
+	"bond-policy-pf1-mtu9000",
+	"bond-policy-pf2-mtu1280",
+	"bond-policy-pf2-mtu9000",
+}
+
+// BondStalePolicyNames is the cleanup list of current and prior bond policy names.
+var BondStalePolicyNames = []string{
+	"ipv4-policy-pf1-mtu500",
+	"ipv4-policy-pf1-mtu9000",
+	"ipv4-policy-pf2-mtu500",
+	"ipv4-policy-pf2-mtu9000",
+	"ipv6-policy-pf1-mtu1280",
+	"ipv6-policy-pf1-mtu9000",
+	"ipv6-policy-pf2-mtu1280",
+	"ipv6-policy-pf2-mtu9000",
+	"bond-policy-pf1-mtu1280",
+	"bond-policy-pf1-mtu9000",
+	"bond-policy-pf2-mtu1280",
+	"bond-policy-pf2-mtu9000",
+	"bond-policy-pf1-mtu1500",
+	"bond-policy-pf2-mtu1500",
+	"bond-scale-policy-pf1",
+	"bond-scale-policy-pf2",
+	"bond-scale-policy-pf1-ipv6",
+	"bond-scale-policy-pf2-ipv6",
+}
+
+// BondNetworkConfig is an SR-IOV network name and resource for a bond slave.
+type BondNetworkConfig struct {
+	Name     string
+	Resource string
+}
+
+// BondStackParams is the input for SetupBondStack.
+type BondStackParams struct {
+	PF1,
+	PF2 string
+	PF1NumVFs,
+	PF2NumVFs int
+	VFSmallStart,
+	VFSmallEnd,
+	VFLargeStart,
+	VFLargeEnd int
+	Networks       []BondNetworkConfig
+	DefaultMTUOnly bool // when true, create only MTU 1500 policies (Bond CNI xmitHashPolicy suite)
+}
+
+// SelectBondVFLayout returns VF ranges for shared 1280/9000 bond policies on each PF.
+func SelectBondVFLayout(minTotal int) (vfSmallEnd, vfLargeStart, vfLargeEnd int, ok bool) {
+	if minTotal < BondMinVFsPerPF {
+		return 0, 0, 0, false
+	}
+
+	switch {
+	case minTotal >= BondMinVFsStandardLayout:
+		// Standard layout: small MTU VFs 0-4, jumbo MTU VFs 5-9.
+		return 4, 5, 9, true
+	default:
+		// Five-VF layout: small MTU VFs 0-1, jumbo MTU VFs 2-4.
+		return 1, 2, 4, true
+	}
+}
+
+// SetupBondStack creates shared bond SR-IOV policies and slave networks, then waits for
+// SR-IOV/MCP stability after policy creation.
+func SetupBondStack(params BondStackParams) error {
+	type policySpec struct {
+		pfSuffix string
+		resource string
+		pf       string
+		numVFs   int
+		mtu      int
+		vfStart  int
+		vfEnd    int
+	}
+
+	policies := []policySpec{
+		{"pf1", BondResourcePF1Small, params.PF1, params.PF1NumVFs, BondMTU1280, params.VFSmallStart, params.VFSmallEnd},
+		{"pf1", BondResourcePF1Jumbo, params.PF1, params.PF1NumVFs, BondMTU9000, params.VFLargeStart, params.VFLargeEnd},
+		{"pf2", BondResourcePF2Small, params.PF2, params.PF2NumVFs, BondMTU1280, params.VFSmallStart, params.VFSmallEnd},
+		{"pf2", BondResourcePF2Jumbo, params.PF2, params.PF2NumVFs, BondMTU9000, params.VFLargeStart, params.VFLargeEnd},
+	}
+
+	if params.DefaultMTUOnly {
+		klog.Infof("Creating default-MTU (%d) SR-IOV bond policies only", BondMTUDefault)
+
+		policies = []policySpec{
+			{
+				"pf1", BondResourcePF1Default, params.PF1, params.PF1NumVFs,
+				BondMTUDefault, params.VFLargeStart, params.VFLargeEnd,
+			},
+			{
+				"pf2", BondResourcePF2Default, params.PF2, params.PF2NumVFs,
+				BondMTUDefault, params.VFLargeStart, params.VFLargeEnd,
+			},
+		}
+	}
+
+	for _, policy := range policies {
+		policyName := fmt.Sprintf("bond-policy-%s-mtu%d", policy.pfSuffix, policy.mtu)
+
+		if err := CreateSriovPolicy(
+			policyName, policy.resource, policy.pf, policy.mtu, policy.vfStart, policy.vfEnd, policy.numVFs,
+		); err != nil {
+			return fmt.Errorf("failed to create bond %s MTU%d policy: %w", policy.pfSuffix, policy.mtu, err)
+		}
+	}
+
+	if err := sriovoperator.WaitForSriovAndMCPStable(
+		APIClient, tsparams.MCOWaitTimeout, tsparams.DefaultStableDuration,
+		NetConfig.CnfMcpLabel, NetConfig.SriovOperatorNamespace); err != nil {
+		return fmt.Errorf("failed to wait for SR-IOV and MCP stability after bond policies: %w", err)
+	}
+
+	if err := CreateBondSlaveNetworks(params.Networks); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateBondSlaveNetworks creates bond slave SriovNetworks without IPAM.
+func CreateBondSlaveNetworks(configs []BondNetworkConfig) error {
+	for _, cfg := range configs {
+		if err := CreateSriovBondNetwork(cfg.Name, cfg.Resource); err != nil {
+			return fmt.Errorf("failed to create network %s: %w", cfg.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// DeleteBondSriovPolicies deletes the named SriovNetworkNodePolicies and waits for MCP to stabilize.
+func DeleteBondSriovPolicies(policyNames []string) error {
+	anyDeleted := false
+
+	for _, name := range policyNames {
+		policy, pullErr := sriov.PullPolicy(APIClient, name, NetConfig.SriovOperatorNamespace)
+		if pullErr != nil {
+			// eco-goinfra PullPolicy returns a custom "does not exist" error, not k8s NotFound.
+			if strings.Contains(pullErr.Error(), "does not exist") {
+				continue
+			}
+
+			return fmt.Errorf("failed to pull SR-IOV policy %s: %w", name, pullErr)
+		}
+
+		if err := policy.Delete(); err != nil {
+			return fmt.Errorf("failed to delete SR-IOV policy %s: %w", name, err)
+		}
+
+		anyDeleted = true
+	}
+
+	if !anyDeleted {
+		return nil
+	}
+
+	return sriovoperator.WaitForSriovAndMCPStable(
+		APIClient, tsparams.MCOWaitTimeout, tsparams.DefaultStableDuration,
+		NetConfig.CnfMcpLabel, NetConfig.SriovOperatorNamespace)
 }

--- a/tests/cnf/core/network/sriov/internal/tsparams/consts.go
+++ b/tests/cnf/core/network/sriov/internal/tsparams/consts.go
@@ -36,6 +36,8 @@ const (
 	LabelLACPTestCases = "lacp"
 	// LabelBondModeTestCases represents SR-IOV Bond CNI mode tests that can be used for test cases selection.
 	LabelBondModeTestCases = "bond-mode"
+	// LabelBondCNITestCases represents Bond CNI + switch LAG connectivity matrix tests.
+	LabelBondCNITestCases = "bond-cni"
 	// LabelOperatorConfigDefaultsTestCases represents SriovOperatorConfig default values tests
 	// that can be used for test cases selection.
 	LabelOperatorConfigDefaultsTestCases = "operatorconfig-defaults"

--- a/tests/cnf/core/network/sriov/tests/sriov-bond-cni.go
+++ b/tests/cnf/core/network/sriov/tests/sriov-bond-cni.go
@@ -1,0 +1,932 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nad"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/cmd"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/ipaddr"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netenv"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netparam"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/sriov/internal/sriovenv"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/sriov/internal/tsparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/sriovoperator"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// bondCNINADName is the Bond CNI NAD used by xmitHashPolicy cases.
+	bondCNINADName = "bond-cni-xor-nad"
+	// bondCNIListenerNetworkName is a static-IPAM SriovNetwork for single-VF listener pods.
+	bondCNIListenerNetworkName = "bond-cni-listener-vf"
+
+	// Shared dual-stack layout on 192.168.0.0/24 and 2001::/64 (suite secondary subnets):
+	// bonded client .10 / ::10; listener A .20/::20 + aliases .22/.23 and ::22/::23;
+	// listener B .21/::21 + aliases .24/.25 and ::24/::25.
+	// Per-host TCP listen ports: hostID 20→5000 … 25→5005 (port = 5000 + hostID - 20).
+	// IPv4 and IPv6 twins share a port (one testcmd listener covers both).
+	bondCNIIPv4Bond            = "192.168.0.10/24"
+	bondCNIIPv6Bond            = "2001::10/64"
+	bondCNIIPv4ListenerA       = "192.168.0.20/24"
+	bondCNIIPv6ListenerA       = "2001::20/64"
+	bondCNIIPv4ListenerB       = "192.168.0.21/24"
+	bondCNIIPv6ListenerB       = "2001::21/64"
+	bondCNIIPv4ListenerAAlias1 = "192.168.0.22/24"
+	bondCNIIPv6ListenerAAlias1 = "2001::22/64"
+	bondCNIIPv4ListenerAAlias2 = "192.168.0.23/24"
+	bondCNIIPv6ListenerAAlias2 = "2001::23/64"
+	bondCNIIPv4ListenerBAlias1 = "192.168.0.24/24"
+	bondCNIIPv6ListenerBAlias1 = "2001::24/64"
+	bondCNIIPv4ListenerBAlias2 = "192.168.0.25/24"
+	bondCNIIPv6ListenerBAlias2 = "2001::25/64"
+	bondCNITCPPortBase         = 5000
+	bondCNITCPPortOctetOffset  = 20
+	// bondCNIHashSkewPingCount is ICMP probes per dest for hash-skew TX measurement.
+	// Matches bondCNIHashSkewMinTX so one successful ping burst can mark a slave used.
+	bondCNIHashSkewPingCount = 10
+	// bondCNIHashSkewMinTX is the minimum per-dest TX delta on a slave to count that slave
+	// as used. Ignore small cross-slave noise (+1/+2) from ARP/ND that is not the hashed flow.
+	bondCNIHashSkewMinTX = 10
+	// bondCNIHashSkewAttempts is how many pool runs to allow before failing (TX-read flakes
+	// or an unlucky dest order that does not show both slaves).
+	bondCNIHashSkewAttempts = 2
+	// bondCNIHAPingMinTX is the minimum ICMP probes that must be sent during HA toggles
+	// so lost ≤ bondCNIHAPingMaxLoss is meaningful (ping is stopped when toggles finish).
+	bondCNIHAPingMinTX = 10
+	// bondCNIHAPingMaxLoss is the max lost ICMP probes allowed across the HA window
+	// (LAG/slave toggles while ping runs; ping is stopped when toggles finish).
+	bondCNIHAPingMaxLoss = 2
+
+	// Listener MACs with opposite last-byte parity so layer2 xmit hash
+	// (src[5]^dst[5])%2 maps the two peers to different bond slaves. Random VF MACs
+	// can collide (see 89648 failure: …:c1 and …:ef both odd → all TX on net1).
+	bondCNIListenerAMAC = "02:00:00:00:00:10"
+	bondCNIListenerBMAC = "02:00:00:00:00:11"
+)
+
+// DiffPF slave SriovNetwork names for Bond CNI (default-MTU resource pool).
+var bondCNINetworksV4DiffPF = []string{
+	"sriov-bond-cni-v4-diffpf-pf1",
+	"sriov-bond-cni-v4-diffpf-pf2",
+}
+
+// bondCNIHashSkewDestIPs is the dual-stack listener IP pool used for ICMP hash-skew
+// (89648 / 89649 / 89650). Walked until both bond slaves show TX >= bondCNIHashSkewMinTX.
+var bondCNIHashSkewDestIPs = []string{
+	bondCNIIPv4ListenerA,
+	bondCNIIPv6ListenerA,
+	bondCNIIPv4ListenerAAlias1,
+	bondCNIIPv6ListenerAAlias1,
+	bondCNIIPv4ListenerAAlias2,
+	bondCNIIPv6ListenerAAlias2,
+	bondCNIIPv4ListenerB,
+	bondCNIIPv6ListenerB,
+	bondCNIIPv4ListenerBAlias1,
+	bondCNIIPv6ListenerBAlias1,
+	bondCNIIPv4ListenerBAlias2,
+	bondCNIIPv6ListenerBAlias2,
+}
+
+var bondCNIListenerAIPs = []string{
+	bondCNIIPv4ListenerA,
+	bondCNIIPv6ListenerA,
+	bondCNIIPv4ListenerAAlias1,
+	bondCNIIPv6ListenerAAlias1,
+	bondCNIIPv4ListenerAAlias2,
+	bondCNIIPv6ListenerAAlias2,
+}
+
+var bondCNIListenerBIPs = []string{
+	bondCNIIPv4ListenerB,
+	bondCNIIPv6ListenerB,
+	bondCNIIPv4ListenerBAlias1,
+	bondCNIIPv6ListenerBAlias1,
+	bondCNIIPv4ListenerBAlias2,
+	bondCNIIPv6ListenerBAlias2,
+}
+
+// Lab switch LAG on worker0 PFs only (numLags=1); worker1 stays non-LAG'd for single-VF
+// listeners. Secondary Multus IPs are dual-stack (IPv4+IPv6); cluster dual-stack is not
+// required. Cases: balance-xor xmitHashPolicy layer2 / layer2+3 / layer3+4.
+var _ = Describe(
+	"Bond CNI xmitHashPolicy",
+	Ordered,
+	Label(tsparams.LabelSuite, tsparams.LabelBondCNITestCases),
+	ContinueOnFailure,
+	func() {
+		var (
+			workerNodeList []*nodes.Builder
+			worker0Name    string
+			worker1Name    string
+			pf1            string
+			pf2            string
+			err            error
+		)
+
+		BeforeAll(func() {
+			By("Verifying cluster has enough nodes")
+
+			err = netenv.DoesClusterHasEnoughNodes(APIClient, NetConfig, 1, 2)
+			Expect(err).ToNot(HaveOccurred(), "Cluster needs at least 2 worker nodes for Bond CNI LAG tests")
+
+			By("Discover and list worker nodes")
+
+			workerNodeList, err = nodes.List(
+				APIClient, metav1.ListOptions{LabelSelector: labels.Set(NetConfig.WorkerLabelMap).String()})
+			Expect(err).ToNot(HaveOccurred(), "Failed to list worker nodes")
+			Expect(len(workerNodeList)).To(BeNumerically(">=", 2), "Expected at least 2 worker nodes")
+
+			worker0Name = workerNodeList[0].Definition.Name
+			worker1Name = workerNodeList[1].Definition.Name
+
+			By("Validating SR-IOV interfaces exist on nodes")
+			Expect(sriovenv.ValidateSriovInterfaces(workerNodeList, 2)).ToNot(HaveOccurred(),
+				"Failed to get required SR-IOV interfaces")
+
+			sriovInterfaces, err := NetConfig.GetSriovInterfaces(2)
+			Expect(err).ToNot(HaveOccurred(), "Failed to retrieve SR-IOV interfaces for testing")
+
+			pf1 = sriovInterfaces[0]
+			pf2 = sriovInterfaces[1]
+
+			By("Removing stale bond SR-IOV policies from prior suite revisions")
+			Expect(sriovenv.DeleteBondSriovPolicies(sriovenv.BondStalePolicyNames)).To(Succeed(),
+				"Failed to remove stale bond SR-IOV policies")
+
+			// Default MTU only — DiffPF slaves + listener VF share the default resource pool.
+			// Policy defines VF count/range; no pre-check of device totalvfs.
+			By("Creating default-MTU SR-IOV policies and DiffPF bond slave networks")
+			Expect(sriovenv.SetupBondStack(sriovenv.BondStackParams{
+				PF1:            pf1,
+				PF2:            pf2,
+				PF1NumVFs:      sriovenv.BondMinVFsPerPF,
+				PF2NumVFs:      sriovenv.BondMinVFsPerPF,
+				VFLargeStart:   0,
+				VFLargeEnd:     sriovenv.BondMinVFsPerPF - 1,
+				DefaultMTUOnly: true,
+				Networks: []sriovenv.BondNetworkConfig{
+					{Name: bondCNINetworksV4DiffPF[0], Resource: sriovenv.BondResourcePF1Default},
+					{Name: bondCNINetworksV4DiffPF[1], Resource: sriovenv.BondResourcePF2Default},
+				},
+			})).To(Succeed(), "Failed to set up bond CNI SR-IOV stack")
+
+			By("Creating static-IPAM SR-IOV network for single-VF listener pods")
+			Expect(sriovenv.CreateSriovNetworkWithStaticIPAM(
+				bondCNIListenerNetworkName, sriovenv.BondResourcePF1Default)).
+				To(Succeed(), "Failed to create bond CNI listener VF network")
+
+			By("Configure static LAG on lab switch for worker0 bond PFs only")
+
+			// One LAG on worker0's two PF ports; worker1 listener ports stay non-LAG'd.
+			// Shared for all xmitHashPolicy cases — restore once in AfterAll.
+			err = setupBondSwitchLAG(1)
+			Expect(err).ToNot(HaveOccurred(), "Failed to configure static LAG on lab switch")
+
+			By(fmt.Sprintf(
+				"Bond CNI LAG topology: bonded-client=%s listeners=%s pf1=%s pf2=%s",
+				worker0Name, worker1Name, pf1, pf2))
+		})
+
+		AfterAll(func() {
+			restoreBondSwitchLAGAfterActiveActiveTest()
+
+			By("Removing SR-IOV configuration")
+
+			err = sriovoperator.RemoveSriovConfigurationAndWaitForSriovAndMCPStable(
+				APIClient,
+				NetConfig.WorkerLabelEnvVar,
+				NetConfig.SriovOperatorNamespace,
+				tsparams.MCOWaitTimeout,
+				tsparams.DefaultTimeout)
+			Expect(err).ToNot(HaveOccurred(), "Failed to remove SR-IOV configuration")
+		})
+
+		AfterEach(func() {
+			By("Deleting test pods and Bond CNI NADs")
+
+			err = namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
+				netparam.DefaultTimeout, pod.GetGVR(), nad.GetGVR())
+			Expect(err).ToNot(HaveOccurred(), "Failed to delete test pods and NADs")
+		})
+
+		It("Validate balance-xor with layer2 xmitHashPolicy", reportxml.ID("89648"), func() {
+			validateBondCNIBalanceXorXmitHashPolicy(
+				worker0Name, worker1Name, sriovenv.BondXmitHashPolicyLayer2)
+		})
+
+		It("Validate balance-xor with layer2+3 xmitHashPolicy", reportxml.ID("89649"), func() {
+			validateBondCNIBalanceXorXmitHashPolicy(
+				worker0Name, worker1Name, sriovenv.BondXmitHashPolicyLayer23)
+		})
+
+		It("Validate balance-xor with layer3+4 xmitHashPolicy", reportxml.ID("89650"), func() {
+			validateBondCNIBalanceXorXmitHashPolicy(
+				worker0Name, worker1Name, sriovenv.BondXmitHashPolicyLayer34)
+		})
+	})
+
+// validateBondCNIBalanceXorXmitHashPolicy deploys two listening single-VF pods (testcmd on net1)
+// and one DiffPF balance-xor bonded client. Egress is from bond0 so xmitHashPolicy applies.
+// Shared helper for layer2 / layer2+3 / layer3+4 (89648 / 89649 / 89650).
+// Secondary Multus addresses are dual-stack; cluster dual-stack is not required.
+// Flow: Create Bond → ICMP → TCP → ICMP hash skew → HA ping → re-skew.
+func validateBondCNIBalanceXorXmitHashPolicy(bondNode, listenerNode, xmitHashPolicy string) {
+	bondPod, _, _ := deployBondCNIXmitHashPolicyStack(
+		bondNode, listenerNode, xmitHashPolicy)
+
+	By(fmt.Sprintf(
+		"Verifying Bond CNI NAD has mode=%s and xmitHashPolicy=%s",
+		sriovenv.BondModeBalanceXOR, xmitHashPolicy))
+	assertBondCNINADConfig(bondCNINADName, sriovenv.BondModeBalanceXOR, xmitHashPolicy)
+
+	By("Verifying Multus network-status: bonded client has net1/net2/bond0 (dual-stack source IPs)")
+	verifyBondCNINetworkStatus(
+		bondPod,
+		bondCNINADName,
+		bondCNIAddrsWithoutPrefix([]string{bondCNIIPv4Bond, bondCNIIPv6Bond}),
+	)
+
+	By(fmt.Sprintf("Verifying bond xmit_hash_policy is %s", xmitHashPolicy))
+	Expect(sriovenv.VerifyBondXmitHashPolicy(
+		bondPod, sriovenv.BondInterfaceName, xmitHashPolicy)).
+		To(Succeed(), "Bond xmit_hash_policy mismatch")
+
+	By("Verifying bond interface state")
+	Expect(sriovenv.VerifyBondInterfaceState(
+		bondPod, sriovenv.BondInterfaceName, sriovenv.BondModeBalanceXOR, 2)).
+		To(Succeed(), "Bond interface state mismatch")
+
+	By("Verifying both bond slaves report MII up")
+	Expect(sriovenv.WaitForBondSlavesMIIUp(bondPod, sriovenv.BondInterfaceName)).
+		To(Succeed(), "Bond slaves not MII up")
+
+	hashSkewDests := bondCNIHashSkewDestIPs
+
+	icmpDests := make([]string, 0, len(hashSkewDests))
+	for _, dest := range hashSkewDests {
+		icmpDests = append(icmpDests, bondICMPDestination(dest))
+	}
+
+	By("Verifying ICMP connectivity over bond0 to all dual-stack listener IPs")
+	Expect(cmd.ICMPConnectivityCheck(bondPod, icmpDests, sriovenv.BondInterfaceName)).
+		To(Succeed(), "ICMP connectivity over bond0 failed")
+
+	By("Verifying TCP connectivity over bond0 to all dual-stack listener IPs")
+	Expect(verifyBondCNITCPConnectivity(bondPod, hashSkewDests, sriovenv.BondMTUDefault)).
+		To(Succeed(), "TCP connectivity over bond0 failed")
+
+	By(fmt.Sprintf(
+		"Verifying xmitHashPolicy=%s spreads ICMP egress across both bond slaves (dests=%v)",
+		xmitHashPolicy, hashSkewDests))
+	Expect(verifyBondCNIHashSkew(bondPod, hashSkewDests)).
+		To(Succeed(), "Bond hash skew across slaves failed")
+
+	By("Triggering LAG member failure during continuous ICMP and verifying little/no ping loss")
+	Expect(toggleSwitchPortsDuringBondCNIContinuousPing(
+		bondPod, bondCNIIPv4ListenerA)).
+		To(Succeed(), "Bond HA after LAG/slave failure failed")
+
+	By("Re-verifying xmitHashPolicy spreads ICMP egress across both bond slaves after HA")
+	Expect(verifyBondCNIHashSkew(bondPod, hashSkewDests)).
+		To(Succeed(), "Bond hash skew across slaves failed after HA")
+}
+
+// deployBondCNIXmitHashPolicyStack creates the Bond CNI NAD, one bonded egress pod, and two
+// listening pods with SR-IOV VFs. Caller relies on AfterEach for pod/NAD cleanup.
+func deployBondCNIXmitHashPolicyStack(
+	bondNode, listenerNode, xmitHashPolicy string,
+) (*pod.Builder, *pod.Builder, *pod.Builder) {
+	By(fmt.Sprintf("Creating balance-xor Bond CNI NAD with xmitHashPolicy=%s", xmitHashPolicy))
+	createBondCNINAD(bondCNINADName, xmitHashPolicy)
+
+	By(fmt.Sprintf("Creating listener A with testcmd on %s (MAC %s)", listenerNode, bondCNIListenerAMAC))
+	listenerA := createBondCNIListeningPod(
+		"server-pod-1",
+		listenerNode,
+		bondCNIListenerNetworkName,
+		bondCNIListenerAIPs,
+		bondCNIListenerAMAC,
+		sriovenv.BondMTUDefault,
+	)
+
+	By(fmt.Sprintf("Creating listener B with testcmd on %s (MAC %s)", listenerNode, bondCNIListenerBMAC))
+	listenerB := createBondCNIListeningPod(
+		"server-pod-2",
+		listenerNode,
+		bondCNIListenerNetworkName,
+		bondCNIListenerBIPs,
+		bondCNIListenerBMAC,
+		sriovenv.BondMTUDefault,
+	)
+
+	By(fmt.Sprintf("Creating bonded client on %s (DiffPF slaves, egress via bond0)", bondNode))
+	bondPod := createBondCNIBondedPod(
+		bondCNINADName,
+		"bond-cni-pod",
+		bondNode,
+		bondCNINetworksV4DiffPF,
+		[]string{bondCNIIPv4Bond, bondCNIIPv6Bond},
+	)
+
+	return bondPod, listenerA, listenerB
+}
+
+// createBondCNIBondedPod creates a privileged DiffPF bonded pod.
+func createBondCNIBondedPod(
+	nadName, podName, nodeName string,
+	slaveNetworks []string,
+	bondIPsWithCIDR []string,
+) *pod.Builder {
+	annotation := pod.StaticIPBondAnnotationWithInterface(
+		nadName,
+		sriovenv.BondInterfaceName,
+		slaveNetworks,
+		bondIPsWithCIDR,
+	)
+	Expect(annotation).NotTo(BeNil(), "Failed to create bond annotation for bonded pod")
+
+	bondPod, err := pod.NewBuilder(APIClient, podName, tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer).
+		DefineOnNode(nodeName).
+		WithPrivilegedFlag().
+		WithSecondaryNetwork(annotation).
+		CreateAndWaitUntilRunning(netparam.DefaultTimeout)
+	Expect(err).ToNot(HaveOccurred(), "Failed to create bonded pod")
+
+	Expect(sriovenv.WaitForBondSlavesMIIUp(bondPod, sriovenv.BondInterfaceName)).
+		To(Succeed(), "Bond slaves not MII up in pod %s", podName)
+
+	return bondPod
+}
+
+// createBondCNIListeningPod creates a single-VF pod that listens with testcmd on net1.
+func createBondCNIListeningPod(
+	podName, nodeName, networkName string,
+	ipRequests []string,
+	macAddress string,
+	mtu int,
+) *pod.Builder {
+	secNetwork := pod.StaticIPAnnotationWithMacAddress(networkName, ipRequests, macAddress)
+	Expect(secNetwork).NotTo(BeNil(), "Failed to build listener network annotation for %s", podName)
+
+	command := bondCNIListenerCommand(ipRequests, mtu)
+
+	container, err := pod.NewContainerBuilder("server", NetConfig.CnfNetTestContainer, command).GetContainerCfg()
+	Expect(err).ToNot(HaveOccurred(), "Failed to build listener container for %s", podName)
+
+	listenerPod, err := pod.NewBuilder(APIClient, podName, tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer).
+		DefineOnNode(nodeName).
+		RedefineDefaultContainer(*container).
+		WithPrivilegedFlag().
+		WithSecondaryNetwork(secNetwork).
+		CreateAndWaitUntilRunning(netparam.DefaultTimeout)
+	Expect(err).ToNot(HaveOccurred(), "Failed to create listening VF pod %s", podName)
+
+	Expect(sriovenv.WaitForServerReady(listenerPod, tsparams.WaitTimeout)).
+		To(Succeed(), "Listener testcmd not ready on pod %s", podName)
+
+	return listenerPod
+}
+
+// bondCNIAddrsWithoutPrefix returns RemovePrefix for each CIDR address.
+func bondCNIAddrsWithoutPrefix(addrsWithCIDR []string) []string {
+	out := make([]string, 0, len(addrsWithCIDR))
+	for _, addr := range addrsWithCIDR {
+		out = append(out, ipaddr.RemovePrefix(addr))
+	}
+
+	return out
+}
+
+// bondCNITCPPortForIP maps a listener address to its TCP listen port (5000 + hostID - 20).
+func bondCNITCPPortForIP(ipWithCIDR string) int {
+	host := ipaddr.RemovePrefix(ipWithCIDR)
+
+	var (
+		hostID int
+		err    error
+	)
+
+	if strings.Contains(host, ":") {
+		last := host
+		if i := strings.LastIndex(host, ":"); i >= 0 {
+			last = host[i+1:]
+		}
+
+		hostID, err = strconv.Atoi(last)
+		Expect(err).ToNot(HaveOccurred(), "failed to parse IPv6 host id from %q", host)
+	} else {
+		parts := strings.Split(host, ".")
+		Expect(parts).To(HaveLen(4), "expected IPv4 address, got %q", host)
+
+		hostID, err = strconv.Atoi(parts[3])
+		Expect(err).ToNot(HaveOccurred(), "failed to parse last octet of %q", host)
+	}
+
+	return bondCNITCPPortBase + hostID - bondCNITCPPortOctetOffset
+}
+
+// bondCNIListenerCommand starts a testcmd TCP listener per unique port on net1.
+func bondCNIListenerCommand(ipRequests []string, mtu int) []string {
+	packetSize := mtu - 100
+	portsSeen := map[int]bool{}
+
+	var listeners strings.Builder
+
+	for _, ipWithCIDR := range ipRequests {
+		port := bondCNITCPPortForIP(ipWithCIDR)
+		if portsSeen[port] {
+			continue
+		}
+
+		portsSeen[port] = true
+		fmt.Fprintf(&listeners,
+			"testcmd -listen -protocol tcp -port %d -interface %s -mtu %d & ",
+			port, tsparams.Net1Interface, packetSize)
+	}
+
+	listeners.WriteString("sleep infinity")
+
+	return []string{"bash", "-c", listeners.String()}
+}
+
+// createBondCNINAD creates a balance-xor Bond CNI NAD with the given xmitHashPolicy.
+func createBondCNINAD(nadName, xmitHashPolicy string) {
+	deleteBondNADBestEffort(nadName)
+
+	var (
+		bondBuilder *nad.Builder
+		err         error
+	)
+
+	bondBuilder, err = sriovenv.CreateBondNADWithXmitHashPolicy(
+		nadName, sriovenv.BondModeBalanceXOR, "static", sriovenv.BondMTUDefault, 2, xmitHashPolicy)
+	Expect(err).ToNot(HaveOccurred(), "Failed to build bond NAD %s with xmitHashPolicy %s",
+		nadName, xmitHashPolicy)
+
+	_, err = bondBuilder.Create()
+	Expect(err).ToNot(HaveOccurred(), "Failed to create bond NAD %s", nadName)
+}
+
+// assertBondCNINADConfig pulls the NAD and checks Spec.Config for bond mode and xmitHashPolicy.
+func assertBondCNINADConfig(nadName, expectedMode, expectedXmitHashPolicy string) {
+	pulled, err := nad.Pull(APIClient, nadName, tsparams.TestNamespaceName)
+	Expect(err).ToNot(HaveOccurred(), "Failed to pull bond NAD %s", nadName)
+	Expect(pulled.Definition.Spec.Config).NotTo(BeEmpty(), "Bond NAD %s has empty Spec.Config", nadName)
+
+	var cfg map[string]interface{}
+	Expect(json.Unmarshal([]byte(pulled.Definition.Spec.Config), &cfg)).
+		To(Succeed(), "Failed to unmarshal bond NAD %s Spec.Config: %s",
+			nadName, pulled.Definition.Spec.Config)
+
+	Expect(cfg["type"]).To(Equal("bond"), "Bond NAD %s type mismatch", nadName)
+	Expect(cfg["mode"]).To(Equal(expectedMode), "Bond NAD %s mode mismatch", nadName)
+	Expect(cfg["xmitHashPolicy"]).To(Equal(expectedXmitHashPolicy),
+		"Bond NAD %s xmitHashPolicy mismatch", nadName)
+}
+
+// bondCNINetworkStatusEntry is a minimal Multus network-status object for assertions.
+type bondCNINetworkStatusEntry struct {
+	Name      string   `json:"name"`
+	Interface string   `json:"interface"`
+	IPs       []string `json:"ips"`
+	Mac       string   `json:"mac"`
+}
+
+// parseBondCNINetworkStatus returns Multus network-status entries keyed by interface name.
+func parseBondCNINetworkStatus(podBuilder *pod.Builder) map[string]bondCNINetworkStatusEntry {
+	pulled, err := pod.Pull(APIClient, podBuilder.Definition.Name, podBuilder.Definition.Namespace)
+	Expect(err).ToNot(HaveOccurred(), "Failed to pull pod %s for network-status", podBuilder.Definition.Name)
+
+	annotation := pulled.Object.Annotations["k8s.v1.cni.cncf.io/network-status"]
+	Expect(annotation).NotTo(BeEmpty(), "Pod %s missing network-status annotation", pulled.Definition.Name)
+
+	var statuses []bondCNINetworkStatusEntry
+	Expect(json.Unmarshal([]byte(annotation), &statuses)).
+		To(Succeed(), "Failed to unmarshal network-status for pod %s: %s", pulled.Definition.Name, annotation)
+
+	By(fmt.Sprintf("network-status for %s: %s", pulled.Definition.Name, annotation))
+
+	ifaces := make(map[string]bondCNINetworkStatusEntry, len(statuses))
+	for _, status := range statuses {
+		if status.Interface != "" {
+			ifaces[status.Interface] = status
+		}
+	}
+
+	return ifaces
+}
+
+// networkStatusIPs returns host addresses from a network-status entry (strips CIDR if present).
+func networkStatusIPs(status bondCNINetworkStatusEntry) []string {
+	gotIPs := make([]string, 0, len(status.IPs))
+	for _, ipWithPrefix := range status.IPs {
+		gotIPs = append(gotIPs, strings.Split(ipWithPrefix, "/")[0])
+	}
+
+	return gotIPs
+}
+
+// verifyBondCNINetworkStatus asserts k8s.v1.cni.cncf.io/network-status after ADD includes
+// Multus-assigned slave interfaces (net1, net2) and bond0 with the expected IPs and NAD name.
+func verifyBondCNINetworkStatus(podBuilder *pod.Builder, bondNADName string, expectedBondIPs []string) {
+	ifaces := parseBondCNINetworkStatus(podBuilder)
+
+	Expect(ifaces).To(HaveKey(sriovenv.BondSlave1IfName),
+		"network-status missing slave interface %s", sriovenv.BondSlave1IfName)
+	Expect(ifaces).To(HaveKey(sriovenv.BondSlave2IfName),
+		"network-status missing slave interface %s", sriovenv.BondSlave2IfName)
+	Expect(ifaces).To(HaveKey(sriovenv.BondInterfaceName),
+		"network-status missing bond interface %s", sriovenv.BondInterfaceName)
+
+	bondStatus := ifaces[sriovenv.BondInterfaceName]
+	Expect(bondStatus.Name).To(ContainSubstring(bondNADName),
+		"bond network-status name %q should reference NAD %s", bondStatus.Name, bondNADName)
+	Expect(bondStatus.Mac).NotTo(BeEmpty(), "bond network-status missing MAC")
+
+	gotIPs := networkStatusIPs(bondStatus)
+	for _, expectedIP := range expectedBondIPs {
+		Expect(gotIPs).To(ContainElement(expectedIP),
+			"bond network-status IPs %v missing expected %s", gotIPs, expectedIP)
+	}
+}
+
+// bondCNITCPTestCmd builds the bond0→dest TCP testcmd used by TCP connectivity checks.
+func bondCNITCPTestCmd(destHost string, tcpPort, packetSize int) string {
+	return fmt.Sprintf("testcmd -protocol tcp -port %d -interface %s -server %s -mtu %d",
+		tcpPort, sriovenv.BondInterfaceName, destHost, packetSize)
+}
+
+// verifyBondCNITCPConnectivity runs testcmd TCP from bond0 to each dest's listen port.
+func verifyBondCNITCPConnectivity(bondPod *pod.Builder, destIPsWithCIDR []string, mtu int) error {
+	packetSize := mtu - 100
+
+	for _, dest := range destIPsWithCIDR {
+		host := ipaddr.RemovePrefix(dest)
+		tcpPort := bondCNITCPPortForIP(dest)
+
+		if err := sriovenv.RunProtocolTest(bondPod, "TCP",
+			bondCNITCPTestCmd(host, tcpPort, packetSize)); err != nil {
+			return fmt.Errorf("TCP to %s:%d failed: %w", host, tcpPort, err)
+		}
+	}
+
+	return nil
+}
+
+// verifyBondCNIHashSkew runs ICMP hash-skew until both bond slaves are used (net1 and
+// net2 TX >= bondCNIHashSkewMinTX for at least one dest each), stopping early once both
+// are seen. Retries up to bondCNIHashSkewAttempts if a full pool pass fails.
+func verifyBondCNIHashSkew(bondPod *pod.Builder, destIPsWithCIDR []string) error {
+	var lastErr error
+
+	for attempt := 1; attempt <= bondCNIHashSkewAttempts; attempt++ {
+		lastErr = checkBondCNIHashSkewAcrossSlaves(bondPod, destIPsWithCIDR)
+		if lastErr == nil {
+			if attempt > 1 {
+				klog.Infof("hash skew succeeded on attempt %d/%d", attempt, bondCNIHashSkewAttempts)
+			}
+
+			return nil
+		}
+
+		klog.Infof("hash skew attempt %d/%d failed: %v", attempt, bondCNIHashSkewAttempts, lastErr)
+	}
+
+	return fmt.Errorf("hash skew failed after %d attempts: %w", bondCNIHashSkewAttempts, lastErr)
+}
+
+// checkBondCNIHashSkewAcrossSlaves is one hash-skew pool walk (no retries).
+func checkBondCNIHashSkewAcrossSlaves(bondPod *pod.Builder, destIPsWithCIDR []string) error {
+	var usedNet1, usedNet2 bool
+
+	for _, dest := range destIPsWithCIDR {
+		deltaNet1, deltaNet2, err := measureBondCNIICMPSlaveTX(bondPod, dest)
+		if err != nil {
+			return err
+		}
+
+		usedNet1 = usedNet1 || deltaNet1 >= bondCNIHashSkewMinTX
+		usedNet2 = usedNet2 || deltaNet2 >= bondCNIHashSkewMinTX
+
+		if usedNet1 && usedNet2 {
+			return nil
+		}
+	}
+
+	return fmt.Errorf(
+		"xmitHashPolicy did not spread ICMP across both slaves with >=%d TX each "+
+			"(net1=%t net2=%t, dests=%v)",
+		bondCNIHashSkewMinTX, usedNet1, usedNet2, destIPsWithCIDR)
+}
+
+// measureBondCNIICMPSlaveTX pings dest from bond0 and returns net1/net2 TX deltas.
+func measureBondCNIICMPSlaveTX(
+	bondPod *pod.Builder, destWithCIDR string,
+) (deltaNet1, deltaNet2 uint64, err error) {
+	host := ipaddr.RemovePrefix(destWithCIDR)
+
+	txBeforeNet1, txBeforeNet2, err := getBondCNISlaveTXPackets(bondPod)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	pingCmd := fmt.Sprintf("ping -I %s -c %d -W 1 %s",
+		sriovenv.BondInterfaceName, bondCNIHashSkewPingCount, host)
+	if parsed := net.ParseIP(host); parsed != nil && parsed.To4() == nil {
+		pingCmd = fmt.Sprintf("ping -6 -I %s -c %d -W 1 %s",
+			sriovenv.BondInterfaceName, bondCNIHashSkewPingCount, host)
+	}
+
+	if out, pingErr := bondPod.ExecCommand([]string{"bash", "-c", pingCmd}); pingErr != nil {
+		return 0, 0, fmt.Errorf("ICMP to hash-skew dest %s failed: %w (out=%s)",
+			host, pingErr, out.String())
+	}
+
+	txAfterNet1, txAfterNet2, err := getBondCNISlaveTXPackets(bondPod)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	deltaNet1 = txDelta(txBeforeNet1, txAfterNet1)
+	deltaNet2 = txDelta(txBeforeNet2, txAfterNet2)
+
+	klog.V(90).Infof("hash skew ICMP %s: net1 TX %d->%d (+%d) net2 TX %d->%d (+%d) minTX=%d",
+		host, txBeforeNet1, txAfterNet1, deltaNet1,
+		txBeforeNet2, txAfterNet2, deltaNet2, bondCNIHashSkewMinTX)
+
+	return deltaNet1, deltaNet2, nil
+}
+
+// txDelta returns after-before, or 0 if the counter decreased (e.g. interface re-plumb).
+func txDelta(before, after uint64) uint64 {
+	if after < before {
+		return 0
+	}
+
+	return after - before
+}
+
+// getBondCNISlaveTXPackets reads net1 and net2 tx_packets from the bonded pod.
+func getBondCNISlaveTXPackets(podBuilder *pod.Builder) (net1TX, net2TX uint64, err error) {
+	net1TX, err = getBondCNIIfaceTXPackets(podBuilder, sriovenv.BondSlave1IfName)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	net2TX, err = getBondCNIIfaceTXPackets(podBuilder, sriovenv.BondSlave2IfName)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return net1TX, net2TX, nil
+}
+
+// getBondCNIIfaceTXPackets reads /sys/class/net/<iface>/statistics/tx_packets inside the pod.
+func getBondCNIIfaceTXPackets(podBuilder *pod.Builder, iface string) (uint64, error) {
+	out, err := podBuilder.ExecCommand([]string{"bash", "-c",
+		fmt.Sprintf("cat /sys/class/net/%s/statistics/tx_packets", iface)})
+	if err != nil {
+		return 0, fmt.Errorf("failed to read %s tx_packets: %w (out=%s)", iface, err, out.String())
+	}
+
+	count, err := strconv.ParseUint(strings.TrimSpace(out.String()), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse %s tx_packets %q: %w", iface, out.String(), err)
+	}
+
+	return count, nil
+}
+
+// toggleSwitchPortsDuringBondCNIContinuousPing toggles each switch LAG member during a continuous ping on bond0.
+func toggleSwitchPortsDuringBondCNIContinuousPing(bondPod *pod.Builder, listenerIP string) error {
+	if bondSwitchCredentials == nil || len(bondSwitchInterfaces) < 2 || len(bondSwitchLagNames) < 1 {
+		return fmt.Errorf("switch LAG not configured (need credentials, 2+ interfaces, LAG name)")
+	}
+
+	jnpr, err := cmd.NewSession(
+		bondSwitchCredentials.SwitchIP, bondSwitchCredentials.User, bondSwitchCredentials.Password)
+	if err != nil {
+		return err
+	}
+	defer jnpr.Close()
+
+	disable := func(iface string) error {
+		return jnpr.Config([]string{fmt.Sprintf("set interfaces %s disable", iface)})
+	}
+	enable := func(iface string) error {
+		return jnpr.Config([]string{fmt.Sprintf("delete interfaces %s disable", iface)})
+	}
+
+	if err := startBondCNIHAContinuousPing(bondPod, listenerIP); err != nil {
+		return err
+	}
+
+	// Give the first probes a moment to start before the first disable.
+	time.Sleep(2 * time.Second)
+
+	if err := cycleSwitchPortDuringBondCNIHAPing(
+		bondPod, jnpr, bondSwitchInterfaces[0], disable, enable); err != nil {
+		return err
+	}
+
+	if err := cycleSwitchPortDuringBondCNIHAPing(
+		bondPod, jnpr, bondSwitchInterfaces[1], disable, enable); err != nil {
+		return err
+	}
+
+	return collectBondCNIHAContinuousPing(bondPod)
+}
+
+// restoreBondCNISwitchPortBestEffort tries to re-enable a switch port after a failed HA step.
+func restoreBondCNISwitchPortBestEffort(enable func(string) error, iface string) {
+	if restoreErr := enable(iface); restoreErr != nil {
+		klog.Warningf("best-effort switch restore failed for %s: %v", iface, restoreErr)
+	}
+}
+
+// cycleSwitchPortDuringBondCNIHAPing disables one switch LAG member, waits for bond degrade,
+// re-enables it, waits for the switch port up, then waits for both slaves MII up.
+func cycleSwitchPortDuringBondCNIHAPing(
+	bondPod *pod.Builder,
+	jnpr *cmd.Junos,
+	port string,
+	disable, enable func(string) error,
+) error {
+	if err := disable(port); err != nil {
+		_ = collectBondCNIHAContinuousPing(bondPod)
+
+		return fmt.Errorf("failed to disable switch interface %s: %w", port, err)
+	}
+
+	if err := sriovenv.WaitForBondDegradedOneSlaveDown(bondPod, sriovenv.BondInterfaceName); err != nil {
+		restoreBondCNISwitchPortBestEffort(enable, port)
+
+		_ = collectBondCNIHAContinuousPing(bondPod)
+
+		return fmt.Errorf("bond did not degrade after disabling %s: %w", port, err)
+	}
+
+	if err := enable(port); err != nil {
+		restoreBondCNISwitchPortBestEffort(enable, port)
+
+		_ = collectBondCNIHAContinuousPing(bondPod)
+
+		return fmt.Errorf("failed to re-enable switch interface %s: %w", port, err)
+	}
+
+	if err := waitForSwitchInterfaceUp(jnpr, port, time.Minute); err != nil {
+		_ = collectBondCNIHAContinuousPing(bondPod)
+
+		return err
+	}
+
+	if err := sriovenv.WaitForBondSlavesMIIUp(bondPod, sriovenv.BondInterfaceName); err != nil {
+		_ = collectBondCNIHAContinuousPing(bondPod)
+
+		return fmt.Errorf("bond did not recover after re-enabling %s: %w", port, err)
+	}
+
+	return nil
+}
+
+const (
+	bondCNIHAPingOutFile  = "/tmp/bond-cni-ha-ping.out"
+	bondCNIHAPingDoneFile = "/tmp/bond-cni-ha-ping.done"
+	bondCNIHAPingPIDFile  = "/tmp/bond-cni-ha-ping.pid"
+)
+
+// startBondCNIHAContinuousPing launches an unbounded ping on bond0 in the background.
+func startBondCNIHAContinuousPing(bondPod *pod.Builder, listenerIP string) error {
+	dest := ipaddr.RemovePrefix(listenerIP)
+	cmdLine := fmt.Sprintf(
+		"rm -f %s %s %s; "+
+			"nohup bash -c '"+
+			"ping -I %s -W 1 %s > %s 2>&1 & "+
+			"echo $! > %s; "+
+			"wait $!; "+
+			"touch %s"+
+			"' >/dev/null 2>&1 & "+
+			// Poll briefly: the wrapper writes the PID file asynchronously.
+			"for _ in $(seq 1 50); do "+
+			"if test -s %s && kill -0 \"$(cat %s)\" 2>/dev/null; then exit 0; fi; "+
+			"sleep 0.1; "+
+			"done; "+
+			"exit 1",
+		bondCNIHAPingOutFile, bondCNIHAPingDoneFile, bondCNIHAPingPIDFile,
+		sriovenv.BondInterfaceName, dest, bondCNIHAPingOutFile,
+		bondCNIHAPingPIDFile,
+		bondCNIHAPingDoneFile,
+		bondCNIHAPingPIDFile, bondCNIHAPingPIDFile)
+
+	if _, err := bondPod.ExecCommand([]string{"bash", "-c", cmdLine}); err != nil {
+		return fmt.Errorf("failed to start continuous HA ping: %w", err)
+	}
+
+	return nil
+}
+
+// collectBondCNIHAContinuousPing stops the background ping by PID (SIGINT so it prints a
+// summary), waits for the wrapper to mark done, and asserts loss stays within limits.
+func collectBondCNIHAContinuousPing(bondPod *pod.Builder) error {
+	// Interrupt only the ping PID; the wrapper waits on it then touches the done file.
+	_, _ = bondPod.ExecCommand([]string{"bash", "-c",
+		fmt.Sprintf(
+			"if test -s %s; then kill -INT \"$(cat %s)\" 2>/dev/null || true; fi",
+			bondCNIHAPingPIDFile, bondCNIHAPingPIDFile)})
+
+	deadline := time.Now().Add(30 * time.Second)
+
+	for {
+		out, err := bondPod.ExecCommand([]string{"bash", "-c",
+			fmt.Sprintf("test -f %s && echo done || echo wait", bondCNIHAPingDoneFile)})
+		if err == nil && strings.Contains(out.String(), "done") {
+			break
+		}
+
+		if time.Now().After(deadline) {
+			_, _ = bondPod.ExecCommand([]string{"bash", "-c",
+				fmt.Sprintf(
+					"if test -s %s; then kill -KILL \"$(cat %s)\" 2>/dev/null || true; fi; touch %s",
+					bondCNIHAPingPIDFile, bondCNIHAPingPIDFile, bondCNIHAPingDoneFile)})
+
+			partial, _ := bondPod.ExecCommand([]string{"bash", "-c",
+				fmt.Sprintf("cat %s 2>/dev/null || echo '(no ping output yet)'", bondCNIHAPingOutFile)})
+
+			return fmt.Errorf("continuous HA ping did not finish within 30s after stop; partial out:\n%s",
+				partial.String())
+		}
+
+		time.Sleep(tsparams.NADWaitTimeout)
+	}
+
+	out, err := bondPod.ExecCommand([]string{"bash", "-c", "cat " + bondCNIHAPingOutFile})
+	if err != nil {
+		return fmt.Errorf("failed to read continuous HA ping output: %w", err)
+	}
+
+	pingOut := out.String()
+
+	transmitted, received, lost, parseErr := parsePingPacketCounts(pingOut)
+	if parseErr != nil {
+		return fmt.Errorf("failed to parse continuous HA ping output: %w (out=%s)", parseErr, pingOut)
+	}
+
+	klog.Infof("Bond CNI HA continuous ping: transmitted=%d received=%d lost=%d (minTX=%d maxAllowed=%d)",
+		transmitted, received, lost, bondCNIHAPingMinTX, bondCNIHAPingMaxLoss)
+
+	if transmitted < bondCNIHAPingMinTX {
+		return fmt.Errorf(
+			"continuous HA ping sent too few probes: tx=%d minRequired=%d (rx=%d lost=%d)\n%s",
+			transmitted, bondCNIHAPingMinTX, received, lost, pingOut)
+	}
+
+	if lost > bondCNIHAPingMaxLoss {
+		return fmt.Errorf(
+			"continuous HA ping loss too high: lost=%d maxAllowed=%d (tx=%d rx=%d)\n%s",
+			lost, bondCNIHAPingMaxLoss, transmitted, received, pingOut)
+	}
+
+	return nil
+}
+
+var pingPacketCountRE = regexp.MustCompile(
+	`(\d+)\s+packets transmitted,\s+(\d+)\s+received`)
+
+// parsePingPacketCounts extracts transmitted/received/lost from ping summary output.
+func parsePingPacketCounts(output string) (transmitted, received, lost int, err error) {
+	match := pingPacketCountRE.FindStringSubmatch(output)
+	if match == nil {
+		return 0, 0, 0, fmt.Errorf("no ping summary line found")
+	}
+
+	transmitted, err = strconv.Atoi(match[1])
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	received, err = strconv.Atoi(match[2])
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	if received > transmitted {
+		received = transmitted
+	}
+
+	return transmitted, received, transmitted - received, nil
+}

--- a/tests/cnf/core/network/sriov/tests/sriov-bond-mode.go
+++ b/tests/cnf/core/network/sriov/tests/sriov-bond-mode.go
@@ -33,20 +33,7 @@ import (
 const (
 	bondNADName = "sriov-bond-nad"
 
-	mtu1280 = 1280
-	mtu9000 = 9000
-
-	// SR-IOV policy resourceNames for bond tests (PF1/PF2 × small/jumbo MTU; shared by IPv4 and IPv6).
-	bondResourcePF1Small = "sriovbondpf1mtu1280"
-	bondResourcePF1Jumbo = "sriovbondpf1mtu9000"
-	bondResourcePF2Small = "sriovbondpf2mtu1280"
-	bondResourcePF2Jumbo = "sriovbondpf2mtu9000"
-
-	// bondMinVFsPerPF is the minimum total VFs per PF for bond tests on Mellanox and other five-VF devices.
-	bondMinVFsPerPF = 5
-	// bondMinVFsStandardLayout is the minimum total VFs per PF for the standard small/jumbo VF split.
-	bondMinVFsStandardLayout = 10
-	// bondMinSwitchInterfaces is the number of physical switch ports used for static LAG setup.
+	// bondMinSwitchInterfaces is the number of physical switch ports in NetConfig for LAG setup.
 	bondMinSwitchInterfaces = 4
 )
 
@@ -131,43 +118,45 @@ var _ = Describe(
 				minTotal = pf2Total
 			}
 
-			if minTotal < bondMinVFsPerPF {
+			if minTotal < sriovenv.BondMinVFsPerPF {
 				Skip(fmt.Sprintf(
 					"Bond tests require >=%d VFs per PF on every worker; min across workers: pf1=%d, pf2=%d",
-					bondMinVFsPerPF, pf1Total, pf2Total))
+					sriovenv.BondMinVFsPerPF, pf1Total, pf2Total))
 			}
 
-			vfSmallEnd, vfLargeStart, vfLargeEnd, layoutOK := selectBondVFLayout(minTotal)
+			vfSmallEnd, vfLargeStart, vfLargeEnd, layoutOK := sriovenv.SelectBondVFLayout(minTotal)
 			Expect(layoutOK).To(BeTrue(), "Failed to select bond VF layout")
 
 			bondNetworks := bondSlaveNetworkConfigs(
 				bondNetworksV4DiffPFSmall, bondNetworksV4DiffPFJumbo,
 				bondNetworksV4SamePFSmall, bondNetworksV4SamePFJumbo,
-				bondResourcePF1Small, bondResourcePF1Jumbo,
-				bondResourcePF2Small, bondResourcePF2Jumbo,
+				sriovenv.BondResourcePF1Small, sriovenv.BondResourcePF1Jumbo,
+				sriovenv.BondResourcePF2Small, sriovenv.BondResourcePF2Jumbo,
 			)
 			bondNetworks = append(bondNetworks, bondSlaveNetworkConfigs(
 				bondNetworksV6DiffPFSmall, bondNetworksV6DiffPFJumbo,
 				bondNetworksV6SamePFSmall, bondNetworksV6SamePFJumbo,
-				bondResourcePF1Small, bondResourcePF1Jumbo,
-				bondResourcePF2Small, bondResourcePF2Jumbo,
+				sriovenv.BondResourcePF1Small, sriovenv.BondResourcePF1Jumbo,
+				sriovenv.BondResourcePF2Small, sriovenv.BondResourcePF2Jumbo,
 			)...)
 
 			By("Removing stale bond SR-IOV policies from prior suite revisions")
 
-			Expect(cleanupStaleBondSriovPolicies()).To(Succeed(), "Failed to remove stale bond SR-IOV policies")
+			Expect(sriovenv.DeleteBondSriovPolicies(sriovenv.BondStalePolicyNames)).To(Succeed(),
+				"Failed to remove stale bond SR-IOV policies")
 
-			setupBondStack(bondStackParams{
-				pf1:          pf1,
-				pf2:          pf2,
-				pf1NumVFs:    pf1NumVFs,
-				pf2NumVFs:    pf2NumVFs,
-				vfSmallStart: 0,
-				vfSmallEnd:   vfSmallEnd,
-				vfLargeStart: vfLargeStart,
-				vfLargeEnd:   vfLargeEnd,
-				networks:     bondNetworks,
-			})
+			By("Creating shared SR-IOV policies and networks for bond tests")
+			Expect(sriovenv.SetupBondStack(sriovenv.BondStackParams{
+				PF1:          pf1,
+				PF2:          pf2,
+				PF1NumVFs:    pf1NumVFs,
+				PF2NumVFs:    pf2NumVFs,
+				VFSmallStart: 0,
+				VFSmallEnd:   vfSmallEnd,
+				VFLargeStart: vfLargeStart,
+				VFLargeEnd:   vfLargeEnd,
+				Networks:     bondNetworks,
+			})).To(Succeed(), "Failed to set up bond SR-IOV stack")
 		})
 
 		AfterAll(func() {
@@ -211,7 +200,7 @@ var _ = Describe(
 
 				runBondScenario(
 					sriovenv.BondModeActiveBackup,
-					mtu1280, mtu9000,
+					sriovenv.BondMTU1280, sriovenv.BondMTU9000,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					bondNetworksV4DiffPFSmall, bondNetworksV4DiffPFJumbo,
 					staticBondIPs(
@@ -228,7 +217,7 @@ var _ = Describe(
 
 				runBondScenario(
 					sriovenv.BondModeActiveBackup,
-					mtu1280, mtu9000,
+					sriovenv.BondMTU1280, sriovenv.BondMTU9000,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					bondNetworksV4SamePFSmall, bondNetworksV4SamePFJumbo,
 					staticBondIPs(
@@ -245,7 +234,7 @@ var _ = Describe(
 
 				runBondScenario(
 					sriovenv.BondModeActiveBackup,
-					mtu1280, mtu9000,
+					sriovenv.BondMTU1280, sriovenv.BondMTU9000,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					bondNetworksV6DiffPFSmall, bondNetworksV6DiffPFJumbo,
 					staticBondIPs(
@@ -262,7 +251,7 @@ var _ = Describe(
 
 				runBondScenario(
 					sriovenv.BondModeActiveBackup,
-					mtu1280, mtu9000,
+					sriovenv.BondMTU1280, sriovenv.BondMTU9000,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					bondNetworksV6SamePFSmall, bondNetworksV6SamePFJumbo,
 					staticBondIPs(
@@ -279,7 +268,7 @@ var _ = Describe(
 
 				runBondScenario(
 					sriovenv.BondModeActiveBackup,
-					mtu1280, mtu9000,
+					sriovenv.BondMTU1280, sriovenv.BondMTU9000,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					bondNetworksV6DiffPFSmall, bondNetworksV6DiffPFJumbo,
 					whereaboutsBondIPs(),
@@ -293,7 +282,7 @@ var _ = Describe(
 
 				runBondScenario(
 					sriovenv.BondModeActiveBackup,
-					mtu1280, mtu9000,
+					sriovenv.BondMTU1280, sriovenv.BondMTU9000,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					bondNetworksV6SamePFSmall, bondNetworksV6SamePFJumbo,
 					whereaboutsBondIPs(),
@@ -321,7 +310,7 @@ var _ = Describe(
 
 				runBondScenario(
 					sriovenv.BondModeBalanceRR,
-					mtu1280, mtu9000,
+					sriovenv.BondMTU1280, sriovenv.BondMTU9000,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					bondNetworksV4DiffPFSmall, bondNetworksV4DiffPFJumbo,
 					staticBondIPs(
@@ -338,7 +327,7 @@ var _ = Describe(
 
 				runBondScenario(
 					sriovenv.BondModeBalanceXOR,
-					mtu1280, mtu9000,
+					sriovenv.BondMTU1280, sriovenv.BondMTU9000,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					bondNetworksV4DiffPFSmall, bondNetworksV4DiffPFJumbo,
 					staticBondIPs(
@@ -355,7 +344,7 @@ var _ = Describe(
 
 				runBondScenario(
 					sriovenv.BondModeBalanceRR,
-					mtu1280, mtu9000,
+					sriovenv.BondMTU1280, sriovenv.BondMTU9000,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					bondNetworksV6DiffPFSmall, bondNetworksV6DiffPFJumbo,
 					staticBondIPs(
@@ -372,7 +361,7 @@ var _ = Describe(
 
 				runBondScenario(
 					sriovenv.BondModeBalanceXOR,
-					mtu1280, mtu9000,
+					sriovenv.BondMTU1280, sriovenv.BondMTU9000,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					bondNetworksV6DiffPFSmall, bondNetworksV6DiffPFJumbo,
 					staticBondIPs(
@@ -450,14 +439,14 @@ var _ = Describe(
 
 				By("Removing functional bond SR-IOV policies before scale setup")
 
-				Expect(deleteBondSriovPolicies(bondFunctionalPolicyNames)).To(Succeed(),
+				Expect(sriovenv.DeleteBondSriovPolicies(sriovenv.BondFunctionalPolicyNames)).To(Succeed(),
 					"Failed to remove functional bond SR-IOV policies before scale tests")
 
 				By("Creating shared SR-IOV policies and networks for 16-VF scale tests")
 
 				// Match functional policy NumVfs (PF total across workers) so scale setup does not
 				// change configured VF count after removing functional policies.
-				createBondScalePolicies(mtu1280, 0, pf1Total, pf2Total)
+				createBondScalePolicies(sriovenv.BondMTU1280, 0, pf1Total, pf2Total)
 
 				err = sriovenv.CreateSriovBondNetwork(scaleNetA, scaleResA)
 				Expect(err).ToNot(HaveOccurred(), "Failed to create scale SR-IOV network A")
@@ -535,7 +524,7 @@ var _ = Describe(
 
 				runBondScaleICMPTest(
 					scaleBondNADIPv4, scaleNetA, scaleNetB,
-					mtu1280,
+					sriovenv.BondMTU1280,
 					tsparams.ServerIPv4IPAddress, tsparams.ClientIPv4IPAddress, "/32",
 				)
 			})
@@ -547,7 +536,7 @@ var _ = Describe(
 
 				runBondScaleICMPTest(
 					scaleBondNADIPv6, scaleNetA, scaleNetB,
-					mtu1280,
+					sriovenv.BondMTU1280,
 					tsparams.ServerIPv6IPAddress, tsparams.ClientIPv6IPAddress, "/128",
 				)
 			})
@@ -821,132 +810,6 @@ func createBondedPodsPair(
 	return serverPod, clientPod
 }
 
-// bondNetworkConfig describes a single SR-IOV network for bond slave creation.
-type bondNetworkConfig struct {
-	name,
-	resource string
-}
-
-type bondStackParams struct {
-	pf1,
-	pf2 string
-	pf1NumVFs,
-	pf2NumVFs int
-	vfSmallStart,
-	vfSmallEnd,
-	vfLargeStart,
-	vfLargeEnd int
-	networks []bondNetworkConfig
-}
-
-// bondFunctionalPolicyNames are the shared MTU-split policies created by setupBondStack.
-var bondFunctionalPolicyNames = []string{
-	"bond-policy-pf1-mtu1280",
-	"bond-policy-pf1-mtu9000",
-	"bond-policy-pf2-mtu1280",
-	"bond-policy-pf2-mtu9000",
-}
-
-// bondSriovPolicyNames lists bond suite policy names from current and prior revisions.
-var bondSriovPolicyNames = []string{
-	"ipv4-policy-pf1-mtu500",
-	"ipv4-policy-pf1-mtu9000",
-	"ipv4-policy-pf2-mtu500",
-	"ipv4-policy-pf2-mtu9000",
-	"ipv6-policy-pf1-mtu1280",
-	"ipv6-policy-pf1-mtu9000",
-	"ipv6-policy-pf2-mtu1280",
-	"ipv6-policy-pf2-mtu9000",
-	"bond-policy-pf1-mtu1280",
-	"bond-policy-pf1-mtu9000",
-	"bond-policy-pf2-mtu1280",
-	"bond-policy-pf2-mtu9000",
-	"bond-scale-policy-pf1",
-	"bond-scale-policy-pf2",
-	"bond-scale-policy-pf1-ipv6",
-	"bond-scale-policy-pf2-ipv6",
-}
-
-func deleteBondSriovPolicies(policyNames []string) error {
-	deleted := false
-
-	for _, name := range policyNames {
-		policy, pullErr := sriov.PullPolicy(APIClient, name, NetConfig.SriovOperatorNamespace)
-		if pullErr != nil {
-			continue
-		}
-
-		if err := policy.Delete(); err != nil {
-			return fmt.Errorf("failed to delete SR-IOV policy %s: %w", name, err)
-		}
-
-		deleted = true
-	}
-
-	if !deleted {
-		return nil
-	}
-
-	return sriovoperator.WaitForSriovAndMCPStable(
-		APIClient, tsparams.MCOWaitTimeout, tsparams.DefaultStableDuration,
-		NetConfig.CnfMcpLabel, NetConfig.SriovOperatorNamespace)
-}
-
-func cleanupStaleBondSriovPolicies() error {
-	return deleteBondSriovPolicies(bondSriovPolicyNames)
-}
-
-// selectBondVFLayout returns VF ranges for shared 1280/9000 bond policies on each PF.
-func selectBondVFLayout(minTotal int) (vfSmallEnd, vfLargeStart, vfLargeEnd int, ok bool) {
-	if minTotal < bondMinVFsPerPF {
-		return 0, 0, 0, false
-	}
-
-	switch {
-	case minTotal >= bondMinVFsStandardLayout:
-		// Standard layout: small MTU VFs 0-4, jumbo MTU VFs 5-9.
-		return 4, 5, 9, true
-	default:
-		// Five-VF layout: small MTU VFs 0-1, jumbo MTU VFs 2-4.
-		return 1, 2, 4, true
-	}
-}
-
-func setupBondStack(params bondStackParams) {
-	By("Creating shared SR-IOV policies and networks for bond tests")
-
-	policies := []struct {
-		pfSuffix string
-		resource string
-		pf       string
-		numVFs   int
-		mtu      int
-		vfStart  int
-		vfEnd    int
-	}{
-		{"pf1", bondResourcePF1Small, params.pf1, params.pf1NumVFs, mtu1280, params.vfSmallStart, params.vfSmallEnd},
-		{"pf1", bondResourcePF1Jumbo, params.pf1, params.pf1NumVFs, mtu9000, params.vfLargeStart, params.vfLargeEnd},
-		{"pf2", bondResourcePF2Small, params.pf2, params.pf2NumVFs, mtu1280, params.vfSmallStart, params.vfSmallEnd},
-		{"pf2", bondResourcePF2Jumbo, params.pf2, params.pf2NumVFs, mtu9000, params.vfLargeStart, params.vfLargeEnd},
-	}
-
-	for _, policy := range policies {
-		policyName := fmt.Sprintf("bond-policy-%s-mtu%d", policy.pfSuffix, policy.mtu)
-
-		Expect(sriovenv.CreateSriovPolicy(
-			policyName, policy.resource, policy.pf, policy.mtu, policy.vfStart, policy.vfEnd, policy.numVFs,
-		)).To(Succeed(), "Failed to create bond %s MTU%d policy", policy.pfSuffix, policy.mtu)
-	}
-
-	Expect(sriovoperator.WaitForSriovAndMCPStable(
-		APIClient, tsparams.MCOWaitTimeout, tsparams.DefaultStableDuration,
-		NetConfig.CnfMcpLabel, NetConfig.SriovOperatorNamespace)).
-		To(Succeed(), "Failed to wait for SR-IOV and MCP stability after bond policies")
-
-	Expect(createBondSlaveNetworks(params.networks)).
-		To(Succeed(), "Failed to create bond slave networks")
-}
-
 func bondSlaveNetworkConfigs(
 	diffPFSmall,
 	diffPFJumbo,
@@ -956,28 +819,17 @@ func bondSlaveNetworkConfigs(
 	resPF1Jumbo,
 	resPF2Small,
 	resPF2Jumbo string,
-) []bondNetworkConfig {
-	return []bondNetworkConfig{
-		{name: diffPFSmall[0], resource: resPF1Small},
-		{name: diffPFJumbo[0], resource: resPF1Jumbo},
-		{name: diffPFSmall[1], resource: resPF2Small},
-		{name: diffPFJumbo[1], resource: resPF2Jumbo},
-		{name: samePFSmall[0], resource: resPF1Small},
-		{name: samePFSmall[1], resource: resPF1Small},
-		{name: samePFJumbo[0], resource: resPF1Jumbo},
-		{name: samePFJumbo[1], resource: resPF1Jumbo},
+) []sriovenv.BondNetworkConfig {
+	return []sriovenv.BondNetworkConfig{
+		{Name: diffPFSmall[0], Resource: resPF1Small},
+		{Name: diffPFJumbo[0], Resource: resPF1Jumbo},
+		{Name: diffPFSmall[1], Resource: resPF2Small},
+		{Name: diffPFJumbo[1], Resource: resPF2Jumbo},
+		{Name: samePFSmall[0], Resource: resPF1Small},
+		{Name: samePFSmall[1], Resource: resPF1Small},
+		{Name: samePFJumbo[0], Resource: resPF1Jumbo},
+		{Name: samePFJumbo[1], Resource: resPF1Jumbo},
 	}
-}
-
-// createBondSlaveNetworks creates bond slave SriovNetworks without IPAM (Trust on, SpoofChk off, LinkState auto).
-func createBondSlaveNetworks(configs []bondNetworkConfig) error {
-	for _, cfg := range configs {
-		if err := sriovenv.CreateSriovBondNetwork(cfg.name, cfg.resource); err != nil {
-			return fmt.Errorf("failed to create network %s: %w", cfg.name, err)
-		}
-	}
-
-	return nil
 }
 
 func bondICMPDestination(serverIPWithCIDR string) string {
@@ -1196,7 +1048,7 @@ func bondNADNamesForCleanup() []string {
 		sriovenv.BondModeBalanceRR,
 		sriovenv.BondModeBalanceXOR,
 	}
-	mtus := []int{mtu1280, mtu9000}
+	mtus := []int{sriovenv.BondMTU1280, sriovenv.BondMTU9000}
 
 	seen := make(map[string]struct{})
 
@@ -1227,7 +1079,14 @@ func bondNADNamesForCleanup() []string {
 	return names
 }
 
-func setupBondSwitchLAGForActiveActiveTests() error {
+// setupBondSwitchLAG configures numLags static switch LAGs (2 ports each) from NetConfig.
+func setupBondSwitchLAG(numLags int) error {
+	if numLags < 1 {
+		return fmt.Errorf("numLags must be >= 1, got %d", numLags)
+	}
+
+	needPorts := 2 * numLags
+
 	var err error
 
 	if bondSwitchCredentials == nil {
@@ -1252,12 +1111,20 @@ func setupBondSwitchLAGForActiveActiveTests() error {
 		return fmt.Errorf("switch LAG names: %w", err)
 	}
 
+	if len(bondSwitchLagNames) < numLags {
+		return fmt.Errorf("need at least %d switch LAG name(s), got %d", numLags, len(bondSwitchLagNames))
+	}
+
+	bondSwitchInterfaces = bondSwitchInterfaces[:needPorts]
+	bondSwitchLagNames = bondSwitchLagNames[:numLags]
+
 	nativeVLAN, err := NetConfig.GetNativeVLANID()
 	if err != nil {
 		return fmt.Errorf("native VLAN: %w", err)
 	}
 
-	klog.Infof("Bond switch LAG native VLAN %d", nativeVLAN)
+	klog.Infof("Bond switch LAG native VLAN %d (lags=%v ports=%v)",
+		nativeVLAN, bondSwitchLagNames, bondSwitchInterfaces)
 
 	bondSwitchSavedConfigs, err = configureStaticLAGsOnSwitch(
 		bondSwitchCredentials, bondSwitchInterfaces, bondSwitchLagNames)
@@ -1278,6 +1145,10 @@ func setupBondSwitchLAGForActiveActiveTests() error {
 	klog.Infof("Configured static switch LAGs %v on ports %v", bondSwitchLagNames, bondSwitchInterfaces)
 
 	return nil
+}
+
+func setupBondSwitchLAGForActiveActiveTests() error {
+	return setupBondSwitchLAG(2)
 }
 
 func restoreBondSwitchLAGAfterActiveActiveTest() {
@@ -1313,18 +1184,19 @@ func bondStaticLAGCleanupCommands(physicalInterfaces, lagInterfaces []string) []
 	return cleanupCommands
 }
 
-// configureStaticLAGsOnSwitch mirrors cnf-gotests configureLAGsOnSwitch: wipe the four physical
-// ports, create two static (non-LACP) 802.3ad LAGs, and trunk lab VLANs on each ae.
+// configureStaticLAGsOnSwitch mirrors cnf-gotests configureLAGsOnSwitch: wipe the physical
+// ports, create static (non-LACP) 802.3ad LAGs, and trunk lab VLANs on each ae.
 func configureStaticLAGsOnSwitch(
 	credentials *sriovenv.SwitchCredentials,
 	physicalInterfaces, lagInterfaces []string,
 ) ([]string, error) {
-	if len(physicalInterfaces) != bondMinSwitchInterfaces {
-		return nil, fmt.Errorf("need %d switch interfaces, got %d", bondMinSwitchInterfaces, len(physicalInterfaces))
+	if len(lagInterfaces) < 1 {
+		return nil, fmt.Errorf("need at least 1 switch LAG name, got %d", len(lagInterfaces))
 	}
 
-	if len(lagInterfaces) != 2 {
-		return nil, fmt.Errorf("need 2 switch LAG names, got %d", len(lagInterfaces))
+	if len(physicalInterfaces) != 2*len(lagInterfaces) {
+		return nil, fmt.Errorf("need %d switch interfaces for %d LAG(s), got %d",
+			2*len(lagInterfaces), len(lagInterfaces), len(physicalInterfaces))
 	}
 
 	jnpr, err := cmd.NewSession(credentials.SwitchIP, credentials.User, credentials.Password)
@@ -1353,15 +1225,13 @@ func configureStaticLAGsOnSwitch(
 			fmt.Errorf("native VLAN: %w", err))
 	}
 
-	lagMembers := [][2]string{
-		{physicalInterfaces[0], physicalInterfaces[1]},
-		{physicalInterfaces[2], physicalInterfaces[3]},
-	}
-
 	var configureCommands []string
 
 	for idx, lagInterface := range lagInterfaces {
-		for _, physicalInterface := range lagMembers[idx] {
+		memberA := physicalInterfaces[idx*2]
+		memberB := physicalInterfaces[idx*2+1]
+
+		for _, physicalInterface := range []string{memberA, memberB} {
 			configureCommands = append(configureCommands,
 				fmt.Sprintf("set interfaces %s ether-options 802.3ad %s", physicalInterface, lagInterface))
 		}
@@ -1449,7 +1319,7 @@ func bondWhereaboutsIPAMForMTU(mtu int) (ipRange, gateway string) {
 	ipRange = tsparams.WhereaboutsIPv6Range
 	gateway = tsparams.WhereaboutsIPv6Gateway
 
-	if mtu >= mtu9000 {
+	if mtu >= sriovenv.BondMTU9000 {
 		ipRange = tsparams.WhereaboutsIPv6Range2
 		gateway = tsparams.WhereaboutsIPv6Gateway2
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Bond CNI switch-LAG coverage for dual-stack balance-XOR bonds with layer 2, layer 2+3, and layer 3+4 transmit-hash policies.
  * Validates network readiness, connectivity, traffic distribution, continuous ping stability, and failover behavior.
  * Improved retry, probing, packet-loss, and recovery checks for more reliable results.
* **New Features**
  * Added dedicated Bond CNI test selection.
  * Improved bond setup, policy verification, resource layout selection, and cleanup.
  * Expanded switch-LAG configuration and interface failover support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->