### PR TITLE
network: remove force reboot

### DIFF
--- a/tests/cnf/core/network/metallb/tests/ip-forwarding.go
+++ b/tests/cnf/core/network/metallb/tests/ip-forwarding.go
@@ -410,7 +410,7 @@ var _ = Describe("IP Forwarding per Interface", Ordered,
 					By("Rebooting the worker node with VLAN interfaces")
 
 					workerNode1Name := workerNodeList[1].Definition.Name
-					_, err = cluster.ExecCmdWithStdout(APIClient, "reboot -f",
+					_, err = cluster.ExecCmdWithStdout(APIClient, "reboot",
 						metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s",
 							corev1.LabelHostname, workerNode1Name)})
 					Expect(err).ToNot(HaveOccurred(), "Failed to reboot worker node %s", workerNode1Name)

--- a/tests/cnf/core/network/metallb/tests/system-metallb.go
+++ b/tests/cnf/core/network/metallb/tests/system-metallb.go
@@ -406,7 +406,7 @@ var _ = Describe("MetalLB system", Ordered, Label(tsparams.LabelSystemMetalLB), 
 			By("Rebooting the worker node with VLAN interfaces")
 
 			workerNodeName := workerNodeList[1].Definition.Name
-			_, err := cluster.ExecCmdWithStdout(APIClient, "reboot -f",
+			_, err := cluster.ExecCmdWithStdout(APIClient, "reboot",
 				metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", corev1.LabelHostname, workerNodeName)})
 			Expect(err).ToNot(HaveOccurred(), "Failed to reboot worker node %s", workerNodeName)
 

--- a/tests/cnf/core/network/security/tests/nftables-custom-firewall-test.go
+++ b/tests/cnf/core/network/security/tests/nftables-custom-firewall-test.go
@@ -653,7 +653,7 @@ func verifyIngressTCPTrafficAfterCustomFirewallActive(
 
 func rebootNodeAndWaitForMcpStable(nodeName string) {
 	_, err := cluster.ExecCmdWithStdout(APIClient,
-		"reboot -f",
+		"reboot",
 		metav1.ListOptions{LabelSelector: fmt.Sprintf("kubernetes.io/hostname=%s", nodeName)})
 	Expect(err).ToNot(HaveOccurred(),
 		"Failed to reboot worker node with label %s", nodeName)


### PR DESCRIPTION
Replace forced reboot (`reboot -f`) with graceful reboot (`reboot`) in test node reboot commands across MetalLB and security test suites


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node reboot handling in networking and firewall recovery tests.
  * Reboots now complete gracefully, improving test reliability while preserving existing stability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->