### PR TITLE
hw-accel: change dtk for external registry test

### DIFF
--- a/tests/hw-accel/kmm/1upgrade/tests/upgrade-test.go
+++ b/tests/hw-accel/kmm/1upgrade/tests/upgrade-test.go
@@ -64,8 +64,7 @@ var _ = Describe("KMM", Ordered, Label(tsparams.LabelSuite), func() {
 			// Deploy a simple module to verify upgrade behavior with existing modules
 			By("Create ConfigMap for module build")
 
-			dtkImage := get.LocalDTKImage(APIClient, GeneralConfig.WorkerLabelMap)
-			configmapContents := define.SimpleKmodConfigMapContents(dtkImage)
+			configmapContents := define.SimpleKmodConfigMapContents()
 			dockerfileConfigMap, err := configmap.
 				NewBuilder(APIClient, kmodName, upgradeTestNamespace).
 				WithData(configmapContents).Create()

--- a/tests/hw-accel/kmm/internal/define/configmap.go
+++ b/tests/hw-accel/kmm/internal/define/configmap.go
@@ -49,19 +49,8 @@ func UserDtkMultiStateConfigMapContents(module, dtkImage string) map[string]stri
 }
 
 // SimpleKmodConfigMapContents returns the configmap for simple-kmod example.
-func SimpleKmodConfigMapContents(dtkImage string) map[string]string {
-	data := map[string]interface{}{
-		"DTKImage": dtkImage,
-	}
-
-	templateInstance := template.Must(template.New("contents").Parse(kmmparams.SimpleKmodContents))
-	builder := &strings.Builder{}
-
-	if err := templateInstance.Execute(builder, data); err != nil {
-		panic(err)
-	}
-
-	return map[string]string{"dockerfile": builder.String()}
+func SimpleKmodConfigMapContents() map[string]string {
+	return map[string]string{"dockerfile": kmmparams.SimpleKmodContents}
 }
 
 // SimpleKmodFirmwareConfigMapContents returns the configmap for simple-kmod-firmware example.

--- a/tests/hw-accel/kmm/internal/kmmparams/const.go
+++ b/tests/hw-accel/kmm/internal/kmmparams/const.go
@@ -60,7 +60,8 @@ COPY --from=builder /build/kmm-kmod/*.ko /opt/lib/modules/${KERNEL_VERSION}/
 RUN depmod -b /opt ${KERNEL_VERSION}
 `
 	// SimpleKmodContents represents the Dockerfile contents for simple-kmod build.
-	SimpleKmodContents = `FROM {{.DTKImage}} as builder
+	SimpleKmodContents = `ARG DTK_AUTO
+FROM ${DTK_AUTO} as builder
 ARG KERNEL_VERSION
 ARG KMODVER
 WORKDIR /build/

--- a/tests/hw-accel/kmm/modules/tests/external-registry-test.go
+++ b/tests/hw-accel/kmm/modules/tests/external-registry-test.go
@@ -78,8 +78,7 @@ var _ = Describe("KMM", Label(kmmparams.LabelSuite, kmmparams.LabelSanity), func
 		It("should build and push image to quay", reportxml.ID("53584"), func() {
 			By("Create configmap")
 
-			dtkImage := get.LocalDTKImage(APIClient, GeneralConfig.WorkerLabelMap)
-			configmapContent := define.SimpleKmodConfigMapContents(dtkImage)
+			configmapContent := define.SimpleKmodConfigMapContents()
 
 			dockerfileConfigMap, err := configmap.NewBuilder(APIClient, moduleName, localNsName).
 				WithData(configmapContent).Create()
@@ -382,8 +381,7 @@ var _ = Describe("KMM", Label(kmmparams.LabelSuite, kmmparams.LabelSanity), func
 		It("should build image without loading it", func() {
 			By("Create configmap")
 
-			dtkImage := get.LocalDTKImage(APIClient, GeneralConfig.WorkerLabelMap)
-			configmapContent := define.SimpleKmodConfigMapContents(dtkImage)
+			configmapContent := define.SimpleKmodConfigMapContents()
 
 			_ = configmap.NewBuilder(APIClient, moduleName, localNsName).Delete()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated hardware-accelerated module test configurations to use automatic toolkit image selection.
  * Simplified configuration setup for module build and deployment tests.
  * Improved consistency across upgrade and external registry test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->