### PR TITLE
cnf network: fix bgpunnumbered afterAll

### DIFF
--- a/tests/cnf/core/network/metallb/tests/bgp-unnumbered.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-unnumbered.go
@@ -110,17 +110,27 @@ var _ = Describe("BGP Unnumbered", Ordered, Label(tsparams.LabelBGPUnnumbered),
 			By("Remove custom MetalLB test label from nodes")
 			removeNodeLabel(workerNodeList, metalLbTestsLabel)
 
-			By(fmt.Sprintf("Resetting ethernet interface %s on worker node %s",
-				interfacesUnderTest[0], workerNodeList[0].Definition.Name))
-			ethIntWorker0Policy := nmstate.NewPolicyBuilder(APIClient, nodeNetConfigPolicyName, NetConfig.WorkerLabelMap).
-				WithEthernetDualStackInterface(interfacesUnderTest[0])
-			err := netnmstate.UpdatePolicyAndWaitUntilItsAvailable(netparam.DefaultTimeout, ethIntWorker0Policy)
-			Expect(err).ToNot(HaveOccurred(), "Failed to update NMState network policy")
+			// Leave the PF up on the setup node.
+			// Do not use absent — that leaves the PF down after NNCP deletion and breaks later suites.
+			// Capture the error so CleanAllNMStatePolicies still runs if restore fails.
+			var restoreErr error
+
+			if len(interfacesUnderTest) > 0 && len(workerNodeList) > 0 {
+				By(fmt.Sprintf("Restoring ethernet interface %s on worker node %s",
+					interfacesUnderTest[0], workerNodeList[0].Definition.Name))
+				ethIntWorker0Policy := nmstate.NewPolicyBuilder(APIClient, nodeNetConfigPolicyName,
+					map[string]string{corev1.LabelHostname: workerNodeList[0].Definition.Name}).
+					WithInterfaceUp(interfacesUnderTest[0])
+				restoreErr = netnmstate.UpdatePolicyAndWaitUntilItsAvailable(
+					netparam.DefaultTimeout, ethIntWorker0Policy)
+			}
 
 			By("Removing NMState policies")
 
-			err = nmstate.CleanAllNMStatePolicies(APIClient)
-			Expect(err).ToNot(HaveOccurred(), "Failed to remove all NMState policies")
+			cleanErr := nmstate.CleanAllNMStatePolicies(APIClient)
+
+			Expect(restoreErr).ToNot(HaveOccurred(), "Failed to restore ethernet interface via NMState policy")
+			Expect(cleanErr).ToNot(HaveOccurred(), "Failed to remove all NMState policies")
 
 			By("Clean MetalLB operator and test namespaces")
 			resetOperatorAndTestNS()

--- a/tests/cnf/core/network/metallb/tests/bgp-unnumbered.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-unnumbered.go
@@ -110,17 +110,27 @@ var _ = Describe("BGP Unnumbered", Ordered, Label(tsparams.LabelBGPUnnumbered),
 			By("Remove custom MetalLB test label from nodes")
 			removeNodeLabel(workerNodeList, metalLbTestsLabel)
 
-			By(fmt.Sprintf("Disabling ethernet interface %s on worker node %s",
-				interfacesUnderTest[0], workerNodeList[0].Definition.Name))
-			ethIntWorker0Policy := nmstate.NewPolicyBuilder(APIClient, nodeNetConfigPolicyName, NetConfig.WorkerLabelMap).
-				WithAbsentInterface(interfacesUnderTest[0])
-			err := netnmstate.UpdatePolicyAndWaitUntilItsAvailable(netparam.DefaultTimeout, ethIntWorker0Policy)
-			Expect(err).ToNot(HaveOccurred(), "Failed to update NMState network policy")
+			// Leave the PF up on the setup node.
+			// Do not use absent — that leaves the PF down after NNCP deletion and breaks later suites.
+			// Capture the error so CleanAllNMStatePolicies still runs if restore fails.
+			var restoreErr error
+
+			if len(interfacesUnderTest) > 0 && len(workerNodeList) > 0 {
+				By(fmt.Sprintf("Restoring ethernet interface %s on worker node %s",
+					interfacesUnderTest[0], workerNodeList[0].Definition.Name))
+				ethIntWorker0Policy := nmstate.NewPolicyBuilder(APIClient, nodeNetConfigPolicyName,
+					map[string]string{corev1.LabelHostname: workerNodeList[0].Definition.Name}).
+					WithInterfaceUp(interfacesUnderTest[0])
+				restoreErr = netnmstate.UpdatePolicyAndWaitUntilItsAvailable(
+					netparam.DefaultTimeout, ethIntWorker0Policy)
+			}
 
 			By("Removing NMState policies")
 
-			err = nmstate.CleanAllNMStatePolicies(APIClient)
-			Expect(err).ToNot(HaveOccurred(), "Failed to remove all NMState policies")
+			cleanErr := nmstate.CleanAllNMStatePolicies(APIClient)
+
+			Expect(restoreErr).ToNot(HaveOccurred(), "Failed to restore ethernet interface via NMState policy")
+			Expect(cleanErr).ToNot(HaveOccurred(), "Failed to remove all NMState policies")
 
 			By("Clean MetalLB operator and test namespaces")
 			resetOperatorAndTestNS()


### PR DESCRIPTION
BGP Unnumbered intentionally “disabled” ECO_CNF_CORE_NET_SRIOV_INTERFACE_LIST[0] in teardown. Deleting the NNCP does not undo that apply, so the PF stayed down for subsequent tests in the same job/cluster. This cleanup has existed since the suite was added (#571); the failure shows up as cross-suite pollution, not a regression inside BGP Unnumbered itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup after BGP Unnumbered network tests by restoring the worker’s Ethernet interface to an active state.
  * Ensured network policies are removed even when interface restoration encounters an error.
  * Reported interface restoration and policy cleanup errors separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->