### PR TITLE
Add support for latest-rhel-10 tag for DTK

### DIFF
--- a/tests/hw-accel/kmm/1bmc/bmc_suite_test.go
+++ b/tests/hw-accel/kmm/1bmc/bmc_suite_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/serviceaccount"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/1bmc/internal/tsparams"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/define"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/get"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/kmmparams"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/reporter"
@@ -77,10 +78,12 @@ var _ = BeforeSuite(func() {
 		Skip(fmt.Sprintf("Error listing worker nodes. Got error: '%v'", err))
 	}
 
+	dtkImage := get.LocalDTKImage(APIClient, GeneralConfig.WorkerLabelMap)
+
 	for _, node := range nodeList {
 		deploymentName := fmt.Sprintf("%s-%s", kmmparams.KmmTestHelperLabelName, node.Object.Name)
 
-		containerCfg, err := pod.NewContainerBuilder("test", kmmparams.DTKImage,
+		containerCfg, err := pod.NewContainerBuilder("test", dtkImage,
 			[]string{"/bin/bash", "-c", "sleep INF"}).
 			WithSecurityContext(kmmparams.PrivilegedSC).
 			WithVolumeMount(corev1.VolumeMount{Name: "host", MountPath: "/host", ReadOnly: false}).

--- a/tests/hw-accel/kmm/1bmc/tests/bmc-firmware-test.go
+++ b/tests/hw-accel/kmm/1bmc/tests/bmc-firmware-test.go
@@ -111,7 +111,8 @@ var _ = Describe("KMM-BMC-Firmware", Ordered, Label(kmmparams.LabelSuite, kmmpar
 
 				By("Create ConfigMap with firmware module Dockerfile")
 
-				configmapContents := define.SimpleKmodFirmwareConfigMapContents()
+				dtkImage := get.LocalDTKImage(APIClient, GeneralConfig.WorkerLabelMap)
+				configmapContents := define.SimpleKmodFirmwareConfigMapContents(dtkImage)
 				dockerfileConfigMap, err := configmap.NewBuilder(APIClient,
 					tsparams.FirmwareModuleName, tsparams.FirmwareBuildNamespace).
 					WithData(configmapContents).Create()

--- a/tests/hw-accel/kmm/1upgrade/tests/upgrade-test.go
+++ b/tests/hw-accel/kmm/1upgrade/tests/upgrade-test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -17,6 +18,7 @@ import (
 	kmmawait "github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/await"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/check"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/define"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/get"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/kmminittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/kmmparams"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
@@ -47,9 +49,10 @@ var _ = Describe("KMM", Ordered, Label(tsparams.LabelSuite), func() {
 				Skip("No UpgradeTargetVersion defined. Skipping test")
 			}
 
-			// Skip module deployment for KMM-HUB since Module CRD is not available on hub cluster
-			// The test will still run to verify operator upgrade, just without module deployment
-			if check.IsKMMHub() {
+			kernelVersion, _ := get.KernelFullVersion(APIClient, GeneralConfig.WorkerLabelMap)
+
+			// Skip module deployment for KMM-HUB (no Module CRD) or RHEL 10 kernels
+			if check.IsKMMHub() || strings.HasPrefix(kernelVersion, "6.") {
 				return
 			}
 
@@ -61,7 +64,8 @@ var _ = Describe("KMM", Ordered, Label(tsparams.LabelSuite), func() {
 			// Deploy a simple module to verify upgrade behavior with existing modules
 			By("Create ConfigMap for module build")
 
-			configmapContents := define.SimpleKmodConfigMapContents()
+			dtkImage := get.LocalDTKImage(APIClient, GeneralConfig.WorkerLabelMap)
+			configmapContents := define.SimpleKmodConfigMapContents(dtkImage)
 			dockerfileConfigMap, err := configmap.
 				NewBuilder(APIClient, kmodName, upgradeTestNamespace).
 				WithData(configmapContents).Create()
@@ -119,8 +123,9 @@ var _ = Describe("KMM", Ordered, Label(tsparams.LabelSuite), func() {
 		})
 
 		AfterAll(func() {
-			// Skip cleanup for KMM-HUB since no resources were created (test was skipped)
-			if check.IsKMMHub() {
+			kernelVersion, _ := get.KernelFullVersion(APIClient, GeneralConfig.WorkerLabelMap)
+
+			if check.IsKMMHub() || strings.HasPrefix(kernelVersion, "6.") {
 				return
 			}
 
@@ -200,8 +205,10 @@ var _ = Describe("KMM", Ordered, Label(tsparams.LabelSuite), func() {
 
 			err = await.OperatorUpgrade(APIClient, ModulesConfig.UpgradeTargetVersion, 5*time.Minute)
 			Expect(err).ToNot(HaveOccurred(), "failed awaiting subscription upgrade")
-			// Skip module verification for KMM-HUB since no module was deployed on hub
-			if !check.IsKMMHub() {
+
+			kernelVersion, _ := get.KernelFullVersion(APIClient, GeneralConfig.WorkerLabelMap)
+
+			if !check.IsKMMHub() && !strings.HasPrefix(kernelVersion, "6.") {
 				By("Check module label is still set on nodes after upgrade")
 
 				_, err = check.NodeLabel(APIClient, moduleName, upgradeTestNamespace,

--- a/tests/hw-accel/kmm/internal/define/configmap.go
+++ b/tests/hw-accel/kmm/internal/define/configmap.go
@@ -49,23 +49,42 @@ func UserDtkMultiStateConfigMapContents(module, dtkImage string) map[string]stri
 }
 
 // SimpleKmodConfigMapContents returns the configmap for simple-kmod example.
-func SimpleKmodConfigMapContents() map[string]string {
-	configmapContents := map[string]string{"dockerfile": kmmparams.SimpleKmodContents}
+func SimpleKmodConfigMapContents(dtkImage string) map[string]string {
+	data := map[string]interface{}{
+		"DTKImage": dtkImage,
+	}
 
-	return configmapContents
+	templateInstance := template.Must(template.New("contents").Parse(kmmparams.SimpleKmodContents))
+	builder := &strings.Builder{}
+
+	if err := templateInstance.Execute(builder, data); err != nil {
+		panic(err)
+	}
+
+	return map[string]string{"dockerfile": builder.String()}
 }
 
 // SimpleKmodFirmwareConfigMapContents returns the configmap for simple-kmod-firmware example.
-func SimpleKmodFirmwareConfigMapContents() map[string]string {
-	configmapContents := map[string]string{"dockerfile": kmmparams.SimpleKmodFirmwareContents}
+func SimpleKmodFirmwareConfigMapContents(dtkImage string) map[string]string {
+	data := map[string]interface{}{
+		"DTKImage": dtkImage,
+	}
 
-	return configmapContents
+	templateInstance := template.Must(template.New("contents").Parse(kmmparams.SimpleKmodFirmwareContents))
+	builder := &strings.Builder{}
+
+	if err := templateInstance.Execute(builder, data); err != nil {
+		panic(err)
+	}
+
+	return map[string]string{"dockerfile": builder.String()}
 }
 
 // LocalMultiStageConfigMapContent returns the configmap multi-stage contents for a specified module name.
-func LocalMultiStageConfigMapContent(module string) map[string]string {
+func LocalMultiStageConfigMapContent(module, dtkImage string) map[string]string {
 	data := map[string]interface{}{
-		"Module": module,
+		"Module":   module,
+		"DTKImage": dtkImage,
 	}
 
 	templateInstance := template.Must(template.New("contents").Parse(kmmparams.LocalMultiStageContents))
@@ -90,11 +109,33 @@ func KmmScannerConfigMapContents() map[string]string {
 }
 
 // MultiKoConfigMapContent returns the configmap contents for building 3 kernel modules.
-func MultiKoConfigMapContent() map[string]string {
-	return map[string]string{"dockerfile": kmmparams.MultiKoContents}
+func MultiKoConfigMapContent(dtkImage string) map[string]string {
+	data := map[string]interface{}{
+		"DTKImage": dtkImage,
+	}
+
+	templateInstance := template.Must(template.New("contents").Parse(kmmparams.MultiKoContents))
+	builder := &strings.Builder{}
+
+	if err := templateInstance.Execute(builder, data); err != nil {
+		panic(err)
+	}
+
+	return map[string]string{"dockerfile": builder.String()}
 }
 
 // MultiKoCustomDirConfigMapContent returns the configmap contents for building 3 kernel modules under /custom.
-func MultiKoCustomDirConfigMapContent() map[string]string {
-	return map[string]string{"dockerfile": kmmparams.MultiKoCustomDirContents}
+func MultiKoCustomDirConfigMapContent(dtkImage string) map[string]string {
+	data := map[string]interface{}{
+		"DTKImage": dtkImage,
+	}
+
+	templateInstance := template.Must(template.New("contents").Parse(kmmparams.MultiKoCustomDirContents))
+	builder := &strings.Builder{}
+
+	if err := templateInstance.Execute(builder, data); err != nil {
+		panic(err)
+	}
+
+	return map[string]string{"dockerfile": builder.String()}
 }

--- a/tests/hw-accel/kmm/internal/get/get.go
+++ b/tests/hw-accel/kmm/internal/get/get.go
@@ -253,19 +253,50 @@ func KmmHubOperatorVersion(apiClient *clients.Settings) (ver *version.Version, e
 	return operatorVersion(apiClient, "hub", kmmparams.KmmHubOperatorNamespace)
 }
 
-// DTKImage returns the DockerImage of the drivertoolkit imagestream.
-func DTKImage(apiClient *clients.Settings) (dtkImage string, err error) {
+// DTKImageStreamTag returns the imagestream tag to use for the DTK image based on kernel version.
+// RHEL 10 kernels (starting with "6.") use the "latest-rhel-10" tag.
+func DTKImageStreamTag(kernelVersion string) string {
+	if strings.HasPrefix(kernelVersion, "6.") {
+		return "latest-rhel-10"
+	}
+
+	return "latest"
+}
+
+// LocalDTKImage returns the internal registry DTK image with the correct tag for the cluster's kernel.
+func LocalDTKImage(apiClient *clients.Settings, nodeSelector map[string]string) string {
+	kernelVersion, err := KernelFullVersion(apiClient, nodeSelector)
+	if err != nil {
+		klog.V(kmmparams.KmmLogLevel).Infof("Could not determine kernel version for DTK tag, using default: %v", err)
+
+		return kmmparams.DTKImage
+	}
+
+	tag := DTKImageStreamTag(kernelVersion)
+
+	return fmt.Sprintf("%s:%s", kmmparams.DTKImage, tag)
+}
+
+// DTKImage returns the DockerImage of the drivertoolkit imagestream using the correct tag for the kernel.
+func DTKImage(apiClient *clients.Settings, nodeSelector map[string]string) (dtkImage string, err error) {
+	kernelVersion, err := KernelFullVersion(apiClient, nodeSelector)
+	if err != nil {
+		return "", fmt.Errorf("failed to get kernel version for DTK tag selection: %w", err)
+	}
+
+	tag := DTKImageStreamTag(kernelVersion)
+
 	dtkIS, err := imagestream.Pull(apiClient, kmmparams.DTKImageStream, kmmparams.DTKImageStreamNamespace)
 	if err != nil {
 		return "", err
 	}
 
-	dtkImage, err = dtkIS.GetDockerImage("latest")
+	dtkImage, err = dtkIS.GetDockerImage(tag)
 	if err != nil {
 		return "", err
 	}
 
-	klog.V(kmmparams.KmmLogLevel).Infof("DTK Image: %s", dtkImage)
+	klog.V(kmmparams.KmmLogLevel).Infof("DTK Image (tag=%s): %s", tag, dtkImage)
 
 	return dtkImage, nil
 }

--- a/tests/hw-accel/kmm/internal/kmmparams/const.go
+++ b/tests/hw-accel/kmm/internal/kmmparams/const.go
@@ -60,8 +60,7 @@ COPY --from=builder /build/kmm-kmod/*.ko /opt/lib/modules/${KERNEL_VERSION}/
 RUN depmod -b /opt ${KERNEL_VERSION}
 `
 	// SimpleKmodContents represents the Dockerfile contents for simple-kmod build.
-	SimpleKmodContents = `ARG DTK_AUTO
-FROM ${DTK_AUTO} as builder
+	SimpleKmodContents = `FROM {{.DTKImage}} as builder
 ARG KERNEL_VERSION
 ARG KMODVER
 WORKDIR /build/
@@ -94,8 +93,7 @@ RUN depmod -b /opt ${KERNEL_VERSION}
 }
 `
 	// SimpleKmodFirmwareContents represents the Dockerfile contents for simple-kmod-firmware build.
-	SimpleKmodFirmwareContents = `ARG DTK_AUTO
-FROM ${DTK_AUTO} as builder
+	SimpleKmodFirmwareContents = `FROM {{.DTKImage}} as builder
 ARG KERNEL_FULL_VERSION
 ARG MOD_NAME
 ARG MOD_NAMESPACE
@@ -122,7 +120,7 @@ RUN mkdir /firmware
 RUN echo -n "simple_kmod_firmware validation string" >> /firmware/simple_kmod_firmware.bin
 `
 	// LocalMultiStageContents represents the Dockerfile contents for multi stage build using local registry.
-	LocalMultiStageContents = `FROM image-registry.openshift-image-registry.svc:5000/openshift/driver-toolkit as builder
+	LocalMultiStageContents = `FROM {{.DTKImage}} as builder
 ARG KERNEL_FULL_VERSION
 ARG MOD_NAME
 WORKDIR /build
@@ -142,8 +140,7 @@ RUN depmod -b /opt ${KERNEL_FULL_VERSION}
 `
 
 	// MultiKoContents represents the Dockerfile for building 3 kernel modules for glob signing tests.
-	MultiKoContents = `ARG DTK_AUTO
-FROM ${DTK_AUTO} as builder
+	MultiKoContents = `FROM {{.DTKImage}} as builder
 ARG KERNEL_VERSION
 WORKDIR /build
 RUN git clone https://github.com/cdvultur/kmm-kmod.git
@@ -162,8 +159,7 @@ RUN depmod -b /opt ${KERNEL_VERSION}
 `
 
 	// MultiKoCustomDirContents represents the Dockerfile for building 3 kernel modules under /custom dir.
-	MultiKoCustomDirContents = `ARG DTK_AUTO
-FROM ${DTK_AUTO} as builder
+	MultiKoCustomDirContents = `FROM {{.DTKImage}} as builder
 ARG KERNEL_VERSION
 WORKDIR /build
 RUN git clone https://github.com/cdvultur/kmm-kmod.git

--- a/tests/hw-accel/kmm/mcm/mcm_suite_test.go
+++ b/tests/hw-accel/kmm/mcm/mcm_suite_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/serviceaccount"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/define"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/get"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/kmmparams"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -79,11 +80,13 @@ var _ = BeforeSuite(func() {
 		Skip(fmt.Sprintf("Error listing worker nodes. Got error: '%v'", err))
 	}
 
+	dtkImage := get.LocalDTKImage(ModulesConfig.SpokeAPIClient, GeneralConfig.WorkerLabelMap)
+
 	for _, node := range nodeList {
 		klog.V(kmmparams.KmmLogLevel).Infof("Creating privileged deployment on node '%v'", node.Object.Name)
 
 		deploymentName := fmt.Sprintf("%s-%s", kmmparams.KmmTestHelperLabelName, node.Object.Name)
-		containerCfg, _ := pod.NewContainerBuilder("test", kmmparams.DTKImage,
+		containerCfg, _ := pod.NewContainerBuilder("test", dtkImage,
 			[]string{"/bin/bash", "-c", "sleep INF"}).
 			WithSecurityContext(kmmparams.PrivilegedSC).GetContainerCfg()
 

--- a/tests/hw-accel/kmm/mcm/tests/intree-test.go
+++ b/tests/hw-accel/kmm/mcm/tests/intree-test.go
@@ -84,7 +84,7 @@ var _ = Describe("KMM-Hub", Ordered, Label(tsparams.LabelSuite), func() {
 
 			By("Obtain DTK image from the Spoke")
 
-			dtkImage, err := get.DTKImage(ModulesConfig.SpokeAPIClient)
+			dtkImage, err := get.DTKImage(ModulesConfig.SpokeAPIClient, GeneralConfig.WorkerLabelMap)
 			Expect(err).ToNot(HaveOccurred(), "Could not get spoke's DTK image.")
 
 			By("Create ConfigMap")

--- a/tests/hw-accel/kmm/mcm/tests/multi-stage.go
+++ b/tests/hw-accel/kmm/mcm/tests/multi-stage.go
@@ -83,7 +83,7 @@ var _ = Describe("KMM-Hub", Ordered, Label(tsparams.LabelSuite), func() {
 
 			By("Obtain DTK image from the Spoke")
 
-			dtkImage, err := get.DTKImage(ModulesConfig.SpokeAPIClient)
+			dtkImage, err := get.DTKImage(ModulesConfig.SpokeAPIClient, GeneralConfig.WorkerLabelMap)
 			Expect(err).ToNot(HaveOccurred(), "Could not get spoke's DTK image.")
 
 			By("Create ConfigMap")

--- a/tests/hw-accel/kmm/mcm/tests/rebuild-trigger-test.go
+++ b/tests/hw-accel/kmm/mcm/tests/rebuild-trigger-test.go
@@ -89,7 +89,7 @@ var _ = Describe("KMM-Hub", Ordered, Label(tsparams.LabelSuite), func() {
 
 			By("Obtain DTK image from the Spoke")
 
-			dtkImage, err := get.DTKImage(ModulesConfig.SpokeAPIClient)
+			dtkImage, err := get.DTKImage(ModulesConfig.SpokeAPIClient, GeneralConfig.WorkerLabelMap)
 			Expect(err).ToNot(HaveOccurred(), "Could not get spoke's DTK image.")
 
 			By("Create ConfigMap")
@@ -275,7 +275,7 @@ var _ = Describe("KMM-Hub", Ordered, Label(tsparams.LabelSuite), func() {
 
 			By("Obtain DTK image from the Spoke")
 
-			dtkImage, err := get.DTKImage(ModulesConfig.SpokeAPIClient)
+			dtkImage, err := get.DTKImage(ModulesConfig.SpokeAPIClient, GeneralConfig.WorkerLabelMap)
 			Expect(err).ToNot(HaveOccurred(), "Could not get spoke's DTK image.")
 
 			By("Create ConfigMap")

--- a/tests/hw-accel/kmm/modules/modules_suite_test.go
+++ b/tests/hw-accel/kmm/modules/modules_suite_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/serviceaccount"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/define"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/get"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/kmmparams"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/reporter"
@@ -65,11 +66,13 @@ var _ = BeforeSuite(func() {
 		Skip(fmt.Sprintf("Error listing worker nodes. Got error: '%v'", err))
 	}
 
+	dtkImage := get.LocalDTKImage(APIClient, GeneralConfig.WorkerLabelMap)
+
 	for _, node := range nodeList {
 		klog.V(kmmparams.KmmLogLevel).Infof("Creating privileged deployment on node '%v'", node.Object.Name)
 
 		deploymentName := fmt.Sprintf("%s-%s", kmmparams.KmmTestHelperLabelName, node.Object.Name)
-		containerCfg, _ := pod.NewContainerBuilder("test", kmmparams.DTKImage,
+		containerCfg, _ := pod.NewContainerBuilder("test", dtkImage,
 			[]string{"/bin/bash", "-c", "sleep INF"}).
 			WithSecurityContext(kmmparams.PrivilegedSC).GetContainerCfg()
 

--- a/tests/hw-accel/kmm/modules/tests/external-registry-test.go
+++ b/tests/hw-accel/kmm/modules/tests/external-registry-test.go
@@ -78,7 +78,8 @@ var _ = Describe("KMM", Label(kmmparams.LabelSuite, kmmparams.LabelSanity), func
 		It("should build and push image to quay", reportxml.ID("53584"), func() {
 			By("Create configmap")
 
-			configmapContent := define.SimpleKmodConfigMapContents()
+			dtkImage := get.LocalDTKImage(APIClient, GeneralConfig.WorkerLabelMap)
+			configmapContent := define.SimpleKmodConfigMapContents(dtkImage)
 
 			dockerfileConfigMap, err := configmap.NewBuilder(APIClient, moduleName, localNsName).
 				WithData(configmapContent).Create()
@@ -381,7 +382,8 @@ var _ = Describe("KMM", Label(kmmparams.LabelSuite, kmmparams.LabelSanity), func
 		It("should build image without loading it", func() {
 			By("Create configmap")
 
-			configmapContent := define.SimpleKmodConfigMapContents()
+			dtkImage := get.LocalDTKImage(APIClient, GeneralConfig.WorkerLabelMap)
+			configmapContent := define.SimpleKmodConfigMapContents(dtkImage)
 
 			_ = configmap.NewBuilder(APIClient, moduleName, localNsName).Delete()
 

--- a/tests/hw-accel/kmm/modules/tests/filestosign-glob-test.go
+++ b/tests/hw-accel/kmm/modules/tests/filestosign-glob-test.go
@@ -96,7 +96,8 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 
 				var err error
 
-				configmapContents := define.MultiKoConfigMapContent()
+				dtkImage := get.LocalDTKImage(APIClient, GeneralConfig.WorkerLabelMap)
+				configmapContents := define.MultiKoConfigMapContent(dtkImage)
 				dockerfileConfigMap, err = configmap.
 					NewBuilder(APIClient, "multi-ko-dockerfile", nsName).
 					WithData(configmapContents).Create()
@@ -379,7 +380,8 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 
 				By("Create custom-dir Dockerfile ConfigMap")
 
-				customDirContents := define.MultiKoCustomDirConfigMapContent()
+				dtkImage := get.LocalDTKImage(APIClient, GeneralConfig.WorkerLabelMap)
+				customDirContents := define.MultiKoCustomDirConfigMapContent(dtkImage)
 				customDirConfigMap, err := configmap.
 					NewBuilder(APIClient, "custom-dir-dockerfile", nsName).
 					WithData(customDirContents).Create()

--- a/tests/hw-accel/kmm/modules/tests/firmware-test.go
+++ b/tests/hw-accel/kmm/modules/tests/firmware-test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/await"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/check"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/define"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/get"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/kmmparams"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/modules/internal/tsparams"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
@@ -56,7 +57,8 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 			testNamespace, err := namespace.NewBuilder(APIClient, kmmparams.FirmwareTestNamespace).Create()
 			Expect(err).ToNot(HaveOccurred(), "error creating test namespace")
 
-			configmapContents := define.SimpleKmodFirmwareConfigMapContents()
+			dtkImage := get.LocalDTKImage(APIClient, GeneralConfig.WorkerLabelMap)
+			configmapContents := define.SimpleKmodFirmwareConfigMapContents(dtkImage)
 
 			By("Create ConfigMap")
 

--- a/tests/hw-accel/kmm/modules/tests/intree-replacement-test.go
+++ b/tests/hw-accel/kmm/modules/tests/intree-replacement-test.go
@@ -78,7 +78,8 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 			_, err := namespace.NewBuilder(APIClient, kmmparams.InTreeReplacementNamespace).Create()
 			Expect(err).ToNot(HaveOccurred(), "error creating test namespace")
 
-			configmapContents := define.LocalMultiStageConfigMapContent(kmodName)
+			dtkImage := get.LocalDTKImage(APIClient, GeneralConfig.WorkerLabelMap)
+			configmapContents := define.LocalMultiStageConfigMapContent(kmodName, dtkImage)
 
 			By("Create ConfigMap")
 

--- a/tests/hw-accel/kmm/modules/tests/multi-stage.go
+++ b/tests/hw-accel/kmm/modules/tests/multi-stage.go
@@ -78,7 +78,8 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 		})
 
 		It("should use internal image-stream", reportxml.ID("53651"), func() {
-			configmapContents := define.LocalMultiStageConfigMapContent(kmodName)
+			dtkImage := get.LocalDTKImage(APIClient, GeneralConfig.WorkerLabelMap)
+			configmapContents := define.LocalMultiStageConfigMapContent(kmodName, dtkImage)
 
 			By("Create ConfigMap")
 

--- a/tests/hw-accel/kmm/modules/tests/multiple-modules.go
+++ b/tests/hw-accel/kmm/modules/tests/multiple-modules.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/await"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/check"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/define"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/get"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/kmmparams"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/modules/internal/tsparams"
 
@@ -62,7 +63,8 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 
 		Context("Modprobe", Label("multiple"), func() {
 			It("should fail if any of the modules is not present", reportxml.ID("62743"), func() {
-				configmapContents := define.LocalMultiStageConfigMapContent(kmodName)
+				dtkImage := get.LocalDTKImage(APIClient, GeneralConfig.WorkerLabelMap)
+				configmapContents := define.LocalMultiStageConfigMapContent(kmodName, dtkImage)
 
 				By("Create ConfigMap")
 


### PR DESCRIPTION
Add support for new tag for DTK in kmm tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated hardware-acceleration test scenarios to select the appropriate local Driver Toolkit image for each cluster’s kernel and worker-node configuration.
  * Improved compatibility with RHEL 10 kernels by selecting the matching toolkit image and avoiding unsupported module deployment and verification steps.
  * Standardized generated build configurations across module, firmware, multi-stage, and multi-module test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->