### PR TITLE
Feat: Add coverage for switchdev mode with sriov-network-operator for OCP

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -157,6 +157,7 @@ linters:
         - github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/o-cloud/internal/ocloudinittools
         - github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/o-cloud/internal/ocloudcommon
         - github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/sriov/internal/ocpsriovinittools
+        - github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/ocphwolinittools
         - github.com/rh-ecosystem-edge/eco-gotests/tests/lca/seedgeneration/internal/seedgenerationinittools
     wsl:
       strict-append: false
@@ -212,6 +213,9 @@ linters:
       - linters:
           - gochecknoinits
         path: tests/ocp/sriov/internal/ocpsriovinittools
+      - linters:
+          - gochecknoinits
+        path: tests/ocp/hwol/internal/ocphwolinittools
       - linters:
           - gochecknoinits
         path: tests/hw-accel/kmm/internal/kmminittools

--- a/tests/internal/sriovoperator/nad.go
+++ b/tests/internal/sriovoperator/nad.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nad"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -41,12 +42,21 @@ func WaitForNADCreation(apiClient *clients.Settings, name, namespace string, tim
 }
 
 // WaitForNADDeletion waits for the NAD to be deleted.
+// Only NotFound (or eco-goinfra's "does not exist" wrap) ends the wait; other
+// Pull errors keep polling so transient API failures do not false-pass.
 func WaitForNADDeletion(apiClient *clients.Settings, name, namespace string, timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(context.Background(), PollingInterval, timeout, true,
 		func(ctx context.Context) (bool, error) {
 			_, err := nad.Pull(apiClient, name, namespace)
+			if err == nil {
+				return false, nil
+			}
 
-			return err != nil, nil
+			if k8serrors.IsNotFound(err) || strings.Contains(err.Error(), "does not exist") {
+				return true, nil
+			}
+
+			return false, nil
 		})
 }
 

--- a/tests/internal/sriovoperator/nad.go
+++ b/tests/internal/sriovoperator/nad.go
@@ -1,0 +1,125 @@
+package sriovoperator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nad"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// CNIType is the Multus/CNI plugin type embedded in a NetworkAttachmentDefinition config.
+type CNIType string
+
+const (
+	// CNITypeSriov is the sriov CNI plugin type.
+	CNITypeSriov CNIType = "sriov"
+	// CNITypeOVS is the ovs CNI plugin type.
+	CNITypeOVS CNIType = "ovs"
+
+	resourceNameAnnotation = "k8s.v1.cni.cncf.io/resourceName"
+	resourceNamePrefix     = "openshift.io/"
+)
+
+type nadConfigType struct {
+	Type   string `json:"type"`
+	Bridge string `json:"bridge,omitempty"`
+}
+
+// WaitForNADCreation waits for NetworkAttachmentDefinition to be created.
+func WaitForNADCreation(apiClient *clients.Settings, name, namespace string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(context.Background(), PollingInterval, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			_, err := nad.Pull(apiClient, name, namespace)
+
+			return err == nil, nil
+		})
+}
+
+// WaitForNADDeletion waits for the NAD to be deleted.
+func WaitForNADDeletion(apiClient *clients.Settings, name, namespace string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(context.Background(), PollingInterval, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			_, err := nad.Pull(apiClient, name, namespace)
+
+			return err != nil, nil
+		})
+}
+
+// AssertNAD verifies a NAD exists with the expected CNI type and device-plugin resource annotation.
+// wantResource may be bare (e.g. "hwolresource") or fully qualified ("openshift.io/hwolresource").
+// wantBridge, when non-empty, requires the NAD CNI config bridge field to match (ovs CNI / OVSNetwork).
+func AssertNAD(
+	apiClient *clients.Settings,
+	name, namespace string,
+	wantCNIType CNIType,
+	wantResource string,
+	wantBridge string,
+) error {
+	if apiClient == nil {
+		return fmt.Errorf("apiClient cannot be nil")
+	}
+
+	if name == "" || namespace == "" {
+		return fmt.Errorf("NAD name and namespace cannot be empty")
+	}
+
+	if wantCNIType == "" {
+		return fmt.Errorf("wantCNIType cannot be empty")
+	}
+
+	if wantResource == "" {
+		return fmt.Errorf("wantResource cannot be empty")
+	}
+
+	nadBuilder, err := nad.Pull(apiClient, name, namespace)
+	if err != nil {
+		return fmt.Errorf("failed to pull NAD %s/%s: %w", namespace, name, err)
+	}
+
+	var cfg nadConfigType
+	if err := json.Unmarshal([]byte(nadBuilder.Object.Spec.Config), &cfg); err != nil {
+		return fmt.Errorf("failed to parse NAD %s/%s config: %w", namespace, name, err)
+	}
+
+	if cfg.Type != string(wantCNIType) {
+		return fmt.Errorf("NAD %s/%s type is %q, want %q", namespace, name, cfg.Type, wantCNIType)
+	}
+
+	if nadBuilder.Object.Annotations == nil {
+		return fmt.Errorf("NAD %s/%s has nil annotations", namespace, name)
+	}
+
+	gotResource, ok := nadBuilder.Object.Annotations[resourceNameAnnotation]
+	if !ok {
+		return fmt.Errorf("NAD %s/%s missing annotation %s", namespace, name, resourceNameAnnotation)
+	}
+
+	if !resourceNamesMatch(gotResource, wantResource) {
+		return fmt.Errorf("NAD %s/%s resource annotation is %q, want %q",
+			namespace, name, gotResource, wantResource)
+	}
+
+	if wantBridge != "" && cfg.Bridge != wantBridge {
+		return fmt.Errorf("NAD %s/%s bridge is %q, want %q",
+			namespace, name, cfg.Bridge, wantBridge)
+	}
+
+	return nil
+}
+
+func resourceNamesMatch(got, want string) bool {
+	return normalizeResourceName(got) == normalizeResourceName(want)
+}
+
+func normalizeResourceName(name string) string {
+	if strings.HasPrefix(name, resourceNamePrefix) {
+		return name
+	}
+
+	return resourceNamePrefix + name
+}

