### PR TITLE
[4.20]network: fix unnumbered test cleanup

### DIFF
--- a/tests/cnf/core/network/metallb/tests/bgp-unnumbered.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-unnumbered.go
@@ -89,10 +89,10 @@ var _ = Describe("BGP Unnumbered", Ordered, Label(tsparams.LabelBGPUnnumbered),
 			By("Remove custom MetalLB test label from nodes")
 			removeNodeLabel(workerNodeList, metalLbTestsLabel)
 
-			By(fmt.Sprintf("Disabling ethernet interface %s on worker node %s",
+			By(fmt.Sprintf("Resetting ethernet interface %s on worker node %s",
 				interfacesUnderTest[0], workerNodeList[0].Definition.Name))
 			ethIntWorker0Policy := nmstate.NewPolicyBuilder(APIClient, nodeNetConfigPolicyName, NetConfig.WorkerLabelMap).
-				WithAbsentInterface(interfacesUnderTest[0])
+				WithEthernetDualStackInterface(interfacesUnderTest[0])
 			err := netnmstate.UpdatePolicyAndWaitUntilItsAvailable(netparam.DefaultTimeout, ethIntWorker0Policy)
 			Expect(err).ToNot(HaveOccurred(), "Failed to update NMState network policy")
 


### PR DESCRIPTION
Backport https://github.com/rh-ecosystem-edge/eco-gotests/pull/1559

Fixes the BGP unnumbered test `AfterAll` cleanup to reset the ethernet interface instead of removing it. Previously, the cleanup used `WithAbsentInterface` which would disable/delete the interface entirely, potentially leaving the node in an unhealthy network state for subsequent tests. The fix switches to `WithEthernetDualStackInterface`, which restores the interface to its default dual-stack configuration.
