### PR TITLE
hw-accel: handle transient errors in KMM tests

### DIFF
--- a/tests/hw-accel/kmm/internal/check/check.go
+++ b/tests/hw-accel/kmm/internal/check/check.go
@@ -458,6 +458,14 @@ func ImageExists(apiClient *clients.Settings, baseImage string,
 	return fmt.Sprintf("%s (kernel: %s)", baseImage, kernelVersion), nil
 }
 
+func isTransientError(err error) bool {
+	errMsg := err.Error()
+
+	return strings.Contains(errMsg, "x509") ||
+		strings.Contains(errMsg, "connection refused") ||
+		strings.Contains(errMsg, "connection reset")
+}
+
 func runCommandOnTestPods(apiClient *clients.Settings,
 	command []string, message string, timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(
@@ -481,6 +489,13 @@ func runCommandOnTestPods(apiClient *clients.Settings,
 
 				buff, err := iterPod.ExecCommand(command, "test")
 				if err != nil {
+					if isTransientError(err) {
+						klog.V(kmmparams.KmmLogLevel).Infof("transient exec error on pod %s, retrying: %v",
+							iterPod.Object.Name, err)
+
+						return false, nil
+					}
+
 					return false, err
 				}
 
@@ -528,6 +543,13 @@ func runCommandOnTestPodsOnNode(apiClient *clients.Settings,
 
 				buff, err := iterPod.ExecCommand(command, "test")
 				if err != nil {
+					if isTransientError(err) {
+						klog.V(kmmparams.KmmLogLevel).Infof("transient exec error on pod %s, retrying: %v",
+							iterPod.Object.Name, err)
+
+						return false, nil
+					}
+
 					return false, err
 				}
 

--- a/tests/hw-accel/kmm/internal/check/check.go
+++ b/tests/hw-accel/kmm/internal/check/check.go
@@ -461,9 +461,21 @@ func ImageExists(apiClient *clients.Settings, baseImage string,
 func isTransientError(err error) bool {
 	errMsg := err.Error()
 
-	return strings.Contains(errMsg, "x509") ||
-		strings.Contains(errMsg, "connection refused") ||
-		strings.Contains(errMsg, "connection reset")
+	transientPatterns := []string{
+		"connection refused",
+		"connection reset",
+		"i/o timeout",
+		"TLS handshake timeout",
+		"x509: certificate signed by unknown authority",
+	}
+
+	for _, pattern := range transientPatterns {
+		if strings.Contains(errMsg, pattern) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func runCommandOnTestPods(apiClient *clients.Settings,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary TLS and connection failures during command execution.
  * Operations now retry transient failures while continuing to report permanent errors immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->