--- a/tests/internal/sriovoperator/sriovenv.go
+++ b/tests/internal/sriovoperator/sriovenv.go
@@ -15,6 +15,8 @@ import (
 const (
 	// SriovStabilizationDelay represents the delay before checking SR-IOV and MCP stability.
 	SriovStabilizationDelay = 10 * time.Second
+	// PollingInterval represents polling interval for wait operations.
+	PollingInterval = 2 * time.Second
 )
 
 var (

--- a/tests/ocp/hwol/README.md
+++ b/tests/ocp/hwol/README.md
@@ -147,7 +147,7 @@ The Ordered HWOL spec ensures `SriovOperatorConfig`
 enabled so firmware SR-IOV/TotalVfs can be programmed on CX6), creates
 `SriovNetworkPoolConfig` (OvsHardwareOffload only — no parallel
 nodeSelector/maxUnavailable), applies switchdev policy with `bridge.ovs: {}`,
-and waits for MCP/node-state sync. The `switchdev` It asserts
+and waits for MCP/node-state sync. The `switchdev` spec asserts
 `eSwitchMode=switchdev` and a managed OVS bridge uplink. Attach table Entries
 create the network CR, assert NAD type/resource (and bridge for ovs), and run a
 sleep pod. The ovs offload Entry creates two same-node iperf pods, asserts

--- a/tests/ocp/hwol/README.md
+++ b/tests/ocp/hwol/README.md
@@ -1,0 +1,89 @@
+# OCP HWOL Test Suite
+
+Validates hardware offload (HWOL / switchdev) on OpenShift using the SR-IOV
+Network Operator. This is a standalone suite under `tests/ocp/hwol/` — select it
+locally with `ECO_TEST_FEATURES=hwol` (`make run-tests`).
+
+## Prerequisites
+
+- OCP cluster with the SR-IOV Network Operator installed and healthy
+- At least one worker node with an mlx5-capable NIC (BF-2 / BF-3 NIC mode / CX-6 Dx for plumbing)
+- `KUBECONFIG` pointing at the cluster
+
+Lab note (BOS2 ANL): Cluster 5 topology is provisioner **143** + BM workers
+**141** / **142** (BF-2). BF-3 NIC mode is required later for customer proof
+(RHELBU-4108); BF-2 is fine for skeleton and plumbing.
+
+## Required environment variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `KUBECONFIG` | Path to kubeconfig | `/path/to/kubeconfig` |
+| `ECO_OCP_HWOL_DEVICES` | Device list (`name:deviceID:vendor:interface`, comma-separated) | `bf2:a2d6:15b3:ens7f0` |
+
+Devices are **not** configured in YAML. `ECO_OCP_HWOL_DEVICES` is required.
+
+## Optional environment variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ECO_OCP_HWOL_OPERATOR_NAMESPACE` | SR-IOV operator namespace | `openshift-sriov-network-operator` |
+| `ECO_OCP_HWOL_TEST_CONTAINER` | Workload container image | see `internal/ocphwolconfig/default.yaml` |
+| `ECO_OCP_HWOL_MCP_LABEL` | Machine config pool label | `sriov` |
+| `ECO_OCP_HWOL_VF_NUM` | Number of VFs to configure | `2` |
+| `ECO_WORKER_LABEL` | Worker node label selector | from shared ocpconfig |
+
+## Directory structure
+
+```text
+tests/ocp/hwol/
+├── hwol_suite_test.go              # Ginkgo suite entrypoint
+├── README.md
+├── tests/
+│   └── setup.go                    # Precondition smoke
+└── internal/
+    ├── ocphwolconfig/              # ECO_OCP_HWOL_* config + default.yaml
+    ├── ocphwolinittools/           # APIClient + HwolOcpConfig globals
+    └── tsparams/                   # Labels, timeouts, reporter dumps
+```
+
+## Test labels
+
+| Label | Description |
+|-------|-------------|
+| `ocphwol` | Suite label — all HWOL tests |
+| `setup` | Precondition smoke (operator, devices, workers) |
+
+## Running tests
+
+### Compile / dry-run (no cluster)
+
+```bash
+go test -c ./tests/ocp/hwol
+ginkgo --dry-run ./tests/ocp/hwol
+```
+
+### Live smoke
+
+```bash
+export KUBECONFIG=/path/to/kubeconfig
+export ECO_OCP_HWOL_DEVICES="bf2:a2d6:15b3:ens7f0"
+export ECO_GOTESTS_PACKAGE_PATH=./tests/ocp/hwol
+export ECO_TEST_LABELS="ocphwol"
+make run-tests
+```
+
+### Setup smoke only
+
+```bash
+export ECO_TEST_LABELS="setup"
+make run-tests
+```
+
+## Current coverage
+
+| Spec | What it checks |
+|------|----------------|
+| HWOL setup smoke | SR-IOV operator deployed, `ECO_OCP_HWOL_DEVICES` parses, ≥1 worker |
+
+Switchdev policy, OVS HWOL, and OVN feature tests are follow-on work.

--- a/tests/ocp/hwol/README.md
+++ b/tests/ocp/hwol/README.md
@@ -14,9 +14,11 @@ locally with `ECO_TEST_FEATURES=hwol` (`make run-tests`).
 - Host IOMMU enabled (`intel_iommu=on iommu=pt`); Dell/BF often also need
   `pci=realloc` (and sometimes BIOS MMIO High Size) before VF create works
 - `KUBECONFIG` pointing at the cluster
-- For the **ovs-network** attach path: Subscription must set `OVS_CNI_IMAGE` to a
+- For the **ovs-network** path: Subscription must set `OVS_CNI_IMAGE` to a
   pullable ovs-cni image, with registry credentials configured on the cluster
   as needed
+- For the **offload** path: test image must include `iperf3` (default does);
+  `ECO_OCP_HWOL_VF_NUM` ≥ 3 (VF0 reserved + server/client VFs)
 
 ## Required environment variables
 
@@ -32,14 +34,15 @@ Devices are **not** configured in YAML. `ECO_OCP_HWOL_DEVICES` is required.
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `ECO_OCP_HWOL_OPERATOR_NAMESPACE` | SR-IOV operator namespace | `openshift-sriov-network-operator` |
-| `ECO_OCP_HWOL_TEST_CONTAINER` | Workload container image | see `internal/ocphwolconfig/default.yaml` |
+| `ECO_OCP_HWOL_TEST_CONTAINER` | Workload / traffic image (needs `iperf3` for offload) | `quay.io/openshifttest/iperf3@sha256:440c5925…` |
 | `ECO_OCP_HWOL_MCP_LABEL` | Machine config pool name / role label | `sriov` |
-| `ECO_OCP_HWOL_VF_NUM` | Number of VFs to configure (≥2; VF0 reserved) | `2` |
+| `ECO_OCP_HWOL_VF_NUM` | Number of VFs (≥3 recommended; VF0 reserved) | `3` |
 | `ECO_WORKER_LABEL` | Worker node label selector | from shared ocpconfig |
 
-If the default test image (`quay.io/ocp-edge-qe/...`) cannot be pulled, set
-`ECO_OCP_HWOL_TEST_CONTAINER` to a public image the cluster can reach
-(e.g. `registry.access.redhat.com/ubi9/ubi-minimal:latest`).
+Default test image is the OpenShift org Quay `iperf3` image (digest-pinned). Prefer
+`openshift/network-tools` once it ships iperf3
+([PR #189](https://github.com/openshift/network-tools/pull/189)). Override with
+`ECO_OCP_HWOL_TEST_CONTAINER` if the lab cannot pull Quay.
 
 ## Directory structure
 
@@ -49,9 +52,9 @@ tests/ocp/hwol/
 ├── README.md
 ├── tests/
 │   ├── setup.go                    # Precondition smoke
-│   └── hwol.go                     # Ordered: foundation, switchdev It, attach table
+│   └── hwol.go                     # Ordered: foundation, switchdev, attach, offload
 └── internal/
-    ├── hwolenv/                    # Foundation, OVSNetwork, policy helpers
+    ├── hwolenv/                    # Foundation, OVSNetwork, offload helpers
     ├── ocphwolconfig/              # ECO_OCP_HWOL_* config + default.yaml
     ├── ocphwolinittools/           # APIClient + HwolOcpConfig globals
     └── tsparams/                   # Labels, timeouts, reporter dumps
@@ -66,12 +69,13 @@ Shared NAD wait/assert helpers live in `tests/internal/sriovoperator/nad.go`.
 | `ocphwol` | Suite label — all HWOL tests |
 | `setup` | Precondition smoke (operator, devices, workers) |
 | `switchdev` | Switchdev mode + managed OVS bridge assert |
-| `ovs-network` | Attach via `OVSNetwork` (ovs CNI) + NAD + pod |
-| `sriov-network` | Attach via `SriovNetwork` (sriov CNI) + NAD + pod |
+| `ovs-network` | Attach / offload via `OVSNetwork` (ovs CNI) |
+| `sriov-network` | Attach / offload via `SriovNetwork` (sriov CNI) |
+| `offload` | Same-node iperf + `ovs-appctl dpctl/dump-flows type=offloaded` |
 
 Foundation (operator config, pool, switchdev policy, MCP wait) runs once in the
 Ordered `BeforeAll` for the HWOL Describe. Filtering with `ECO_TEST_LABELS`
-still runs that foundation when an attach or switchdev `It`/`Entry` is selected.
+still runs that foundation when an attach, offload, or switchdev spec is selected.
 
 ## Running tests
 
@@ -107,7 +111,6 @@ make run-tests
 export ECO_TEST_FEATURES=hwol
 export ECO_TEST_LABELS=ovs-network
 export ECO_OCP_HWOL_DEVICES="bf2:a2d6:15b3:ens7f0np0"
-export ECO_OCP_HWOL_TEST_CONTAINER=registry.access.redhat.com/ubi9/ubi-minimal:latest
 make run-tests
 ```
 
@@ -117,7 +120,25 @@ make run-tests
 export ECO_TEST_FEATURES=hwol
 export ECO_TEST_LABELS=sriov-network
 export ECO_OCP_HWOL_DEVICES="bf2:a2d6:15b3:ens7f0np0"
-export ECO_OCP_HWOL_TEST_CONTAINER=registry.access.redhat.com/ubi9/ubi-minimal:latest
+make run-tests
+```
+
+### offload verify (iperf + dpctl; OVSNetwork path)
+
+Hardware-offload traffic verification is the **OVSNetwork / ovs CNI** path:
+NAD config must name the managed bridge, both pod VF representors must be
+`ovs-vsctl` ports on that bridge, then same-node iperf and
+`dpctl/dump-flows type=offloaded`. The **sriov-network offload** Entry is
+**Pending** until sriov CNI places VF representors on the managed bridge;
+sriov **attach** still runs. Prefer CI labels such as
+`ECO_TEST_LABELS=ovs-network` (attach + offload ovs) or
+`ECO_TEST_LABELS='offload && ovs-network'`.
+
+```bash
+export ECO_TEST_FEATURES=hwol
+export ECO_TEST_LABELS='offload && ovs-network'
+export ECO_OCP_HWOL_DEVICES="bf2:a2d6:15b3:ens7f0np0"
+export ECO_OCP_HWOL_VF_NUM=3
 make run-tests
 ```
 
@@ -127,7 +148,10 @@ The Ordered HWOL spec ensures `SriovOperatorConfig` (`disablePlugins: [mellanox]
 nodeSelector/maxUnavailable), applies switchdev policy with `bridge.ovs: {}`,
 and waits for MCP/node-state sync. The `switchdev` It asserts
 `eSwitchMode=switchdev` and a managed OVS bridge uplink. Attach table Entries
-create the network CR, assert NAD type/resource, and run a sleep pod.
+create the network CR, assert NAD type/resource (and bridge for ovs), and run a
+sleep pod. The ovs offload Entry creates two same-node iperf pods, asserts
+representors on the managed bridge, runs traffic, and asserts non-empty
+`type=offloaded` datapath flows on the node.
 
 `AfterAll` removes HWOL OVSNetwork/SriovNetwork objects, policies, and the pool
 config — run on a dedicated lab MCP, not a shared production-like pool. Cleanup
@@ -141,10 +165,18 @@ re-running.
 |------|----------------|
 | HWOL setup smoke | SR-IOV operator deployed, `ECO_OCP_HWOL_DEVICES` parses, ≥1 worker |
 | HWOL switchdev | Foundation + OVS bridge status on MCP nodes |
-| HWOL attach (ovs / sriov) | NAD `type` + resource annotation + pod secondary network |
+| HWOL attach (ovs / sriov) | NAD `type` + resource (+ ovs bridge) + pod secondary network |
+| HWOL offload (ovs) | Representors on managed bridge + iperf3 + `type=offloaded` flows |
+| HWOL offload (sriov) | Pending — VF representors not on managed OVS bridge |
 
 Attach networks default to host-local IPAM (configurable on the create helpers);
 NV-IPAM is not a suite prerequisite.
 
-OVN feature tables and offload flow assertions (`ovs-appctl dpctl/dump-flows
-type=offloaded`) are follow-on work.
+The offload path requires the HWOL PF to have **link/carrier** (BF/CX data
+ports cabled to the lab switch). Without carrier, switchdev + NAD attach can
+still pass while same-node VF↔VF iperf fails (`Host is unreachable`) because the
+mlx5 eSwitch does not deliver traffic to OVS representors.
+
+Representor tcpdump heuristics and full
+[kubernetes-traffic-flow-tests](https://github.com/ovn-kubernetes/kubernetes-traffic-flow-tests)
+(`validate_offload`) integration are follow-on work.

--- a/tests/ocp/hwol/README.md
+++ b/tests/ocp/hwol/README.md
@@ -7,19 +7,23 @@ locally with `ECO_TEST_FEATURES=hwol` (`make run-tests`).
 ## Prerequisites
 
 - OCP cluster with the SR-IOV Network Operator installed and healthy
-- At least one worker node with an mlx5-capable NIC (BF-2 / BF-3 NIC mode / CX-6 Dx for plumbing)
+- At least one worker with an mlx5-capable NIC in a mode that supports host
+  eswitch switchdev (BF-3 NIC mode / CX-6 Dx; BF-2 DPU mode is **not** enough)
+- MCP matching `ECO_OCP_HWOL_MCP_LABEL` (default `sriov`) with workers labeled
+  `node-role.kubernetes.io/<mcp_label>=""`
+- Host IOMMU enabled (`intel_iommu=on iommu=pt`); Dell/BF often also need
+  `pci=realloc` (and sometimes BIOS MMIO High Size) before VF create works
 - `KUBECONFIG` pointing at the cluster
-
-Lab note (BOS2 ANL): Cluster 5 topology is provisioner **143** + BM workers
-**141** / **142** (BF-2). BF-3 NIC mode is required later for customer proof
-(RHELBU-4108); BF-2 is fine for skeleton and plumbing.
+- For the **ovs-network** attach path: Subscription must set `OVS_CNI_IMAGE` to a
+  pullable ovs-cni image, with registry credentials configured on the cluster
+  as needed
 
 ## Required environment variables
 
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `KUBECONFIG` | Path to kubeconfig | `/path/to/kubeconfig` |
-| `ECO_OCP_HWOL_DEVICES` | Device list (`name:deviceID:vendor:interface`, comma-separated) | `bf2:a2d6:15b3:ens7f0` |
+| `ECO_OCP_HWOL_DEVICES` | Device list (`name:deviceID:vendor:interface`, comma-separated) | `bf2:a2d6:15b3:ens7f0np0` |
 
 Devices are **not** configured in YAML. `ECO_OCP_HWOL_DEVICES` is required.
 
@@ -29,9 +33,13 @@ Devices are **not** configured in YAML. `ECO_OCP_HWOL_DEVICES` is required.
 |----------|-------------|---------|
 | `ECO_OCP_HWOL_OPERATOR_NAMESPACE` | SR-IOV operator namespace | `openshift-sriov-network-operator` |
 | `ECO_OCP_HWOL_TEST_CONTAINER` | Workload container image | see `internal/ocphwolconfig/default.yaml` |
-| `ECO_OCP_HWOL_MCP_LABEL` | Machine config pool label | `sriov` |
-| `ECO_OCP_HWOL_VF_NUM` | Number of VFs to configure | `2` |
+| `ECO_OCP_HWOL_MCP_LABEL` | Machine config pool name / role label | `sriov` |
+| `ECO_OCP_HWOL_VF_NUM` | Number of VFs to configure (≥2; VF0 reserved) | `2` |
 | `ECO_WORKER_LABEL` | Worker node label selector | from shared ocpconfig |
+
+If the default test image (`quay.io/ocp-edge-qe/...`) cannot be pulled, set
+`ECO_OCP_HWOL_TEST_CONTAINER` to a public image the cluster can reach
+(e.g. `registry.access.redhat.com/ubi9/ubi-minimal:latest`).
 
 ## Directory structure
 
@@ -40,12 +48,16 @@ tests/ocp/hwol/
 ├── hwol_suite_test.go              # Ginkgo suite entrypoint
 ├── README.md
 ├── tests/
-│   └── setup.go                    # Precondition smoke
+│   ├── setup.go                    # Precondition smoke
+│   └── hwol.go                     # Ordered: foundation, switchdev It, attach table
 └── internal/
+    ├── hwolenv/                    # Foundation, OVSNetwork, policy helpers
     ├── ocphwolconfig/              # ECO_OCP_HWOL_* config + default.yaml
     ├── ocphwolinittools/           # APIClient + HwolOcpConfig globals
     └── tsparams/                   # Labels, timeouts, reporter dumps
 ```
+
+Shared NAD wait/assert helpers live in `tests/internal/sriovoperator/nad.go`.
 
 ## Test labels
 
@@ -53,6 +65,13 @@ tests/ocp/hwol/
 |-------|-------------|
 | `ocphwol` | Suite label — all HWOL tests |
 | `setup` | Precondition smoke (operator, devices, workers) |
+| `switchdev` | Switchdev mode + managed OVS bridge assert |
+| `ovs-network` | Attach via `OVSNetwork` (ovs CNI) + NAD + pod |
+| `sriov-network` | Attach via `SriovNetwork` (sriov CNI) + NAD + pod |
+
+Foundation (operator config, pool, switchdev policy, MCP wait) runs once in the
+Ordered `BeforeAll` for the HWOL Describe. Filtering with `ECO_TEST_LABELS`
+still runs that foundation when an attach or switchdev `It`/`Entry` is selected.
 
 ## Running tests
 
@@ -63,27 +82,69 @@ go test -c ./tests/ocp/hwol
 ginkgo --dry-run ./tests/ocp/hwol
 ```
 
-### Live smoke
+### Live smoke (local make runner)
 
 ```bash
 export KUBECONFIG=/path/to/kubeconfig
-export ECO_OCP_HWOL_DEVICES="bf2:a2d6:15b3:ens7f0"
-export ECO_GOTESTS_PACKAGE_PATH=./tests/ocp/hwol
-export ECO_TEST_LABELS="ocphwol"
+export ECO_TEST_FEATURES=hwol
+export ECO_TEST_LABELS=setup
+export ECO_OCP_HWOL_DEVICES="bf2:a2d6:15b3:ens7f0np0"
 make run-tests
 ```
 
-### Setup smoke only
+### switchdev bridge assert
 
 ```bash
-export ECO_TEST_LABELS="setup"
+export ECO_TEST_FEATURES=hwol
+export ECO_TEST_LABELS=switchdev
+export ECO_OCP_HWOL_DEVICES="bf2:a2d6:15b3:ens7f0np0"
 make run-tests
 ```
+
+### ovs CNI attach (requires OVS_CNI_IMAGE on the Subscription)
+
+```bash
+export ECO_TEST_FEATURES=hwol
+export ECO_TEST_LABELS=ovs-network
+export ECO_OCP_HWOL_DEVICES="bf2:a2d6:15b3:ens7f0np0"
+export ECO_OCP_HWOL_TEST_CONTAINER=registry.access.redhat.com/ubi9/ubi-minimal:latest
+make run-tests
+```
+
+### sriov CNI attach
+
+```bash
+export ECO_TEST_FEATURES=hwol
+export ECO_TEST_LABELS=sriov-network
+export ECO_OCP_HWOL_DEVICES="bf2:a2d6:15b3:ens7f0np0"
+export ECO_OCP_HWOL_TEST_CONTAINER=registry.access.redhat.com/ubi9/ubi-minimal:latest
+make run-tests
+```
+
+The Ordered HWOL spec ensures `SriovOperatorConfig` (`disablePlugins: [mellanox]`,
+`featureGates.manageSoftwareBridges`, `enableOvsOffload`), creates
+`SriovNetworkPoolConfig` (OvsHardwareOffload only — no parallel
+nodeSelector/maxUnavailable), applies switchdev policy with `bridge.ovs: {}`,
+and waits for MCP/node-state sync. The `switchdev` It asserts
+`eSwitchMode=switchdev` and a managed OVS bridge uplink. Attach table Entries
+create the network CR, assert NAD type/resource, and run a sleep pod.
+
+`AfterAll` removes HWOL OVSNetwork/SriovNetwork objects, policies, and the pool
+config — run on a dedicated lab MCP, not a shared production-like pool. Cleanup
+waits up to `CleanupWaitTimeout` (15m). If that times out (often switchdev reset
+stuck with `device or resource busy`), reboot the MCP-labeled HWOL node before
+re-running.
 
 ## Current coverage
 
 | Spec | What it checks |
 |------|----------------|
 | HWOL setup smoke | SR-IOV operator deployed, `ECO_OCP_HWOL_DEVICES` parses, ≥1 worker |
+| HWOL switchdev | Foundation + OVS bridge status on MCP nodes |
+| HWOL attach (ovs / sriov) | NAD `type` + resource annotation + pod secondary network |
 
-Switchdev policy, OVS HWOL, and OVN feature tests are follow-on work.
+Attach networks default to host-local IPAM (configurable on the create helpers);
+NV-IPAM is not a suite prerequisite.
+
+OVN feature tables and offload flow assertions (`ovs-appctl dpctl/dump-flows
+type=offloaded`) are follow-on work.

--- a/tests/ocp/hwol/README.md
+++ b/tests/ocp/hwol/README.md
@@ -142,8 +142,9 @@ export ECO_OCP_HWOL_VF_NUM=3
 make run-tests
 ```
 
-The Ordered HWOL spec ensures `SriovOperatorConfig` (`disablePlugins: [mellanox]`,
-`featureGates.manageSoftwareBridges`, `enableOvsOffload`), creates
+The Ordered HWOL spec ensures `SriovOperatorConfig`
+(`featureGates.manageSoftwareBridges`, `enableOvsOffload`; mellanox plugin left
+enabled so firmware SR-IOV/TotalVfs can be programmed on CX6), creates
 `SriovNetworkPoolConfig` (OvsHardwareOffload only — no parallel
 nodeSelector/maxUnavailable), applies switchdev policy with `bridge.ovs: {}`,
 and waits for MCP/node-state sync. The `switchdev` It asserts

--- a/tests/ocp/hwol/hwol_suite_test.go
+++ b/tests/ocp/hwol/hwol_suite_test.go
@@ -23,6 +23,10 @@ var (
 )
 
 func TestHWOL(t *testing.T) {
+	if HwolOcpConfig == nil {
+		t.Fatal("HwolOcpConfig is nil: config init failed (see NewHwolOcpConfig logs)")
+	}
+
 	_, reporterConfig := GinkgoConfiguration()
 	reporterConfig.JUnitReport = HwolOcpConfig.GetJunitReportPath(currentFile)
 
@@ -31,6 +35,10 @@ func TestHWOL(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	if HwolOcpConfig == nil {
+		Fail("HwolOcpConfig is nil: config init failed (see NewHwolOcpConfig logs)")
+	}
+
 	By("Creating test namespace with privileged labels")
 
 	for key, value := range params.PrivilegedNSLabels {

--- a/tests/ocp/hwol/hwol_suite_test.go
+++ b/tests/ocp/hwol/hwol_suite_test.go
@@ -1,0 +1,68 @@
+package hwol
+
+import (
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/cluster"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/params"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/reporter"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/sriovoperator"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/ocphwolinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/tsparams"
+	_ "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/tests"
+)
+
+var (
+	_, currentFile, _, _ = runtime.Caller(0)
+	testNS               = namespace.NewBuilder(APIClient, tsparams.TestNamespaceName)
+)
+
+func TestHWOL(t *testing.T) {
+	_, reporterConfig := GinkgoConfiguration()
+	reporterConfig.JUnitReport = HwolOcpConfig.GetJunitReportPath(currentFile)
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "hwol", Label(tsparams.Labels...), reporterConfig)
+}
+
+var _ = BeforeSuite(func() {
+	By("Creating test namespace with privileged labels")
+
+	for key, value := range params.PrivilegedNSLabels {
+		testNS.WithLabel(key, value)
+	}
+
+	_, err := testNS.Create()
+	Expect(err).ToNot(HaveOccurred(), "error to create test namespace")
+
+	By("Verifying if HWOL tests can be executed on given cluster")
+
+	err = sriovoperator.IsSriovDeployed(APIClient, HwolOcpConfig.OcpHwolOperatorNamespace)
+	Expect(err).ToNot(HaveOccurred(), "Cluster doesn't support HWOL test cases")
+
+	By("Pulling test images on cluster before running test cases")
+
+	err = cluster.PullTestImageOnNodes(APIClient, HwolOcpConfig.WorkerLabel, HwolOcpConfig.OcpHwolTestContainer, 300)
+	Expect(err).ToNot(HaveOccurred(), "Failed to pull test image on nodes")
+})
+
+var _ = AfterSuite(func() {
+	By("Deleting test namespace")
+
+	err := testNS.DeleteAndWait(tsparams.DefaultTimeout)
+	Expect(err).ToNot(HaveOccurred(), "error to delete test namespace")
+})
+
+var _ = JustAfterEach(func() {
+	reporter.ReportIfFailed(
+		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump)
+})
+
+var _ = ReportAfterSuite("", func(report Report) {
+	reportxml.Create(report, HwolOcpConfig.GetReportPath(), HwolOcpConfig.TCPrefix)
+})

--- a/tests/ocp/hwol/internal/hwolenv/hwolenv.go
+++ b/tests/ocp/hwol/internal/hwolenv/hwolenv.go
@@ -1,0 +1,334 @@
+// Package hwolenv provides helpers for OCP HWOL switchdev / OVS bridge setup.
+package hwolenv
+
+import (
+	"fmt"
+	"time"
+
+	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/sriov"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/sriovoperator"
+	hwolconfig "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/ocphwolconfig"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/ocphwolinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/tsparams"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
+)
+
+// MCPNodeSelector returns the node-role label selector for the HWOL MCP pool.
+func MCPNodeSelector(mcpLabel string) map[string]string {
+	return map[string]string{fmt.Sprintf("node-role.kubernetes.io/%s", mcpLabel): ""}
+}
+
+// EnsureHwolOperatorConfig verifies SriovOperatorConfig is set for the
+// manageSoftwareBridges + mlx5 path (disable mellanox plugin, enable OVS offload).
+func EnsureHwolOperatorConfig(operatorNS string) error {
+	opCfg, err := sriov.PullOperatorConfig(APIClient, operatorNS)
+	if err != nil {
+		return fmt.Errorf("failed to pull SriovOperatorConfig: %w", err)
+	}
+
+	changed := false
+
+	if !hasDisablePlugin(opCfg.Definition.Spec.DisablePlugins, tsparams.MellanoxPlugin) {
+		opCfg = opCfg.WithDisablePlugins([]string{tsparams.MellanoxPlugin})
+		changed = true
+	}
+
+	if opCfg.Definition.Spec.FeatureGates == nil {
+		opCfg.Definition.Spec.FeatureGates = map[string]bool{}
+	}
+
+	if !opCfg.Definition.Spec.FeatureGates[tsparams.ManageSoftwareBridgesGate] {
+		opCfg.Definition.Spec.FeatureGates[tsparams.ManageSoftwareBridgesGate] = true
+		changed = true
+	}
+
+	if !opCfg.Definition.Spec.EnableOvsOffload {
+		opCfg.Definition.Spec.EnableOvsOffload = true
+		changed = true
+	}
+
+	if !changed {
+		return nil
+	}
+
+	_, err = opCfg.Update()
+	if err != nil {
+		return fmt.Errorf("failed to update SriovOperatorConfig for HWOL: %w", err)
+	}
+
+	return nil
+}
+
+func hasDisablePlugin(plugins sriovv1.PluginNameSlice, name string) bool {
+	for _, plugin := range plugins {
+		if string(plugin) == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// EnsureSwitchdevFoundation configures operator, pool, and switchdev policy and waits for
+// SR-IOV/MCP stability. It does not create SriovNetwork or OVSNetwork CRs.
+func EnsureSwitchdevFoundation(
+	operatorNS, mcpLabel string,
+	device hwolconfig.DeviceConfig,
+	vfNum int,
+) error {
+	if err := EnsureHwolOperatorConfig(operatorNS); err != nil {
+		return err
+	}
+
+	mcpNodes, err := ListMCPWorkerNodes(mcpLabel)
+	if err != nil {
+		return fmt.Errorf("failed to list MCP nodes: %w", err)
+	}
+
+	if len(mcpNodes) == 0 {
+		return fmt.Errorf("no nodes with label node-role.kubernetes.io/%s", mcpLabel)
+	}
+
+	if _, err := CreateOvsOffloadPoolConfig(tsparams.PoolConfigName, operatorNS, mcpLabel); err != nil {
+		return err
+	}
+
+	if _, err := CreateSwitchdevPolicy(
+		tsparams.PolicyName,
+		operatorNS,
+		tsparams.ResourceName,
+		device,
+		vfNum,
+		MCPNodeSelector(mcpLabel),
+	); err != nil {
+		return err
+	}
+
+	return WaitForSriovAndMCPStable(
+		operatorNS,
+		mcpLabel,
+		tsparams.MCOWaitTimeout,
+		tsparams.DefaultStableDuration,
+	)
+}
+
+// CreateOvsOffloadPoolConfig creates SriovNetworkPoolConfig with only
+// ovsHardwareOffloadConfig.name set to the MCP name.
+// Do not set nodeSelector/maxUnavailable together with OvsHardwareOffload — webhook rejects it.
+func CreateOvsOffloadPoolConfig(name, operatorNS, mcpName string) (*sriov.PoolConfigBuilder, error) {
+	builder := sriov.NewPoolConfigBuilder(APIClient, name, operatorNS)
+	if builder == nil {
+		return nil, fmt.Errorf("failed to init SriovNetworkPoolConfig builder")
+	}
+
+	builder.Definition.Spec.OvsHardwareOffloadConfig = sriovv1.OvsHardwareOffloadConfig{
+		Name: mcpName,
+	}
+
+	if builder.Exists() {
+		builder.Definition.ResourceVersion = builder.Object.ResourceVersion
+
+		updated, err := builder.Update()
+		if err != nil {
+			return nil, fmt.Errorf("failed to update SriovNetworkPoolConfig %s: %w", name, err)
+		}
+
+		return updated, nil
+	}
+
+	created, err := builder.Create()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SriovNetworkPoolConfig %s: %w", name, err)
+	}
+
+	return created, nil
+}
+
+// CreateSwitchdevPolicy creates a switchdev SriovNetworkNodePolicy with OVS bridge management.
+// VF0 is reserved as the management port (pfNames range starts at 1).
+func CreateSwitchdevPolicy(
+	name, operatorNS, resourceName string,
+	device hwolconfig.DeviceConfig,
+	vfNum int,
+	nodeSelector map[string]string,
+) (*sriov.PolicyBuilder, error) {
+	if vfNum < 2 {
+		return nil, fmt.Errorf("vfNum must be >= 2 to reserve VF0 as management port, got %d", vfNum)
+	}
+
+	pfSelector := fmt.Sprintf("%s#1-%d", device.InterfaceName, vfNum-1)
+
+	policy := sriov.NewPolicyBuilder(
+		APIClient,
+		name,
+		operatorNS,
+		resourceName,
+		vfNum,
+		[]string{pfSelector},
+		nodeSelector,
+	).WithDevType("netdevice").WithMTU(1500)
+
+	policy.Definition.Spec.NicSelector.Vendor = device.Vendor
+	policy.Definition.Spec.NicSelector.DeviceID = device.DeviceID
+	policy.Definition.Spec.EswitchMode = tsparams.SwitchdevMode
+	policy.Definition.Spec.Bridge = sriovv1.Bridge{
+		OVS: &sriovv1.OVSConfig{},
+	}
+
+	created, err := policy.Create()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SriovNetworkNodePolicy %s: %w", name, err)
+	}
+
+	return created, nil
+}
+
+// CreateSriovNetwork creates a SriovNetwork for the HWOL resource in the test namespace.
+// If ipam is empty, HostLocalIPAM is used. Callers may pass other IPAM JSON later
+// (for example NV-IPAM) without changing this helper.
+func CreateSriovNetwork(
+	name, operatorNS, resourceName, networkNS, ipam string,
+) (*sriov.NetworkBuilder, error) {
+	network := sriov.NewNetworkBuilder(APIClient, name, operatorNS, networkNS, resourceName)
+	if network == nil {
+		return nil, fmt.Errorf("failed to init SriovNetwork builder")
+	}
+
+	if ipam == "" {
+		ipam = HostLocalIPAM
+	}
+
+	network.Definition.Spec.IPAM = ipam
+
+	created, err := network.Create()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SriovNetwork %s: %w", name, err)
+	}
+
+	return created, nil
+}
+
+// WaitForSriovAndMCPStable waits for SR-IOV node states and the HWOL MCP to stabilize.
+func WaitForSriovAndMCPStable(operatorNS, mcpName string, timeout, stableDuration time.Duration) error {
+	return sriovoperator.WaitForSriovAndMCPStable(
+		APIClient, timeout, stableDuration, mcpName, operatorNS)
+}
+
+// ListMCPWorkerNodes returns nodes matching the HWOL MCP role label.
+func ListMCPWorkerNodes(mcpLabel string) ([]*nodes.Builder, error) {
+	selector := labels.Set(MCPNodeSelector(mcpLabel)).String()
+
+	return nodes.List(APIClient, metav1.ListOptions{LabelSelector: selector})
+}
+
+// AssertSwitchdevAndOVSBridge checks SriovNetworkNodeState for switchdev mode and a managed OVS bridge
+// on the given PF for each MCP-labeled node.
+func AssertSwitchdevAndOVSBridge(operatorNS, mcpLabel, pfName string) error {
+	workerNodes, err := ListMCPWorkerNodes(mcpLabel)
+	if err != nil {
+		return fmt.Errorf("failed to list MCP nodes: %w", err)
+	}
+
+	if len(workerNodes) == 0 {
+		return fmt.Errorf("no nodes found with label node-role.kubernetes.io/%s", mcpLabel)
+	}
+
+	for _, node := range workerNodes {
+		nodeName := node.Object.Name
+		state := sriov.NewNetworkNodeStateBuilder(APIClient, nodeName, operatorNS)
+
+		if err := state.Discover(); err != nil {
+			return fmt.Errorf("failed to discover SriovNetworkNodeState for %s: %w", nodeName, err)
+		}
+
+		if state.Objects.Status.SyncStatus != "Succeeded" {
+			return fmt.Errorf("node %s syncStatus is %q, want Succeeded",
+				nodeName, state.Objects.Status.SyncStatus)
+		}
+
+		iface, err := findStatusInterface(state.Objects.Status.Interfaces, pfName)
+		if err != nil {
+			return fmt.Errorf("node %s: %w", nodeName, err)
+		}
+
+		if iface.EswitchMode != tsparams.SwitchdevMode {
+			return fmt.Errorf("node %s interface %s eSwitchMode is %q, want %s",
+				nodeName, pfName, iface.EswitchMode, tsparams.SwitchdevMode)
+		}
+
+		if err := assertOVSBridgeForPF(state.Objects.Status.Bridges, pfName, iface.PciAddress); err != nil {
+			return fmt.Errorf("node %s: %w", nodeName, err)
+		}
+
+		klog.V(90).Infof("HWOL switchdev+OVS bridge OK on node %s pf %s pci %s",
+			nodeName, pfName, iface.PciAddress)
+	}
+
+	return nil
+}
+
+func findStatusInterface(ifaces sriovv1.InterfaceExts, pfName string) (*sriovv1.InterfaceExt, error) {
+	for i := range ifaces {
+		if ifaces[i].Name == pfName {
+			return &ifaces[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("interface %s not found in SriovNetworkNodeState status", pfName)
+}
+
+func assertOVSBridgeForPF(bridges sriovv1.Bridges, pfName, pciAddress string) error {
+	if len(bridges.OVS) == 0 {
+		return fmt.Errorf("no OVS bridges in SriovNetworkNodeState status for PF %s", pfName)
+	}
+
+	for _, bridge := range bridges.OVS {
+		for _, uplink := range bridge.Uplinks {
+			if uplink.Name == pfName || uplink.PciAddress == pciAddress {
+				return nil
+			}
+		}
+	}
+
+	return fmt.Errorf("no OVS bridge uplink matching PF %s (%s)", pfName, pciAddress)
+}
+
+// CleanupHwolResources removes switchdev-created networks, policies, and pool config, then waits for stability.
+func CleanupHwolResources(operatorNS, mcpName string, timeout, stableDuration time.Duration) error {
+	klog.V(90).Infof("Cleaning HWOL test resources in namespace %s", operatorNS)
+
+	ovsNet := NewOvsNetworkBuilder(
+		APIClient, tsparams.OvsNetworkName, operatorNS, tsparams.TestNamespaceName, tsparams.ResourceName)
+	if ovsNet != nil {
+		if err := ovsNet.Delete(); err != nil {
+			return fmt.Errorf("failed to delete OVSNetwork %s: %w", tsparams.OvsNetworkName, err)
+		}
+	}
+
+	if err := sriovoperator.RemoveAllSriovNetworks(APIClient, operatorNS, tsparams.DefaultTimeout); err != nil {
+		return err
+	}
+
+	if err := sriov.CleanAllNetworkNodePolicies(APIClient, operatorNS); err != nil {
+		return err
+	}
+
+	if pool, err := sriov.PullPoolConfig(APIClient, tsparams.PoolConfigName, operatorNS); err == nil {
+		if delErr := pool.Delete(); delErr != nil {
+			return fmt.Errorf("failed to delete SriovNetworkPoolConfig %s: %w", tsparams.PoolConfigName, delErr)
+		}
+	}
+
+	if err := WaitForSriovAndMCPStable(operatorNS, mcpName, timeout, stableDuration); err != nil {
+		return fmt.Errorf(
+			"HWOL cleanup timed out waiting for SR-IOV/MCP stable: SNNS may be stuck resetting "+
+				"switchdev (device or resource busy); reboot the MCP-labeled HWOL node before re-run: %w",
+			err)
+	}
+
+	return nil
+}

--- a/tests/ocp/hwol/internal/hwolenv/hwolenv.go
+++ b/tests/ocp/hwol/internal/hwolenv/hwolenv.go
@@ -28,7 +28,11 @@ func MCPNodeSelector(mcpLabel string) map[string]string {
 }
 
 // EnsureHwolOperatorConfig verifies SriovOperatorConfig is set for the
-// manageSoftwareBridges + mlx5 path (disable mellanox plugin, enable OVS offload).
+// manageSoftwareBridges + mlx5 HWOL path (enable OVS offload).
+//
+// Do not disable the mellanox plugin: on some beds CX6 firmware SR-IOV
+// (PCI SR-IOV / TotalVfs) is only enabled by that plugin during Apply.
+// Forcing disablePlugins=[mellanox] left Lab245 stuck at TotalVfs=0.
 func EnsureHwolOperatorConfig(operatorNS string) error {
 	opCfg, err := sriov.PullOperatorConfig(APIClient, operatorNS)
 	if err != nil {
@@ -37,8 +41,8 @@ func EnsureHwolOperatorConfig(operatorNS string) error {
 
 	changed := false
 
-	if !hasDisablePlugin(opCfg.Definition.Spec.DisablePlugins, tsparams.MellanoxPlugin) {
-		opCfg = opCfg.WithDisablePlugins([]string{tsparams.MellanoxPlugin})
+	if len(opCfg.Definition.Spec.DisablePlugins) > 0 {
+		opCfg = opCfg.RemoveDisablePlugins()
 		changed = true
 	}
 
@@ -66,16 +70,6 @@ func EnsureHwolOperatorConfig(operatorNS string) error {
 	}
 
 	return nil
-}
-
-func hasDisablePlugin(plugins sriovv1.PluginNameSlice, name string) bool {
-	for _, plugin := range plugins {
-		if string(plugin) == name {
-			return true
-		}
-	}
-
-	return false
 }
 
 // EnsureSwitchdevFoundation configures operator, pool, and switchdev policy and waits for

--- a/tests/ocp/hwol/internal/hwolenv/hwolenv.go
+++ b/tests/ocp/hwol/internal/hwolenv/hwolenv.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/ocphwolinittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/tsparams"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
@@ -383,42 +384,9 @@ func assertOVSBridgeForPF(bridges sriovv1.Bridges, pfName, pciAddress string) er
 
 var offloadedPacketsRE = regexp.MustCompile(`packets:(\d+)`)
 
-// AssertVFRepresentorsOnBridge maps each VF PCI address to its host representor netdev
-// (PF virtfnN → typically <pf>_<N>) and asserts that representor is an ovs-vsctl port
-// on bridge. Used for the ovs CNI offload path before iperf.
-func AssertVFRepresentorsOnBridge(nodeName, bridge, image string, pciAddrs ...string) error {
-	if nodeName == "" {
-		return fmt.Errorf("nodeName cannot be empty")
-	}
-
-	if bridge == "" {
-		return fmt.Errorf("bridge cannot be empty")
-	}
-
-	if image == "" {
-		return fmt.Errorf("debug pod image cannot be empty")
-	}
-
-	if len(pciAddrs) == 0 {
-		return fmt.Errorf("at least one PCI address is required")
-	}
-
-	for _, pci := range pciAddrs {
-		if strings.TrimSpace(pci) == "" {
-			return fmt.Errorf("PCI address cannot be empty")
-		}
-	}
-
-	debugPod, err := newOvsDebugPod(nodeName, image)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		_, _ = debugPod.Delete()
-	}()
-
-	script := `
+// vfRepresentorOnBridgeScript maps each VF PCI address to its host representor
+// netdev and asserts that representor is an ovs-vsctl port on $1.
+const vfRepresentorOnBridgeScript = `
 set -eu
 bridge="$1"
 shift
@@ -550,7 +518,7 @@ func AssertOvsOffloadedFlows(nodeName, image string) error {
 	}
 
 	defer func() {
-		_, _ = debugPod.Delete()
+		_, _ = debugPod.DeleteAndWait(tsparams.DefaultTimeout)
 	}()
 
 	out, err := debugPod.ExecCommand([]string{
@@ -568,7 +536,8 @@ func AssertOvsOffloadedFlows(nodeName, image string) error {
 
 	matches := offloadedPacketsRE.FindAllStringSubmatch(flows, -1)
 	if len(matches) == 0 {
-		// Some dumps omit packets:; non-empty offloaded output is still success.
+		// Success when dump has offloaded flows but omits packets: (some OVS versions);
+		// all-zero packets: counters still fail below.
 		return nil
 	}
 
@@ -646,10 +615,13 @@ func CleanupHwolResources(operatorNS, mcpName string, timeout, stableDuration ti
 		return err
 	}
 
-	if pool, err := sriov.PullPoolConfig(APIClient, tsparams.PoolConfigName, operatorNS); err == nil {
-		if delErr := pool.Delete(); delErr != nil {
-			return fmt.Errorf("failed to delete SriovNetworkPoolConfig %s: %w", tsparams.PoolConfigName, delErr)
+	pool, err := sriov.PullPoolConfig(APIClient, tsparams.PoolConfigName, operatorNS)
+	if err != nil {
+		if !k8serrors.IsNotFound(err) && !strings.Contains(err.Error(), "does not exist") {
+			return fmt.Errorf("failed to pull SriovNetworkPoolConfig %s: %w", tsparams.PoolConfigName, err)
 		}
+	} else if delErr := pool.Delete(); delErr != nil {
+		return fmt.Errorf("failed to delete SriovNetworkPoolConfig %s: %w", tsparams.PoolConfigName, delErr)
 	}
 
 	if err := WaitForSriovAndMCPStable(operatorNS, mcpName, timeout, stableDuration); err != nil {

--- a/tests/ocp/hwol/internal/hwolenv/hwolenv.go
+++ b/tests/ocp/hwol/internal/hwolenv/hwolenv.go
@@ -3,15 +3,20 @@ package hwolenv
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/sriov"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/sriovoperator"
 	hwolconfig "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/ocphwolconfig"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/ocphwolinittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/tsparams"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
@@ -150,6 +155,7 @@ func CreateOvsOffloadPoolConfig(name, operatorNS, mcpName string) (*sriov.PoolCo
 
 // CreateSwitchdevPolicy creates a switchdev SriovNetworkNodePolicy with OVS bridge management.
 // VF0 is reserved as the management port (pfNames range starts at 1).
+// If a policy already exists with a different numVfs/pfNames selector, it is replaced.
 func CreateSwitchdevPolicy(
 	name, operatorNS, resourceName string,
 	device hwolconfig.DeviceConfig,
@@ -179,6 +185,48 @@ func CreateSwitchdevPolicy(
 		OVS: &sriovv1.OVSConfig{},
 	}
 
+	if policy.Exists() {
+		existing := policy.Object.Spec
+		same := existing.NumVfs == vfNum &&
+			existing.EswitchMode == tsparams.SwitchdevMode &&
+			existing.Bridge.OVS != nil &&
+			len(existing.NicSelector.PfNames) == 1 &&
+			existing.NicSelector.PfNames[0] == pfSelector &&
+			existing.NicSelector.Vendor == device.Vendor &&
+			existing.NicSelector.DeviceID == device.DeviceID
+
+		if same {
+			klog.V(90).Infof("SriovNetworkNodePolicy %s already matches desired HWOL config", name)
+
+			return policy, nil
+		}
+
+		klog.V(90).Infof(
+			"Replacing SriovNetworkNodePolicy %s (numVfs/pfNames mismatch: have %d %v, want %d [%s])",
+			name, existing.NumVfs, existing.NicSelector.PfNames, vfNum, pfSelector)
+
+		if err := policy.Delete(); err != nil {
+			return nil, fmt.Errorf("failed to delete outdated SriovNetworkNodePolicy %s: %w", name, err)
+		}
+
+		// Rebuild definition after delete; Exists()/Delete mutate builder state.
+		policy = sriov.NewPolicyBuilder(
+			APIClient,
+			name,
+			operatorNS,
+			resourceName,
+			vfNum,
+			[]string{pfSelector},
+			nodeSelector,
+		).WithDevType("netdevice").WithMTU(1500)
+		policy.Definition.Spec.NicSelector.Vendor = device.Vendor
+		policy.Definition.Spec.NicSelector.DeviceID = device.DeviceID
+		policy.Definition.Spec.EswitchMode = tsparams.SwitchdevMode
+		policy.Definition.Spec.Bridge = sriovv1.Bridge{
+			OVS: &sriovv1.OVSConfig{},
+		}
+	}
+
 	created, err := policy.Create()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SriovNetworkNodePolicy %s: %w", name, err)
@@ -190,6 +238,10 @@ func CreateSwitchdevPolicy(
 // CreateSriovNetwork creates a SriovNetwork for the HWOL resource in the test namespace.
 // If ipam is empty, HostLocalIPAM is used. Callers may pass other IPAM JSON later
 // (for example NV-IPAM) without changing this helper.
+//
+// Sriov CNI same-node HWOL is deferred: VF representors are not ports on the managed
+// OVS bridge, so L2 between same-node pods fails. Keep this helper for attach coverage;
+// the offload Entry that uses it is Pending until representor plumbing exists.
 func CreateSriovNetwork(
 	name, operatorNS, resourceName, networkNS, ipam string,
 ) (*sriov.NetworkBuilder, error) {
@@ -281,6 +333,44 @@ func findStatusInterface(ifaces sriovv1.InterfaceExts, pfName string) (*sriovv1.
 	return nil, fmt.Errorf("interface %s not found in SriovNetworkNodeState status", pfName)
 }
 
+// LookupManagedOVSBridge returns the managed OVS bridge name for pfName on the first MCP worker.
+func LookupManagedOVSBridge(operatorNS, mcpLabel, pfName string) (string, error) {
+	workerNodes, err := ListMCPWorkerNodes(mcpLabel)
+	if err != nil {
+		return "", fmt.Errorf("failed to list MCP nodes: %w", err)
+	}
+
+	if len(workerNodes) == 0 {
+		return "", fmt.Errorf("no nodes found with label node-role.kubernetes.io/%s", mcpLabel)
+	}
+
+	nodeName := workerNodes[0].Object.Name
+	state := sriov.NewNetworkNodeStateBuilder(APIClient, nodeName, operatorNS)
+
+	if err := state.Discover(); err != nil {
+		return "", fmt.Errorf("failed to discover SriovNetworkNodeState for %s: %w", nodeName, err)
+	}
+
+	iface, err := findStatusInterface(state.Objects.Status.Interfaces, pfName)
+	if err != nil {
+		return "", fmt.Errorf("node %s: %w", nodeName, err)
+	}
+
+	for _, bridge := range state.Objects.Status.Bridges.OVS {
+		for _, uplink := range bridge.Uplinks {
+			if uplink.Name == pfName || uplink.PciAddress == iface.PciAddress {
+				if bridge.Name == "" {
+					return "", fmt.Errorf("node %s: OVS bridge for PF %s has empty name", nodeName, pfName)
+				}
+
+				return bridge.Name, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("node %s: no managed OVS bridge for PF %s", nodeName, pfName)
+}
+
 func assertOVSBridgeForPF(bridges sriovv1.Bridges, pfName, pciAddress string) error {
 	if len(bridges.OVS) == 0 {
 		return fmt.Errorf("no OVS bridges in SriovNetworkNodeState status for PF %s", pfName)
@@ -295,6 +385,251 @@ func assertOVSBridgeForPF(bridges sriovv1.Bridges, pfName, pciAddress string) er
 	}
 
 	return fmt.Errorf("no OVS bridge uplink matching PF %s (%s)", pfName, pciAddress)
+}
+
+var offloadedPacketsRE = regexp.MustCompile(`packets:(\d+)`)
+
+// AssertVFRepresentorsOnBridge maps each VF PCI address to its host representor netdev
+// (PF virtfnN → typically <pf>_<N>) and asserts that representor is an ovs-vsctl port
+// on bridge. Used for the ovs CNI offload path before iperf.
+func AssertVFRepresentorsOnBridge(nodeName, bridge, image string, pciAddrs ...string) error {
+	if nodeName == "" {
+		return fmt.Errorf("nodeName cannot be empty")
+	}
+
+	if bridge == "" {
+		return fmt.Errorf("bridge cannot be empty")
+	}
+
+	if image == "" {
+		return fmt.Errorf("debug pod image cannot be empty")
+	}
+
+	if len(pciAddrs) == 0 {
+		return fmt.Errorf("at least one PCI address is required")
+	}
+
+	for _, pci := range pciAddrs {
+		if strings.TrimSpace(pci) == "" {
+			return fmt.Errorf("PCI address cannot be empty")
+		}
+	}
+
+	debugPod, err := newOvsDebugPod(nodeName, image)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_, _ = debugPod.Delete()
+	}()
+
+	script := `
+set -eu
+bridge="$1"
+shift
+normalize_pci() {
+  pci="$1"
+  case "$pci" in
+    *:*:*.*) echo "$pci" ;;
+    *:*.*) echo "0000:$pci" ;;
+    *) echo "$pci" ;;
+  esac
+}
+pci_basename() {
+  basename "$(normalize_pci "$1")"
+}
+for pci in "$@"; do
+  full="$(normalize_pci "$pci")"
+  short="$(pci_basename "$pci")"
+  dev="/sys/bus/pci/devices/$full"
+  if [ ! -e "$dev" ]; then
+    echo "PCI device $full not found on host" >&2
+    exit 1
+  fi
+  if [ ! -e "$dev/physfn" ]; then
+    echo "PCI $full has no physfn (not a VF?)" >&2
+    exit 1
+  fi
+  pf_pci="$(basename "$(readlink -f "$dev/physfn")")"
+  pf_net=""
+  for n in /sys/bus/pci/devices/"$pf_pci"/net/*; do
+    [ -e "$n" ] || continue
+    pf_net="$(basename "$n")"
+    break
+  done
+  if [ -z "$pf_net" ]; then
+    echo "no netdev for PF $pf_pci" >&2
+    exit 1
+  fi
+  vf_idx=""
+  for virtfn in /sys/bus/pci/devices/"$pf_pci"/virtfn*; do
+    [ -e "$virtfn" ] || continue
+    target="$(basename "$(readlink -f "$virtfn")")"
+    if [ "$target" = "$short" ] || [ "$target" = "$(basename "$full")" ]; then
+      vf_idx="${virtfn##*virtfn}"
+      break
+    fi
+  done
+  if [ -z "$vf_idx" ]; then
+    echo "could not map PCI $full to a virtfn under PF $pf_pci" >&2
+    exit 1
+  fi
+  rep="${pf_net}_${vf_idx}"
+  if [ ! -d "/sys/class/net/$rep" ]; then
+    echo "representor netdev $rep for PCI $full not found" >&2
+    exit 1
+  fi
+  if ! ovs-vsctl list-ports "$bridge" | grep -qx "$rep"; then
+    echo "representor $rep (PCI $full) is not a port on bridge $bridge" >&2
+    echo "bridge ports:" >&2
+    ovs-vsctl list-ports "$bridge" >&2 || true
+    exit 1
+  fi
+  echo "OK $full -> $rep on $bridge"
+done
+`
+
+// AssertVFRepresentorsOnBridge maps each VF PCI address to its host representor netdev
+// (PF virtfnN → typically <pf>_<N>) and asserts that representor is an ovs-vsctl port
+// on bridge. Used for the ovs CNI offload path before iperf.
+func AssertVFRepresentorsOnBridge(nodeName, bridge, image string, pciAddrs ...string) error {
+	if nodeName == "" {
+		return fmt.Errorf("nodeName cannot be empty")
+	}
+
+	if bridge == "" {
+		return fmt.Errorf("bridge cannot be empty")
+	}
+
+	if image == "" {
+		return fmt.Errorf("debug pod image cannot be empty")
+	}
+
+	if len(pciAddrs) == 0 {
+		return fmt.Errorf("at least one PCI address is required")
+	}
+
+	for _, pci := range pciAddrs {
+		if strings.TrimSpace(pci) == "" {
+			return fmt.Errorf("PCI address cannot be empty")
+		}
+	}
+
+	debugPod, err := newOvsDebugPod(nodeName, image)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_, _ = debugPod.DeleteAndWait(tsparams.DefaultTimeout)
+	}()
+
+	args := []string{"chroot", "/host", "sh", "-c", vfRepresentorOnBridgeScript, "sh", bridge}
+	args = append(args, pciAddrs...)
+
+	out, err := debugPod.ExecCommand(args)
+	if err != nil {
+		return fmt.Errorf("VF representor-on-bridge check failed on %s bridge %s: %w (out=%s)",
+			nodeName, bridge, err, out.String())
+	}
+
+	klog.V(90).Infof("VF representors on bridge %s (%s):\n%s", bridge, nodeName, out.String())
+
+	return nil
+}
+
+// AssertOvsOffloadedFlows runs ovs-appctl dpctl/dump-flows type=offloaded on the node
+// via a privileged hostNetwork debug pod with the host root mounted at /host.
+func AssertOvsOffloadedFlows(nodeName, image string) error {
+	if nodeName == "" {
+		return fmt.Errorf("nodeName cannot be empty")
+	}
+
+	if image == "" {
+		return fmt.Errorf("debug pod image cannot be empty")
+	}
+
+	debugPod, err := newOvsDebugPod(nodeName, image)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_, _ = debugPod.Delete()
+	}()
+
+	out, err := debugPod.ExecCommand([]string{
+		"chroot", "/host", "ovs-appctl", "dpctl/dump-flows", "--names", "type=offloaded",
+	})
+	if err != nil {
+		return fmt.Errorf("ovs-appctl dpctl/dump-flows type=offloaded failed on %s: %w (out=%s)",
+			nodeName, err, out.String())
+	}
+
+	flows := strings.TrimSpace(out.String())
+	if flows == "" {
+		return fmt.Errorf("no offloaded flows on node %s", nodeName)
+	}
+
+	matches := offloadedPacketsRE.FindAllStringSubmatch(flows, -1)
+	if len(matches) == 0 {
+		// Some dumps omit packets:; non-empty offloaded output is still success.
+		return nil
+	}
+
+	for _, m := range matches {
+		packets, convErr := strconv.ParseUint(m[1], 10, 64)
+		if convErr != nil {
+			continue
+		}
+
+		if packets > 0 {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("offloaded flows on %s have zero packet counters:\n%s", nodeName, flows)
+}
+
+func newOvsDebugPod(nodeName, image string) (*pod.Builder, error) {
+	hostPathType := corev1.HostPathDirectory
+	builder := pod.NewBuilder(
+		APIClient,
+		fmt.Sprintf("hwol-ovs-debug-%s", strings.ReplaceAll(nodeName, ".", "-")),
+		tsparams.TestNamespaceName,
+		image,
+	).DefineOnNode(nodeName).
+		WithPrivilegedFlag().
+		WithHostNetwork().
+		WithHostPid(true).
+		// BusyBox images reject GNU "sleep infinity".
+		RedefineDefaultCMD([]string{"sleep", "86400000"}).
+		WithVolume(corev1.Volume{
+			Name: "host",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/",
+					Type: &hostPathType,
+				},
+			},
+		})
+
+	if builder == nil || builder.Definition == nil || len(builder.Definition.Spec.Containers) == 0 {
+		return nil, fmt.Errorf("failed to init OVS debug pod builder")
+	}
+
+	builder.Definition.Spec.Containers[0].VolumeMounts = append(
+		builder.Definition.Spec.Containers[0].VolumeMounts,
+		corev1.VolumeMount{Name: "host", MountPath: "/host", ReadOnly: true},
+	)
+
+	created, err := builder.CreateAndWaitUntilRunning(tsparams.DefaultTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OVS debug pod on %s: %w", nodeName, err)
+	}
+
+	return created, nil
 }
 
 // CleanupHwolResources removes switchdev-created networks, policies, and pool config, then waits for stability.

--- a/tests/ocp/hwol/internal/hwolenv/ovsnetwork.go
+++ b/tests/ocp/hwol/internal/hwolenv/ovsnetwork.go
@@ -1,0 +1,248 @@
+package hwolenv
+
+import (
+	"context"
+	"fmt"
+
+	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/ocphwolinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/tsparams"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// HostLocalIPAM is the default host-local IPAM for HWOL attach networks
+// (matches SR-IOV Network Operator network examples).
+const HostLocalIPAM = `{
+  "type": "host-local",
+  "subnet": "10.56.217.0/24",
+  "rangeStart": "10.56.217.171",
+  "rangeEnd": "10.56.217.181"
+}`
+
+// OvsNetworkBuilder builds OVSNetwork CRs for the HWOL suite.
+type OvsNetworkBuilder struct {
+	// Definition is the desired OVSNetwork used to create the object.
+	Definition *sriovv1.OVSNetwork
+	// Object is the OVSNetwork as last seen on the cluster.
+	Object *sriovv1.OVSNetwork
+	// errorMsg is processed before the OVSNetwork object is created.
+	errorMsg string
+	// apiClient opens an API connection to the cluster.
+	apiClient runtimeClient.Client
+}
+
+// NewOvsNetworkBuilder creates a new OvsNetworkBuilder.
+func NewOvsNetworkBuilder(
+	apiClient *clients.Settings, name, nsname, targetNsname, resName string) *OvsNetworkBuilder {
+	if apiClient == nil {
+		klog.V(100).Info("The apiClient cannot be nil")
+
+		return nil
+	}
+
+	err := apiClient.AttachScheme(sriovv1.AddToScheme)
+	if err != nil {
+		klog.V(100).Info("Failed to add sriovv1 scheme to client schemes")
+
+		return nil
+	}
+
+	builder := &OvsNetworkBuilder{
+		apiClient: apiClient.Client,
+		Definition: &sriovv1.OVSNetwork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: nsname,
+				Labels: map[string]string{
+					tsparams.TestResourceLabelKey: tsparams.TestResourceLabelValue,
+				},
+			},
+			Spec: sriovv1.OVSNetworkSpec{
+				ResourceName:     resName,
+				NetworkNamespace: targetNsname,
+			},
+		},
+	}
+
+	if name == "" {
+		builder.errorMsg = "OVSNetwork 'name' cannot be empty"
+
+		return builder
+	}
+
+	if nsname == "" {
+		builder.errorMsg = "OVSNetwork 'nsname' cannot be empty"
+
+		return builder
+	}
+
+	if resName == "" {
+		builder.errorMsg = "OVSNetwork 'resName' cannot be empty"
+
+		return builder
+	}
+
+	return builder
+}
+
+// WithIPAM sets IPAM JSON on the OVSNetwork definition.
+func (builder *OvsNetworkBuilder) WithIPAM(ipam string) *OvsNetworkBuilder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	if ipam == "" {
+		builder.errorMsg = "OVSNetwork 'ipam' cannot be empty"
+
+		return builder
+	}
+
+	builder.Definition.Spec.IPAM = ipam
+
+	return builder
+}
+
+// Get returns the OVSNetwork object if found.
+func (builder *OvsNetworkBuilder) Get() (*sriovv1.OVSNetwork, error) {
+	if valid, err := builder.validate(); !valid {
+		return nil, err
+	}
+
+	klog.V(100).Infof(
+		"Collecting OVSNetwork object %s in namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	network := &sriovv1.OVSNetwork{}
+
+	err := builder.apiClient.Get(context.TODO(),
+		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
+		network)
+	if err != nil {
+		klog.V(100).Infof(
+			"OVSNetwork object %s does not exist in namespace %s",
+			builder.Definition.Name, builder.Definition.Namespace)
+
+		return nil, err
+	}
+
+	return network, nil
+}
+
+// Exists checks whether the given OVSNetwork object exists in the cluster.
+func (builder *OvsNetworkBuilder) Exists() bool {
+	if valid, _ := builder.validate(); !valid {
+		return false
+	}
+
+	klog.V(100).Infof("Checking if OVSNetwork %s exists", builder.Definition.Name)
+
+	var err error
+
+	builder.Object, err = builder.Get()
+
+	return err == nil || !k8serrors.IsNotFound(err)
+}
+
+// Create generates an OVSNetwork in the cluster and stores the created object in the struct.
+func (builder *OvsNetworkBuilder) Create() (*OvsNetworkBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	if !builder.Exists() {
+		err := builder.apiClient.Create(context.TODO(), builder.Definition)
+		if err != nil {
+			klog.V(100).Info("Failed to create OVSNetwork")
+
+			return nil, err
+		}
+	}
+
+	builder.Object = builder.Definition
+
+	return builder, nil
+}
+
+// Delete removes the OVSNetwork object.
+func (builder *OvsNetworkBuilder) Delete() error {
+	if valid, err := builder.validate(); !valid {
+		return err
+	}
+
+	if !builder.Exists() {
+		klog.V(100).Info("OVSNetwork cannot be deleted because it does not exist")
+
+		builder.Object = nil
+
+		return nil
+	}
+
+	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
+	if err != nil {
+		return err
+	}
+
+	builder.Object = nil
+
+	return nil
+}
+
+func (builder *OvsNetworkBuilder) validate() (bool, error) {
+	resourceCRD := "OVSNetwork"
+
+	if builder == nil {
+		klog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
+
+		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
+	}
+
+	if builder.Definition == nil {
+		klog.V(100).Infof("The %s is undefined", resourceCRD)
+
+		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceCRD))
+	}
+
+	if builder.apiClient == nil {
+		klog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
+
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
+	}
+
+	if builder.errorMsg != "" {
+		klog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
+
+		return false, fmt.Errorf("%s", builder.errorMsg)
+	}
+
+	return true, nil
+}
+
+// CreateOvsNetwork creates an OVSNetwork CR that generates a NAD using the ovs CNI plugin
+// (not sriov CNI) in networkNS. If ipam is empty, HostLocalIPAM is used. Callers may pass
+// other IPAM JSON later (for example NV-IPAM) without changing this helper.
+func CreateOvsNetwork(
+	name, operatorNS, resourceName, networkNS, ipam string,
+) (*OvsNetworkBuilder, error) {
+	network := NewOvsNetworkBuilder(APIClient, name, operatorNS, networkNS, resourceName)
+	if network == nil {
+		return nil, fmt.Errorf("failed to init OVSNetwork builder")
+	}
+
+	if ipam == "" {
+		ipam = HostLocalIPAM
+	}
+
+	network = network.WithIPAM(ipam)
+
+	created, err := network.Create()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OVSNetwork %s: %w", name, err)
+	}
+
+	return created, nil
+}

--- a/tests/ocp/hwol/internal/hwolenv/ovsnetwork.go
+++ b/tests/ocp/hwol/internal/hwolenv/ovsnetwork.go
@@ -9,7 +9,6 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/ocphwolinittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/tsparams"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -162,7 +161,9 @@ func (builder *OvsNetworkBuilder) Exists() bool {
 
 	builder.Object, err = builder.Get()
 
-	return err == nil || !k8serrors.IsNotFound(err)
+	// True only when Get succeeds. Treating non-NotFound errors as "exists"
+	// would skip Create and leave tests assuming a network that was never applied.
+	return err == nil
 }
 
 // Create generates an OVSNetwork in the cluster and stores the created object in the struct.

--- a/tests/ocp/hwol/internal/hwolenv/ovsnetwork.go
+++ b/tests/ocp/hwol/internal/hwolenv/ovsnetwork.go
@@ -107,6 +107,23 @@ func (builder *OvsNetworkBuilder) WithIPAM(ipam string) *OvsNetworkBuilder {
 	return builder
 }
 
+// WithBridge sets the OVS bridge name used by ovs-cni for VF representors.
+func (builder *OvsNetworkBuilder) WithBridge(bridge string) *OvsNetworkBuilder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	if bridge == "" {
+		builder.errorMsg = "OVSNetwork 'bridge' cannot be empty"
+
+		return builder
+	}
+
+	builder.Definition.Spec.Bridge = bridge
+
+	return builder
+}
+
 // Get returns the OVSNetwork object if found.
 func (builder *OvsNetworkBuilder) Get() (*sriovv1.OVSNetwork, error) {
 	if valid, err := builder.validate(); !valid {
@@ -225,8 +242,10 @@ func (builder *OvsNetworkBuilder) validate() (bool, error) {
 // CreateOvsNetwork creates an OVSNetwork CR that generates a NAD using the ovs CNI plugin
 // (not sriov CNI) in networkNS. If ipam is empty, HostLocalIPAM is used. Callers may pass
 // other IPAM JSON later (for example NV-IPAM) without changing this helper.
+// bridge may be empty; when set it is written into the NAD so representors attach to the
+// managed HWOL bridge (e.g. br-0000_ca_00.0).
 func CreateOvsNetwork(
-	name, operatorNS, resourceName, networkNS, ipam string,
+	name, operatorNS, resourceName, networkNS, ipam, bridge string,
 ) (*OvsNetworkBuilder, error) {
 	network := NewOvsNetworkBuilder(APIClient, name, operatorNS, networkNS, resourceName)
 	if network == nil {
@@ -238,6 +257,10 @@ func CreateOvsNetwork(
 	}
 
 	network = network.WithIPAM(ipam)
+
+	if bridge != "" {
+		network = network.WithBridge(bridge)
+	}
 
 	created, err := network.Create()
 	if err != nil {

--- a/tests/ocp/hwol/internal/ocphwolconfig/config.go
+++ b/tests/ocp/hwol/internal/ocphwolconfig/config.go
@@ -126,16 +126,24 @@ func parseHwolDevicesEnv(envDevices string) ([]DeviceConfig, error) {
 			Vendor:        strings.TrimSpace(parts[2]),
 			InterfaceName: strings.TrimSpace(parts[3]),
 		})
+
+		dev := &devices[len(devices)-1]
+		if dev.Name == "" || dev.DeviceID == "" || dev.Vendor == "" || dev.InterfaceName == "" {
+			return nil, fmt.Errorf(
+				"invalid ECO_OCP_HWOL_DEVICES entry %q - name, deviceid, vendor, and interface must be non-empty",
+				entry)
+		}
 	}
 
 	return devices, nil
 }
 
 // GetVFNum returns the configured number of virtual functions.
+// CreateSwitchdevPolicy reserves VF0 and needs at least two workload VFs.
 func (hwolOcpConfig *HwolOcpConfig) GetVFNum() (int, error) {
-	if hwolOcpConfig.VFNum <= 0 {
+	if hwolOcpConfig.VFNum < 2 {
 		return 0, fmt.Errorf(
-			"no HWOL VFs configured, check env var ECO_OCP_HWOL_VF_NUM")
+			"ECO_OCP_HWOL_VF_NUM must be >= 2 (got %d)", hwolOcpConfig.VFNum)
 	}
 
 	return hwolOcpConfig.VFNum, nil

--- a/tests/ocp/hwol/internal/ocphwolconfig/config.go
+++ b/tests/ocp/hwol/internal/ocphwolconfig/config.go
@@ -1,0 +1,171 @@
+// Package ocphwolconfig provides HWOL-specific configuration for OCP tests.
+package ocphwolconfig
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/internal/ocpconfig"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	// PathToDefaultOcpHwolParamsFile path to config file with default ocp hwol parameters.
+	PathToDefaultOcpHwolParamsFile = "default.yaml"
+)
+
+// DeviceConfig represents a network device configuration for HWOL tests.
+type DeviceConfig struct {
+	Name          string `yaml:"name"`
+	DeviceID      string `yaml:"device_id"`
+	Vendor        string `yaml:"vendor"`
+	InterfaceName string `yaml:"interface_name"`
+}
+
+// HwolOcpConfig type keeps HWOL configuration.
+type HwolOcpConfig struct {
+	*ocpconfig.OcpConfig
+	OcpHwolOperatorNamespace string `yaml:"sriov_operator_namespace" envconfig:"ECO_OCP_HWOL_OPERATOR_NAMESPACE"`
+	OcpHwolTestContainer     string `yaml:"ocp_hwol_test_container" envconfig:"ECO_OCP_HWOL_TEST_CONTAINER"`
+	MCPLabel                 string `yaml:"mcp_label" envconfig:"ECO_OCP_HWOL_MCP_LABEL"`
+	VFNum                    int    `yaml:"vf_num" envconfig:"ECO_OCP_HWOL_VF_NUM"`
+	DevicesEnv               string `envconfig:"ECO_OCP_HWOL_DEVICES"`
+}
+
+// NewHwolOcpConfig returns instance of HwolOcpConfig.
+func NewHwolOcpConfig() *HwolOcpConfig {
+	log.Print("Creating new HwolOcpConfig struct")
+
+	var hwolOcpConf HwolOcpConfig
+
+	hwolOcpConf.OcpConfig = ocpconfig.NewOcpConfig()
+
+	if hwolOcpConf.OcpConfig == nil {
+		log.Print("Error to initialize OcpConfig")
+
+		return nil
+	}
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		log.Print("Error: unable to determine config file path")
+
+		return nil
+	}
+
+	baseDir := filepath.Dir(filename)
+	confFile := filepath.Join(baseDir, PathToDefaultOcpHwolParamsFile)
+
+	err := readFile(&hwolOcpConf, confFile)
+	if err != nil {
+		log.Printf("Error to read config file %s: %v", confFile, err)
+
+		return nil
+	}
+
+	err = readEnv(&hwolOcpConf)
+	if err != nil {
+		log.Printf("Error to read environment variables: %v", err)
+
+		return nil
+	}
+
+	return &hwolOcpConf
+}
+
+// GetHwolDevices returns configured HWOL devices from ECO_OCP_HWOL_DEVICES.
+// Devices must be supplied via environment variable; YAML device lists are not supported.
+func (hwolOcpConfig *HwolOcpConfig) GetHwolDevices() ([]DeviceConfig, error) {
+	if hwolOcpConfig.DevicesEnv == "" {
+		return nil, fmt.Errorf("no HWOL devices configured, set ECO_OCP_HWOL_DEVICES " +
+			"(format: name:deviceID:vendor:interface[,...])")
+	}
+
+	devices, err := parseHwolDevicesEnv(hwolOcpConfig.DevicesEnv)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(devices) == 0 {
+		return nil, fmt.Errorf("no HWOL devices configured, set ECO_OCP_HWOL_DEVICES " +
+			"(format: name:deviceID:vendor:interface[,...])")
+	}
+
+	return devices, nil
+}
+
+// parseHwolDevicesEnv parses device configuration from ECO_OCP_HWOL_DEVICES.
+// Format: "name1:deviceid1:vendor1:interface1,name2:deviceid2:vendor2:interface2,...".
+func parseHwolDevicesEnv(envDevices string) ([]DeviceConfig, error) {
+	var devices []DeviceConfig
+
+	entries := strings.Split(envDevices, ",")
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+
+		parts := strings.Split(entry, ":")
+		if len(parts) != 4 {
+			return nil, fmt.Errorf(
+				"invalid ECO_OCP_HWOL_DEVICES entry %q - expected format: name:deviceid:vendor:interface",
+				entry)
+		}
+
+		devices = append(devices, DeviceConfig{
+			Name:          strings.TrimSpace(parts[0]),
+			DeviceID:      strings.TrimSpace(parts[1]),
+			Vendor:        strings.TrimSpace(parts[2]),
+			InterfaceName: strings.TrimSpace(parts[3]),
+		})
+	}
+
+	return devices, nil
+}
+
+// GetVFNum returns the configured number of virtual functions.
+func (hwolOcpConfig *HwolOcpConfig) GetVFNum() (int, error) {
+	if hwolOcpConfig.VFNum <= 0 {
+		return 0, fmt.Errorf(
+			"no HWOL VFs configured, check env var ECO_OCP_HWOL_VF_NUM")
+	}
+
+	return hwolOcpConfig.VFNum, nil
+}
+
+func readFile(hwolOcpConfig *HwolOcpConfig, cfgFile string) error {
+	openedCfgFile, err := os.Open(cfgFile)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = openedCfgFile.Close()
+	}()
+
+	decoder := yaml.NewDecoder(openedCfgFile)
+
+	err = decoder.Decode(hwolOcpConfig)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+
+	return nil
+}
+
+func readEnv(hwolOcpConfig *HwolOcpConfig) error {
+	err := envconfig.Process("", hwolOcpConfig)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tests/ocp/hwol/internal/ocphwolconfig/default.yaml
+++ b/tests/ocp/hwol/internal/ocphwolconfig/default.yaml
@@ -1,0 +1,17 @@
+---
+# OCP HWOL Test Suite Default Configuration
+#
+# Devices are NOT configured here. Set ECO_OCP_HWOL_DEVICES at runtime:
+#   name:deviceID:vendor:interface (comma-separated for multiple)
+
+# Test container image used for workload pods
+ocp_hwol_test_container: quay.io/ocp-edge-qe/eco-gotests-sriov-client:v4.15.2
+
+# SR-IOV Network Operator namespace
+sriov_operator_namespace: openshift-sriov-network-operator
+
+# Machine Config Pool label for HWOL / switchdev policies
+mcp_label: sriov
+
+# Default number of Virtual Functions to configure
+vf_num: 2

--- a/tests/ocp/hwol/internal/ocphwolconfig/default.yaml
+++ b/tests/ocp/hwol/internal/ocphwolconfig/default.yaml
@@ -4,8 +4,10 @@
 # Devices are NOT configured here. Set ECO_OCP_HWOL_DEVICES at runtime:
 #   name:deviceID:vendor:interface (comma-separated for multiple)
 
-# Test container image used for workload pods
-ocp_hwol_test_container: quay.io/ocp-edge-qe/eco-gotests-sriov-client:v4.15.2
+# Workload / traffic image (must include iperf3 for the offload path).
+# OpenShift org Quay image; pin by digest. Prefer openshift/network-tools once it
+# ships iperf3 (https://github.com/openshift/network-tools/pull/189).
+ocp_hwol_test_container: quay.io/openshifttest/iperf3@sha256:440c59251338e9fcf0a00d822878862038d3b2e2403c67c940c7781297953614
 
 # SR-IOV Network Operator namespace
 sriov_operator_namespace: openshift-sriov-network-operator
@@ -13,5 +15,5 @@ sriov_operator_namespace: openshift-sriov-network-operator
 # Machine Config Pool label for HWOL / switchdev policies
 mcp_label: sriov
 
-# Default number of Virtual Functions to configure
-vf_num: 2
+# Default number of Virtual Functions (≥3: VF0 reserved + ≥2 workload VFs for offload)
+vf_num: 3

--- a/tests/ocp/hwol/internal/ocphwolinittools/ocphwolinittools.go
+++ b/tests/ocp/hwol/internal/ocphwolinittools/ocphwolinittools.go
@@ -1,0 +1,21 @@
+package ocphwolinittools
+
+import (
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
+	hwolconfig "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/ocphwolconfig"
+)
+
+var (
+	// APIClient provides API access to cluster.
+	APIClient *clients.Settings
+	// HwolOcpConfig provides access to HWOL configuration parameters.
+	HwolOcpConfig *hwolconfig.HwolOcpConfig
+)
+
+// init loads all variables automatically when this package is imported. Once package is imported a user has full
+// access to all vars within init function. It is recommended to import this package using dot import.
+func init() {
+	HwolOcpConfig = hwolconfig.NewHwolOcpConfig()
+	APIClient = inittools.APIClient
+}

--- a/tests/ocp/hwol/internal/tsparams/consts.go
+++ b/tests/ocp/hwol/internal/tsparams/consts.go
@@ -16,9 +16,16 @@ const (
 	LabelOvsNetwork = "ovs-network"
 	// LabelSriovNetwork represents sriov CNI attach coverage.
 	LabelSriovNetwork = "sriov-network"
+	// LabelOffload represents iperf traffic + OVS type=offloaded flow coverage.
+	LabelOffload = "offload"
 
 	// ResourceNamePrefix is the OpenShift device-plugin resource name prefix.
 	ResourceNamePrefix = "openshift.io/"
+
+	// IperfDuration is the client-side iperf3 test duration for offload checks.
+	IperfDuration = 15 * time.Second
+	// MinVFNumForOffload is VF0 reserved plus two workload VFs for server/client pods.
+	MinVFNumForOffload = 3
 
 	// DefaultTimeout represents default timeout for general operations.
 	DefaultTimeout = 300 * time.Second

--- a/tests/ocp/hwol/internal/tsparams/consts.go
+++ b/tests/ocp/hwol/internal/tsparams/consts.go
@@ -10,16 +10,50 @@ const (
 	LabelSuite = "ocphwol"
 	// LabelSetup represents the setup/smoke test label for filtering.
 	LabelSetup = "setup"
+	// LabelSwitchdev represents switchdev / OVS bridge coverage.
+	LabelSwitchdev = "switchdev"
+	// LabelOvsNetwork represents OVS CNI attach coverage.
+	LabelOvsNetwork = "ovs-network"
+	// LabelSriovNetwork represents sriov CNI attach coverage.
+	LabelSriovNetwork = "sriov-network"
+
+	// ResourceNamePrefix is the OpenShift device-plugin resource name prefix.
+	ResourceNamePrefix = "openshift.io/"
 
 	// DefaultTimeout represents default timeout for general operations.
 	DefaultTimeout = 300 * time.Second
 	// WaitTimeout represents default timeout for most waiting operations.
 	WaitTimeout = 20 * time.Minute
+	// MCOWaitTimeout represents MCP / SR-IOV drain and apply wait budget.
+	MCOWaitTimeout = 45 * time.Minute
+	// CleanupWaitTimeout is the AfterAll budget for leaving switchdev.
+	// Leaving switchdev can hang on busy eswitch; fail fast instead of burning MCOWaitTimeout.
+	CleanupWaitTimeout = 15 * time.Minute
+	// DefaultStableDuration is how long MCP must remain stable after update.
+	DefaultStableDuration = 1 * time.Minute
 	// RetryInterval represents retry interval for ginkgo Eventually functions.
 	RetryInterval = 3 * time.Second
 
 	// MlxVendorID is the Mellanox/NVIDIA PCI vendor ID.
 	MlxVendorID = "15b3"
+
+	// SwitchdevMode is the eSwitchMode value for hardware offload.
+	SwitchdevMode = "switchdev"
+	// ManageSoftwareBridgesGate is the SriovOperatorConfig feature gate for OVS bridge management.
+	ManageSoftwareBridgesGate = "manageSoftwareBridges"
+	// MellanoxPlugin is the plugin name disabled for the mlx5 / manageSoftwareBridges path.
+	MellanoxPlugin = "mellanox"
+
+	// PoolConfigName is the SriovNetworkPoolConfig created by switchdev tests.
+	PoolConfigName = "hwol-ovs-offload"
+	// PolicyName is the SriovNetworkNodePolicy created by switchdev tests.
+	PolicyName = "hwol-switchdev"
+	// ResourceName is the SR-IOV resource name advertised for HWOL VFs.
+	ResourceName = "hwolresource"
+	// SriovNetworkName is the SriovNetwork created alongside the switchdev policy.
+	SriovNetworkName = "hwol-sriovnet"
+	// OvsNetworkName is the OVSNetwork created by ovs-network tests.
+	OvsNetworkName = "hwol-ovsnet"
 
 	// TestResourceLabelKey is the label key used to identify test-created resources.
 	TestResourceLabelKey = "eco-gotests.openshift.io/test"

--- a/tests/ocp/hwol/internal/tsparams/consts.go
+++ b/tests/ocp/hwol/internal/tsparams/consts.go
@@ -1,0 +1,28 @@
+// Package tsparams provides test suite parameters and constants for OCP HWOL tests.
+package tsparams
+
+import "time"
+
+const (
+	// TestNamespaceName is the namespace where HWOL test cases are performed.
+	TestNamespaceName = "hwol-tests"
+	// LabelSuite represents the HWOL suite label for test selection.
+	LabelSuite = "ocphwol"
+	// LabelSetup represents the setup/smoke test label for filtering.
+	LabelSetup = "setup"
+
+	// DefaultTimeout represents default timeout for general operations.
+	DefaultTimeout = 300 * time.Second
+	// WaitTimeout represents default timeout for most waiting operations.
+	WaitTimeout = 20 * time.Minute
+	// RetryInterval represents retry interval for ginkgo Eventually functions.
+	RetryInterval = 3 * time.Second
+
+	// MlxVendorID is the Mellanox/NVIDIA PCI vendor ID.
+	MlxVendorID = "15b3"
+
+	// TestResourceLabelKey is the label key used to identify test-created resources.
+	TestResourceLabelKey = "eco-gotests.openshift.io/test"
+	// TestResourceLabelValue is the label value for test-created resources.
+	TestResourceLabelValue = "ocp-hwol"
+)

--- a/tests/ocp/hwol/internal/tsparams/consts.go
+++ b/tests/ocp/hwol/internal/tsparams/consts.go
@@ -48,8 +48,6 @@ const (
 	SwitchdevMode = "switchdev"
 	// ManageSoftwareBridgesGate is the SriovOperatorConfig feature gate for OVS bridge management.
 	ManageSoftwareBridgesGate = "manageSoftwareBridges"
-	// MellanoxPlugin is the plugin name disabled for the mlx5 / manageSoftwareBridges path.
-	MellanoxPlugin = "mellanox"
 
 	// PoolConfigName is the SriovNetworkPoolConfig created by switchdev tests.
 	PoolConfigName = "hwol-ovs-offload"

--- a/tests/ocp/hwol/internal/tsparams/ocphwolvars.go
+++ b/tests/ocp/hwol/internal/tsparams/ocphwolvars.go
@@ -1,0 +1,29 @@
+// Package tsparams provides test suite parameters and constants for OCP HWOL tests.
+package tsparams
+
+import (
+	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	"github.com/openshift-kni/k8sreporter"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/ocphwolinittools"
+)
+
+var (
+	// Labels represent the suite-level labels applied to all tests in the suite.
+	Labels = []string{LabelSuite}
+
+	// ReporterCRDsToDump tells the reporter what CRDs to dump on failure.
+	ReporterCRDsToDump = []k8sreporter.CRData{
+		{Cr: &mcfgv1.MachineConfigPoolList{}},
+		{Cr: &sriovv1.SriovNetworkNodePolicyList{}},
+		{Cr: &sriovv1.SriovNetworkList{}},
+		{Cr: &sriovv1.SriovNetworkNodeStateList{}},
+		{Cr: &sriovv1.SriovOperatorConfigList{}},
+	}
+
+	// ReporterNamespacesToDump tells the reporter what namespaces to dump on failure.
+	ReporterNamespacesToDump = map[string]string{
+		HwolOcpConfig.OcpHwolOperatorNamespace: HwolOcpConfig.OcpHwolOperatorNamespace,
+		TestNamespaceName:                      "other",
+	}
+)

--- a/tests/ocp/hwol/internal/tsparams/ocphwolvars.go
+++ b/tests/ocp/hwol/internal/tsparams/ocphwolvars.go
@@ -5,7 +5,6 @@ import (
 	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	"github.com/openshift-kni/k8sreporter"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
-	. "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/ocphwolinittools"
 )
 
 var (
@@ -24,8 +23,10 @@ var (
 	}
 
 	// ReporterNamespacesToDump tells the reporter what namespaces to dump on failure.
+	// Use the default operator namespace literal so a nil HwolOcpConfig at package
+	// init does not panic before suite setup can Fail clearly.
 	ReporterNamespacesToDump = map[string]string{
-		HwolOcpConfig.OcpHwolOperatorNamespace: HwolOcpConfig.OcpHwolOperatorNamespace,
-		TestNamespaceName:                      "other",
+		"openshift-sriov-network-operator": "openshift-sriov-network-operator",
+		TestNamespaceName:                  "other",
 	}
 )

--- a/tests/ocp/hwol/internal/tsparams/ocphwolvars.go
+++ b/tests/ocp/hwol/internal/tsparams/ocphwolvars.go
@@ -16,9 +16,11 @@ var (
 	ReporterCRDsToDump = []k8sreporter.CRData{
 		{Cr: &mcfgv1.MachineConfigPoolList{}},
 		{Cr: &sriovv1.SriovNetworkNodePolicyList{}},
+		{Cr: &sriovv1.SriovNetworkPoolConfigList{}},
 		{Cr: &sriovv1.SriovNetworkList{}},
 		{Cr: &sriovv1.SriovNetworkNodeStateList{}},
 		{Cr: &sriovv1.SriovOperatorConfigList{}},
+		{Cr: &sriovv1.OVSNetworkList{}},
 	}
 
 	// ReporterNamespacesToDump tells the reporter what namespaces to dump on failure.

--- a/tests/ocp/hwol/tests/hwol.go
+++ b/tests/ocp/hwol/tests/hwol.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -17,7 +18,10 @@ import (
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/ocphwolinittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/tsparams"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 type networkStatusEntry struct {
@@ -324,7 +328,11 @@ func deleteAttachNetwork(cniType sriovoperator.CNIType, networkName, operatorNS 
 	case sriovoperator.CNITypeSriov:
 		builder, err := sriov.PullNetwork(APIClient, networkName, operatorNS)
 		if err != nil {
-			return nil
+			if k8serrors.IsNotFound(err) || strings.Contains(err.Error(), "does not exist") {
+				return nil
+			}
+
+			return err
 		}
 
 		return builder.Delete()
@@ -474,26 +482,51 @@ exec iperf3 -s -B "$ip"
 `}
 }
 
-// waitForHwolResource waits until node allocatable openshift.io/hwolresource >= min.
-func waitForHwolResource(nodeName string, min int64, timeout time.Duration) error {
+// waitForHwolResource waits until available openshift.io/hwolresource on the node
+// (allocatable minus non-terminated pod requests) is at least minAvail.
+func waitForHwolResource(nodeName string, minAvail int64, timeout time.Duration) error {
 	resName := corev1.ResourceName(tsparams.ResourceNamePrefix + tsparams.ResourceName)
-	deadline := time.Now().Add(timeout)
 
-	for time.Now().Before(deadline) {
-		node, err := nodes.Pull(APIClient, nodeName)
-		if err != nil {
-			return fmt.Errorf("failed to pull node %s: %w", nodeName, err)
-		}
+	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			node, err := nodes.Pull(APIClient, nodeName)
+			if err != nil {
+				return false, fmt.Errorf("failed to pull node %s: %w", nodeName, err)
+			}
 
-		qty := node.Object.Status.Allocatable[resName]
-		if qty.Value() >= min {
-			return nil
-		}
+			allocatable := node.Object.Status.Allocatable[resName]
 
-		time.Sleep(5 * time.Second)
-	}
+			nodePods, err := pod.ListInAllNamespaces(APIClient, metav1.ListOptions{
+				FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+			})
+			if err != nil {
+				return false, fmt.Errorf("failed to list pods on node %s: %w", nodeName, err)
+			}
 
-	return fmt.Errorf("timed out waiting for %s allocatable >= %d on %s", resName, min, nodeName)
+			var requested resource.Quantity
+
+			for _, nodePod := range nodePods {
+				if nodePod.Object == nil {
+					continue
+				}
+
+				phase := nodePod.Object.Status.Phase
+				if phase == corev1.PodSucceeded || phase == corev1.PodFailed {
+					continue
+				}
+
+				for i := range nodePod.Object.Spec.Containers {
+					if qty, ok := nodePod.Object.Spec.Containers[i].Resources.Requests[resName]; ok {
+						requested.Add(qty)
+					}
+				}
+			}
+
+			available := allocatable.DeepCopy()
+			available.Sub(requested)
+
+			return available.Value() >= minAvail, nil
+		})
 }
 
 // runIperfBetweenPods runs the iperf3 client against a server already listening in serverPod

--- a/tests/ocp/hwol/tests/hwol.go
+++ b/tests/ocp/hwol/tests/hwol.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/sriov"
@@ -19,8 +21,14 @@ import (
 )
 
 type networkStatusEntry struct {
-	Name string   `json:"name"`
-	IPs  []string `json:"ips"`
+	Name       string   `json:"name"`
+	IPs        []string `json:"ips"`
+	DeviceInfo *struct {
+		Type string `json:"type"`
+		Pci  *struct {
+			PciAddress string `json:"pci-address"`
+		} `json:"pci"`
+	} `json:"device-info,omitempty"`
 }
 
 var _ = Describe(
@@ -32,6 +40,9 @@ var _ = Describe(
 			operatorNS string
 			mcpLabel   string
 			pfName     string
+			vfNum      int
+			workerNode string
+			ovsBridge  string
 		)
 
 		BeforeAll(func() {
@@ -45,7 +56,7 @@ var _ = Describe(
 			Expect(devices).ToNot(BeEmpty(), "No HWOL devices configured")
 			pfName = devices[0].InterfaceName
 
-			vfNum, err := HwolOcpConfig.GetVFNum()
+			vfNum, err = HwolOcpConfig.GetVFNum()
 			Expect(err).ToNot(HaveOccurred(), "Failed to get VF count")
 
 			By("Ensuring switchdev foundation (operator config, pool, policy, wait)")
@@ -53,6 +64,15 @@ var _ = Describe(
 			Expect(hwolenv.EnsureSwitchdevFoundation(
 				operatorNS, mcpLabel, devices[0], vfNum,
 			)).To(Succeed(), "Failed to ensure switchdev foundation")
+
+			mcpNodes, err := hwolenv.ListMCPWorkerNodes(mcpLabel)
+			Expect(err).ToNot(HaveOccurred(), "Failed to list MCP nodes")
+			Expect(mcpNodes).ToNot(BeEmpty(), "No MCP-labeled workers")
+			workerNode = mcpNodes[0].Object.Name
+
+			ovsBridge, err = hwolenv.LookupManagedOVSBridge(operatorNS, mcpLabel, pfName)
+			Expect(err).ToNot(HaveOccurred(), "Failed to look up managed OVS bridge")
+			Expect(ovsBridge).ToNot(BeEmpty(), "Managed OVS bridge name is empty")
 		})
 
 		AfterAll(func() {
@@ -80,7 +100,7 @@ var _ = Describe(
 			func(cniType sriovoperator.CNIType, networkName string) {
 				By(fmt.Sprintf("Creating %s network %s", cniType, networkName))
 
-				err := createAttachNetwork(cniType, networkName, operatorNS)
+				err := createAttachNetwork(cniType, networkName, operatorNS, ovsBridge)
 				Expect(err).ToNot(HaveOccurred(), "Failed to create attach network")
 
 				DeferCleanup(func() {
@@ -101,49 +121,168 @@ var _ = Describe(
 
 				By("Asserting NAD CNI type and resource annotation")
 
+				wantBridge := ""
+				if cniType == sriovoperator.CNITypeOVS {
+					wantBridge = ovsBridge
+				}
+
 				Expect(sriovoperator.AssertNAD(
 					APIClient,
 					networkName,
 					tsparams.TestNamespaceName,
 					cniType,
 					tsparams.ResourceNamePrefix+tsparams.ResourceName,
+					wantBridge,
 				)).To(Succeed(), "NAD assertion failed")
 
 				By("Creating sleep pod with secondary network")
 
-				attachPod, err := createAttachPod(fmt.Sprintf("hwol-attach-%s", cniType), networkName)
+				attachPod, err := createTrafficPod(
+					fmt.Sprintf("hwol-attach-%s", cniType), networkName, "", nil)
 				Expect(err).ToNot(HaveOccurred(), "Failed to create attach pod")
 
 				DeferCleanup(func() {
 					By("Deleting attach pod")
 
-					Expect(attachPod.Delete()).To(Succeed(), "Failed to delete attach pod")
+					_, delErr := attachPod.Delete()
+					Expect(delErr).ToNot(HaveOccurred(), "Failed to delete attach pod")
 				})
 
 				By("Asserting pod network-status includes the attach NAD with an IP")
 
-				Expect(attachPod.Object.Annotations).To(HaveKey("k8s.v1.cni.cncf.io/network-status"))
-				Expect(assertNetworkStatusHasIP(
-					attachPod.Object.Annotations["k8s.v1.cni.cncf.io/network-status"],
-					networkName,
-				)).To(Succeed(), "network-status should reference attach NAD with an assigned IP")
+				_, err = waitForNetworkStatusIP(attachPod, networkName)
+				Expect(err).ToNot(HaveOccurred(),
+					"network-status should reference attach NAD with an assigned IP")
 			},
 			Entry("ovs CNI", Label(tsparams.LabelOvsNetwork), reportxml.ID("85002"),
 				sriovoperator.CNITypeOVS, tsparams.OvsNetworkName),
 			Entry("sriov CNI", Label(tsparams.LabelSriovNetwork), reportxml.ID("85003"),
 				sriovoperator.CNITypeSriov, tsparams.SriovNetworkName),
 		)
+
+		DescribeTable("offload path",
+			func(cniType sriovoperator.CNIType, networkName string) {
+				Expect(vfNum).To(BeNumerically(">=", tsparams.MinVFNumForOffload),
+					"offload needs ≥%d VFs (VF0 reserved + server/client); set ECO_OCP_HWOL_VF_NUM",
+					tsparams.MinVFNumForOffload)
+
+				By(fmt.Sprintf("Creating %s network %s for offload", cniType, networkName))
+
+				err := createAttachNetwork(cniType, networkName, operatorNS, ovsBridge)
+				Expect(err).ToNot(HaveOccurred(), "Failed to create offload network")
+
+				DeferCleanup(func() {
+					By(fmt.Sprintf("Deleting %s network %s", cniType, networkName))
+
+					Expect(deleteAttachNetwork(cniType, networkName, operatorNS)).To(Succeed(),
+						"Failed to delete offload network")
+					Expect(sriovoperator.WaitForNADDeletion(
+						APIClient, networkName, tsparams.TestNamespaceName, tsparams.DefaultTimeout,
+					)).To(Succeed(), "NAD was not deleted")
+				})
+
+				By("Waiting for NAD creation")
+
+				Expect(sriovoperator.WaitForNADCreation(
+					APIClient, networkName, tsparams.TestNamespaceName, tsparams.DefaultTimeout,
+				)).To(Succeed(), "NAD was not created")
+
+				By("Asserting NAD CNI type and resource annotation")
+
+				wantBridge := ""
+				if cniType == sriovoperator.CNITypeOVS {
+					wantBridge = ovsBridge
+				}
+
+				Expect(sriovoperator.AssertNAD(
+					APIClient,
+					networkName,
+					tsparams.TestNamespaceName,
+					cniType,
+					tsparams.ResourceNamePrefix+tsparams.ResourceName,
+					wantBridge,
+				)).To(Succeed(), "NAD assertion failed")
+
+				By(fmt.Sprintf("Creating iperf server/client pods on node %s", workerNode))
+
+				// Prior table entry may still hold VFs until the device plugin frees them.
+				Expect(waitForHwolResource(workerNode, 2, tsparams.DefaultTimeout)).To(Succeed(),
+					"need ≥2 openshift.io/hwolresource before creating iperf pods")
+
+				// Run iperf3 as the server container PID 1. Starting it via kubectl exec
+				// (even with -D / background) does not leave a listener in this image.
+				serverPod, err := createTrafficPod(
+					fmt.Sprintf("hwol-iperf-srv-%s", cniType), networkName, workerNode,
+					iperfServerCMD())
+				Expect(err).ToNot(HaveOccurred(), "Failed to create iperf server pod")
+
+				DeferCleanup(func() {
+					_, delErr := serverPod.Delete()
+					Expect(delErr).ToNot(HaveOccurred(), "Failed to delete iperf server pod")
+				})
+
+				Expect(waitForHwolResource(workerNode, 1, tsparams.DefaultTimeout)).To(Succeed(),
+					"need ≥1 openshift.io/hwolresource for iperf client")
+
+				clientPod, err := createTrafficPod(
+					fmt.Sprintf("hwol-iperf-cli-%s", cniType), networkName, workerNode, nil)
+				Expect(err).ToNot(HaveOccurred(), "Failed to create iperf client pod")
+
+				DeferCleanup(func() {
+					_, delErr := clientPod.Delete()
+					Expect(delErr).ToNot(HaveOccurred(), "Failed to delete iperf client pod")
+				})
+
+				serverIP, serverPCI, err := waitForNetworkStatusIPAndPCI(serverPod, networkName)
+				Expect(err).ToNot(HaveOccurred(), "Failed to get server secondary IP/PCI")
+
+				clientIP, clientPCI, err := waitForNetworkStatusIPAndPCI(clientPod, networkName)
+				Expect(err).ToNot(HaveOccurred(), "Failed to get client secondary IP/PCI")
+
+				if cniType == sriovoperator.CNITypeOVS {
+					By("Asserting VF representors are ports on the managed OVS bridge")
+
+					Expect(hwolenv.AssertVFRepresentorsOnBridge(
+						workerNode, ovsBridge, HwolOcpConfig.OcpHwolTestContainer,
+						serverPCI, clientPCI,
+					)).To(Succeed(), "expected server and client VF representors on bridge")
+				}
+
+				By("Running iperf3 between pods on secondary network")
+
+				Expect(runIperfBetweenPods(
+					clientPod, serverIP, clientIP, tsparams.IperfDuration,
+				)).To(Succeed(), "iperf3 traffic failed")
+
+				By("Asserting OVS datapath has type=offloaded flows")
+
+				Expect(hwolenv.AssertOvsOffloadedFlows(
+					workerNode, HwolOcpConfig.OcpHwolTestContainer,
+				)).To(Succeed(), "expected non-empty offloaded flows after iperf")
+			},
+			Entry("ovs CNI",
+				Label(tsparams.LabelOffload), Label(tsparams.LabelOvsNetwork), reportxml.ID("85004"),
+				sriovoperator.CNITypeOVS, tsparams.OvsNetworkName),
+			// Sriov CNI same-node HWOL is deferred: VF representors are not on the managed OVS bridge.
+			PEntry("sriov CNI",
+				Label(tsparams.LabelOffload), Label(tsparams.LabelSriovNetwork), reportxml.ID("85005"),
+				sriovoperator.CNITypeSriov, tsparams.SriovNetworkName),
+		)
 	})
 
-func createAttachNetwork(cniType sriovoperator.CNIType, networkName, operatorNS string) error {
+func createAttachNetwork(
+	cniType sriovoperator.CNIType, networkName, operatorNS, ovsBridge string,
+) error {
 	switch cniType {
 	case sriovoperator.CNITypeOVS:
 		_, err := hwolenv.CreateOvsNetwork(
 			networkName, operatorNS, tsparams.ResourceName, tsparams.TestNamespaceName,
-			hwolenv.HostLocalIPAM)
+			hwolenv.HostLocalIPAM, ovsBridge)
 
 		return err
 	case sriovoperator.CNITypeSriov:
+		// Sriov CNI same-node HWOL is deferred: VF representors are not attached to the
+		// managed OVS bridge; the offload Entry is Pending until a supported plumbing path exists.
 		_, err := hwolenv.CreateSriovNetwork(
 			networkName, operatorNS, tsparams.ResourceName, tsparams.TestNamespaceName,
 			hwolenv.HostLocalIPAM)
@@ -152,29 +291,6 @@ func createAttachNetwork(cniType sriovoperator.CNIType, networkName, operatorNS 
 	default:
 		return fmt.Errorf("unsupported CNI type %q", cniType)
 	}
-}
-
-// assertNetworkStatusHasIP checks Multus network-status for an entry matching networkName
-// with at least one assigned IP (IPAM-agnostic: host-local, NV-IPAM, etc.).
-func assertNetworkStatusHasIP(networkStatusJSON, networkName string) error {
-	var entries []networkStatusEntry
-	if err := json.Unmarshal([]byte(networkStatusJSON), &entries); err != nil {
-		return fmt.Errorf("failed to parse network-status: %w", err)
-	}
-
-	for _, entry := range entries {
-		if entry.Name == networkName ||
-			strings.HasSuffix(entry.Name, "/"+networkName) ||
-			strings.Contains(entry.Name, networkName) {
-			if len(entry.IPs) > 0 {
-				return nil
-			}
-
-			return fmt.Errorf("network-status entry %q has no ips", entry.Name)
-		}
-	}
-
-	return fmt.Errorf("network-status has no entry for network %q", networkName)
 }
 
 func deleteAttachNetwork(cniType sriovoperator.CNIType, networkName, operatorNS string) error {
@@ -199,7 +315,96 @@ func deleteAttachNetwork(cniType sriovoperator.CNIType, networkName, operatorNS 
 	}
 }
 
-func createAttachPod(podName, networkName string) (*pod.Builder, error) {
+// waitForNetworkStatusIP refreshes the pod and waits until Multus network-status has an IP
+// for networkName.
+func waitForNetworkStatusIP(trafficPod *pod.Builder, networkName string) (string, error) {
+	var netIP string
+
+	var lastErr error
+
+	Eventually(func() error {
+		if !trafficPod.Exists() {
+			lastErr = fmt.Errorf("pod %s/%s does not exist",
+				trafficPod.Definition.Namespace, trafficPod.Definition.Name)
+
+			return lastErr
+		}
+
+		status := trafficPod.Object.Annotations["k8s.v1.cni.cncf.io/network-status"]
+		netIP, _, lastErr = networkStatusIPAndPCI(status, networkName, false)
+
+		return lastErr
+	}).WithTimeout(tsparams.DefaultTimeout).WithPolling(tsparams.RetryInterval).Should(Succeed())
+
+	return netIP, lastErr
+}
+
+// waitForNetworkStatusIPAndPCI waits until Multus network-status has an IP and PCI address
+// for networkName.
+func waitForNetworkStatusIPAndPCI(trafficPod *pod.Builder, networkName string) (string, string, error) {
+	var netIP, pci string
+
+	var lastErr error
+
+	Eventually(func() error {
+		if !trafficPod.Exists() {
+			lastErr = fmt.Errorf("pod %s/%s does not exist",
+				trafficPod.Definition.Namespace, trafficPod.Definition.Name)
+
+			return lastErr
+		}
+
+		status := trafficPod.Object.Annotations["k8s.v1.cni.cncf.io/network-status"]
+		netIP, pci, lastErr = networkStatusIPAndPCI(status, networkName, true)
+
+		return lastErr
+	}).WithTimeout(tsparams.DefaultTimeout).WithPolling(tsparams.RetryInterval).Should(Succeed())
+
+	return netIP, pci, lastErr
+}
+
+// networkStatusIPAndPCI returns the first IP (and optionally PCI) for a Multus network-status
+// entry matching networkName. When requirePCI is true, device-info pci-address must be set.
+func networkStatusIPAndPCI(
+	networkStatusJSON, networkName string, requirePCI bool,
+) (string, string, error) {
+	var entries []networkStatusEntry
+	if err := json.Unmarshal([]byte(networkStatusJSON), &entries); err != nil {
+		return "", "", fmt.Errorf("failed to parse network-status: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.Name == networkName ||
+			strings.HasSuffix(entry.Name, "/"+networkName) ||
+			strings.Contains(entry.Name, networkName) {
+			if len(entry.IPs) == 0 {
+				return "", "", fmt.Errorf("network-status entry %q has no ips", entry.Name)
+			}
+
+			netIP := entry.IPs[0]
+			if idx := strings.Index(netIP, "/"); idx >= 0 {
+				netIP = netIP[:idx]
+			}
+
+			pci := ""
+			if entry.DeviceInfo != nil && entry.DeviceInfo.Pci != nil {
+				pci = entry.DeviceInfo.Pci.PciAddress
+			}
+
+			if requirePCI && pci == "" {
+				return "", "", fmt.Errorf("network-status entry %q has no device-info PCI", entry.Name)
+			}
+
+			return netIP, pci, nil
+		}
+	}
+
+	return "", "", fmt.Errorf("network-status has no entry for network %q", networkName)
+}
+
+// createTrafficPod creates a sleep pod with the HWOL secondary network.
+// If nodeName is non-empty, the pod is pinned to that node (required for host-local IPAM pairs).
+func createTrafficPod(podName, networkName, nodeName string, cmd []string) (*pod.Builder, error) {
 	resName := corev1.ResourceName(tsparams.ResourceNamePrefix + tsparams.ResourceName)
 	secNetwork := pod.StaticIPAnnotation(networkName, nil)
 
@@ -207,16 +412,25 @@ func createAttachPod(podName, networkName string) (*pod.Builder, error) {
 		return nil, fmt.Errorf("failed to build secondary network annotation for %s", networkName)
 	}
 
+	// openshifttest/iperf3 is BusyBox: GNU "sleep infinity" is rejected ("invalid number").
+	if len(cmd) == 0 {
+		cmd = []string{"sleep", "86400000"}
+	}
+
 	builder := pod.NewBuilder(
 		APIClient,
 		podName,
 		tsparams.TestNamespaceName,
 		HwolOcpConfig.OcpHwolTestContainer,
-	).RedefineDefaultCMD([]string{"sleep", "infinity"}).
+	).RedefineDefaultCMD(cmd).
 		WithSecondaryNetwork(secNetwork)
 
+	if nodeName != "" {
+		builder = builder.DefineOnNode(nodeName)
+	}
+
 	if builder == nil || builder.Definition == nil || len(builder.Definition.Spec.Containers) == 0 {
-		return nil, fmt.Errorf("failed to init attach pod builder")
+		return nil, fmt.Errorf("failed to init traffic pod builder")
 	}
 
 	builder.Definition.Spec.Containers[0].Resources = corev1.ResourceRequirements{
@@ -225,4 +439,81 @@ func createAttachPod(podName, networkName string) (*pod.Builder, error) {
 	}
 
 	return builder.CreateAndWaitUntilRunning(tsparams.DefaultTimeout)
+}
+
+// iperfServerCMD returns a shell command that waits for net1, then runs iperf3 bound to that IP.
+// VF/sriov pods need -B on the secondary iface; plain iperf3 -s may not accept on net1.
+func iperfServerCMD() []string {
+	return []string{"sh", "-c", `
+iface=net1
+for i in $(seq 1 60); do
+  ip=$(ip -4 -o addr show dev "$iface" 2>/dev/null | awk '{print $4}' | cut -d/ -f1)
+  [ -n "$ip" ] && break
+  sleep 1
+done
+[ -n "$ip" ] || { echo "no IPv4 on $iface"; exit 1; }
+exec iperf3 -s -B "$ip"
+`}
+}
+
+// waitForHwolResource waits until node allocatable openshift.io/hwolresource >= min.
+func waitForHwolResource(nodeName string, min int64, timeout time.Duration) error {
+	resName := corev1.ResourceName(tsparams.ResourceNamePrefix + tsparams.ResourceName)
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		node, err := nodes.Pull(APIClient, nodeName)
+		if err != nil {
+			return fmt.Errorf("failed to pull node %s: %w", nodeName, err)
+		}
+
+		qty := node.Object.Status.Allocatable[resName]
+		if qty.Value() >= min {
+			return nil
+		}
+
+		time.Sleep(5 * time.Second)
+	}
+
+	return fmt.Errorf("timed out waiting for %s allocatable >= %d on %s", resName, min, nodeName)
+}
+
+// runIperfBetweenPods runs the iperf3 client against a server already listening in serverPod
+// (container command iperf3 -s). Client binds to the secondary-network IP so traffic does not
+// egress via the pod primary NIC.
+func runIperfBetweenPods(
+	clientPod *pod.Builder,
+	serverIP, clientIP string,
+	duration time.Duration,
+) error {
+	if serverIP == "" || clientIP == "" {
+		return fmt.Errorf("serverIP and clientIP cannot be empty")
+	}
+
+	seconds := int(duration.Seconds())
+	if seconds < 1 {
+		seconds = 1
+	}
+
+	// Brief settle, then verify L2 reachability before iperf (sriov VF paths need ARP).
+	time.Sleep(3 * time.Second)
+
+	if _, err := clientPod.ExecCommand([]string{
+		"ping", "-I", clientIP, "-c", "3", "-W", "2", serverIP,
+	}); err != nil {
+		return fmt.Errorf("ping from %s to %s failed: %w", clientIP, serverIP, err)
+	}
+
+	out, err := clientPod.ExecCommandWithTimeout(
+		[]string{
+			"iperf3", "-c", serverIP, "-B", clientIP,
+			"-t", fmt.Sprintf("%d", seconds),
+		},
+		duration+30*time.Second,
+	)
+	if err != nil {
+		return fmt.Errorf("iperf3 client failed: %w (out=%s)", err, out.String())
+	}
+
+	return nil
 }

--- a/tests/ocp/hwol/tests/hwol.go
+++ b/tests/ocp/hwol/tests/hwol.go
@@ -1,0 +1,228 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/sriov"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/sriovoperator"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/hwolenv"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/ocphwolinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/tsparams"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+type networkStatusEntry struct {
+	Name string   `json:"name"`
+	IPs  []string `json:"ips"`
+}
+
+var _ = Describe(
+	"HWOL",
+	Ordered,
+	ContinueOnFailure,
+	func() {
+		var (
+			operatorNS string
+			mcpLabel   string
+			pfName     string
+		)
+
+		BeforeAll(func() {
+			operatorNS = HwolOcpConfig.OcpHwolOperatorNamespace
+			mcpLabel = HwolOcpConfig.MCPLabel
+
+			By("Loading HWOL device configuration from ECO_OCP_HWOL_DEVICES")
+
+			devices, err := HwolOcpConfig.GetHwolDevices()
+			Expect(err).ToNot(HaveOccurred(), "Failed to get HWOL devices")
+			Expect(devices).ToNot(BeEmpty(), "No HWOL devices configured")
+			pfName = devices[0].InterfaceName
+
+			vfNum, err := HwolOcpConfig.GetVFNum()
+			Expect(err).ToNot(HaveOccurred(), "Failed to get VF count")
+
+			By("Ensuring switchdev foundation (operator config, pool, policy, wait)")
+
+			Expect(hwolenv.EnsureSwitchdevFoundation(
+				operatorNS, mcpLabel, devices[0], vfNum,
+			)).To(Succeed(), "Failed to ensure switchdev foundation")
+		})
+
+		AfterAll(func() {
+			By("Cleaning HWOL resources")
+
+			err := hwolenv.CleanupHwolResources(
+				operatorNS,
+				mcpLabel,
+				tsparams.CleanupWaitTimeout,
+				tsparams.DefaultStableDuration,
+			)
+			Expect(err).ToNot(HaveOccurred(), "Failed to clean HWOL resources")
+		})
+
+		It("verifies switchdev mode and managed OVS bridge on MCP nodes",
+			Label(tsparams.LabelSwitchdev),
+			reportxml.ID("85001"),
+			func() {
+				By("Asserting eSwitchMode=switchdev and OVS bridge uplink for PF")
+
+				Expect(hwolenv.AssertSwitchdevAndOVSBridge(operatorNS, mcpLabel, pfName)).To(Succeed())
+			})
+
+		DescribeTable("attach path",
+			func(cniType sriovoperator.CNIType, networkName string) {
+				By(fmt.Sprintf("Creating %s network %s", cniType, networkName))
+
+				err := createAttachNetwork(cniType, networkName, operatorNS)
+				Expect(err).ToNot(HaveOccurred(), "Failed to create attach network")
+
+				DeferCleanup(func() {
+					By(fmt.Sprintf("Deleting %s network %s", cniType, networkName))
+
+					Expect(deleteAttachNetwork(cniType, networkName, operatorNS)).To(Succeed(),
+						"Failed to delete attach network")
+					Expect(sriovoperator.WaitForNADDeletion(
+						APIClient, networkName, tsparams.TestNamespaceName, tsparams.DefaultTimeout,
+					)).To(Succeed(), "NAD was not deleted")
+				})
+
+				By("Waiting for NAD creation")
+
+				Expect(sriovoperator.WaitForNADCreation(
+					APIClient, networkName, tsparams.TestNamespaceName, tsparams.DefaultTimeout,
+				)).To(Succeed(), "NAD was not created")
+
+				By("Asserting NAD CNI type and resource annotation")
+
+				Expect(sriovoperator.AssertNAD(
+					APIClient,
+					networkName,
+					tsparams.TestNamespaceName,
+					cniType,
+					tsparams.ResourceNamePrefix+tsparams.ResourceName,
+				)).To(Succeed(), "NAD assertion failed")
+
+				By("Creating sleep pod with secondary network")
+
+				attachPod, err := createAttachPod(fmt.Sprintf("hwol-attach-%s", cniType), networkName)
+				Expect(err).ToNot(HaveOccurred(), "Failed to create attach pod")
+
+				DeferCleanup(func() {
+					By("Deleting attach pod")
+
+					Expect(attachPod.Delete()).To(Succeed(), "Failed to delete attach pod")
+				})
+
+				By("Asserting pod network-status includes the attach NAD with an IP")
+
+				Expect(attachPod.Object.Annotations).To(HaveKey("k8s.v1.cni.cncf.io/network-status"))
+				Expect(assertNetworkStatusHasIP(
+					attachPod.Object.Annotations["k8s.v1.cni.cncf.io/network-status"],
+					networkName,
+				)).To(Succeed(), "network-status should reference attach NAD with an assigned IP")
+			},
+			Entry("ovs CNI", Label(tsparams.LabelOvsNetwork), reportxml.ID("85002"),
+				sriovoperator.CNITypeOVS, tsparams.OvsNetworkName),
+			Entry("sriov CNI", Label(tsparams.LabelSriovNetwork), reportxml.ID("85003"),
+				sriovoperator.CNITypeSriov, tsparams.SriovNetworkName),
+		)
+	})
+
+func createAttachNetwork(cniType sriovoperator.CNIType, networkName, operatorNS string) error {
+	switch cniType {
+	case sriovoperator.CNITypeOVS:
+		_, err := hwolenv.CreateOvsNetwork(
+			networkName, operatorNS, tsparams.ResourceName, tsparams.TestNamespaceName,
+			hwolenv.HostLocalIPAM)
+
+		return err
+	case sriovoperator.CNITypeSriov:
+		_, err := hwolenv.CreateSriovNetwork(
+			networkName, operatorNS, tsparams.ResourceName, tsparams.TestNamespaceName,
+			hwolenv.HostLocalIPAM)
+
+		return err
+	default:
+		return fmt.Errorf("unsupported CNI type %q", cniType)
+	}
+}
+
+// assertNetworkStatusHasIP checks Multus network-status for an entry matching networkName
+// with at least one assigned IP (IPAM-agnostic: host-local, NV-IPAM, etc.).
+func assertNetworkStatusHasIP(networkStatusJSON, networkName string) error {
+	var entries []networkStatusEntry
+	if err := json.Unmarshal([]byte(networkStatusJSON), &entries); err != nil {
+		return fmt.Errorf("failed to parse network-status: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.Name == networkName ||
+			strings.HasSuffix(entry.Name, "/"+networkName) ||
+			strings.Contains(entry.Name, networkName) {
+			if len(entry.IPs) > 0 {
+				return nil
+			}
+
+			return fmt.Errorf("network-status entry %q has no ips", entry.Name)
+		}
+	}
+
+	return fmt.Errorf("network-status has no entry for network %q", networkName)
+}
+
+func deleteAttachNetwork(cniType sriovoperator.CNIType, networkName, operatorNS string) error {
+	switch cniType {
+	case sriovoperator.CNITypeOVS:
+		builder := hwolenv.NewOvsNetworkBuilder(
+			APIClient, networkName, operatorNS, tsparams.TestNamespaceName, tsparams.ResourceName)
+		if builder == nil {
+			return fmt.Errorf("failed to init OVSNetwork builder for delete")
+		}
+
+		return builder.Delete()
+	case sriovoperator.CNITypeSriov:
+		builder, err := sriov.PullNetwork(APIClient, networkName, operatorNS)
+		if err != nil {
+			return nil
+		}
+
+		return builder.Delete()
+	default:
+		return fmt.Errorf("unsupported CNI type %q", cniType)
+	}
+}
+
+func createAttachPod(podName, networkName string) (*pod.Builder, error) {
+	resName := corev1.ResourceName(tsparams.ResourceNamePrefix + tsparams.ResourceName)
+	secNetwork := pod.StaticIPAnnotation(networkName, nil)
+
+	if secNetwork == nil {
+		return nil, fmt.Errorf("failed to build secondary network annotation for %s", networkName)
+	}
+
+	builder := pod.NewBuilder(
+		APIClient,
+		podName,
+		tsparams.TestNamespaceName,
+		HwolOcpConfig.OcpHwolTestContainer,
+	).RedefineDefaultCMD([]string{"sleep", "infinity"}).
+		WithSecondaryNetwork(secNetwork)
+
+	if builder == nil || builder.Definition == nil || len(builder.Definition.Spec.Containers) == 0 {
+		return nil, fmt.Errorf("failed to init attach pod builder")
+	}
+
+	builder.Definition.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{resName: resource.MustParse("1")},
+		Limits:   corev1.ResourceList{resName: resource.MustParse("1")},
+	}
+
+	return builder.CreateAndWaitUntilRunning(tsparams.DefaultTimeout)
+}

--- a/tests/ocp/hwol/tests/hwol.go
+++ b/tests/ocp/hwol/tests/hwol.go
@@ -84,6 +84,24 @@ var _ = Describe(
 				tsparams.CleanupWaitTimeout,
 				tsparams.DefaultStableDuration,
 			)
+			if err == nil {
+				return
+			}
+
+			// Leaving switchdev often hits mlx5 "device or resource busy"; do not fail
+			// an otherwise green ovs run. Unexpected cleanup errors still fail AfterAll.
+			errMsg := err.Error()
+			if strings.Contains(errMsg, "device or resource busy") ||
+				strings.Contains(errMsg, "context deadline exceeded") ||
+				strings.Contains(errMsg, "stuck resetting switchdev") {
+				GinkgoWriter.Printf(
+					"WARNING: HWOL cleanup timed out leaving switchdev (reboot MCP node before re-run): %v\n",
+					err)
+				AddReportEntry("hwol-cleanup-busy", errMsg)
+
+				return
+			}
+
 			Expect(err).ToNot(HaveOccurred(), "Failed to clean HWOL resources")
 		})
 

--- a/tests/ocp/hwol/tests/setup.go
+++ b/tests/ocp/hwol/tests/setup.go
@@ -1,0 +1,38 @@
+// Package tests contains the HWOL test cases for OCP.
+package tests
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/sriovoperator"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/ocphwolinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/hwol/internal/tsparams"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe(
+	"HWOL setup",
+	Ordered,
+	Label(tsparams.LabelSetup),
+	func() {
+		It("verifies operator, devices config, and worker nodes", func() {
+			By("Checking the SR-IOV operator is running")
+
+			err := sriovoperator.IsSriovDeployed(APIClient, HwolOcpConfig.OcpHwolOperatorNamespace)
+			Expect(err).ToNot(HaveOccurred(), "SR-IOV operator is not running")
+
+			By("Loading HWOL device configuration from ECO_OCP_HWOL_DEVICES")
+
+			devices, err := HwolOcpConfig.GetHwolDevices()
+			Expect(err).ToNot(HaveOccurred(), "Failed to get HWOL devices")
+			Expect(len(devices)).To(BeNumerically(">", 0), "No HWOL devices configured")
+
+			By("Discovering worker nodes")
+
+			workerNodes, err := nodes.List(APIClient,
+				metav1.ListOptions{LabelSelector: HwolOcpConfig.WorkerLabel})
+			Expect(err).ToNot(HaveOccurred(), "Failed to discover nodes")
+			Expect(len(workerNodes)).To(BeNumerically(">=", 1), "No worker nodes found")
+		})
+	})

--- a/tests/ocp/hwol/tests/setup.go
+++ b/tests/ocp/hwol/tests/setup.go
@@ -17,6 +17,9 @@ var _ = Describe(
 	Label(tsparams.LabelSetup),
 	func() {
 		It("verifies operator, devices config, and worker nodes", func() {
+			Expect(HwolOcpConfig).ToNot(BeNil(),
+				"HwolOcpConfig is nil: config init failed (see NewHwolOcpConfig logs)")
+
 			By("Checking the SR-IOV operator is running")
 
 			err := sriovoperator.IsSriovDeployed(APIClient, HwolOcpConfig.OcpHwolOperatorNamespace)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OCP hardware-offload validation for switchdev, OVS networking, SR-IOV network attachment, traffic connectivity, and offloaded datapath flows.
  - Added configurable hardware-device and virtual-function settings with default values.
  - Added automated resource provisioning, stability checks, cleanup, and failure diagnostics.

- **Documentation**
  - Added guidance covering prerequisites, configuration, execution, coverage, cleanup, and known limitations.

- **Tests**
  - Added validation for SR-IOV availability, worker-node readiness, network status, VF representors, and OVS offload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->