### PR TITLE
ptp: assert holdover-acquired lock state before holdover tests

### DIFF
--- a/tests/cnf/ran/ptp/internal/metrics/consts.go
+++ b/tests/cnf/ran/ptp/internal/metrics/consts.go
@@ -27,6 +27,20 @@ const (
 	MetricHAProfileStatus PtpMetric = "openshift_ptp_ha_profile_status"
 	MetricPPSStatus       PtpMetric = "openshift_ptp_pps_status"
 	MetricClockClass      PtpMetric = "openshift_ptp_clock_class"
+	MetricPhaseStatus     PtpMetric = "openshift_ptp_phase_status"
+)
+
+// PtpPhaseState is an enum representing all possible states of the openshift_ptp_phase_status metric.
+type PtpPhaseState int
+
+//nolint:revive // The phase state names are self explanatory and do not need individual comments.
+const (
+	PhaseStateUnknown PtpPhaseState = iota - 1
+	PhaseStateInvalid
+	PhaseStateFreerun
+	PhaseStateLocked
+	PhaseStateLockedHoldoverAcquired
+	PhaseStateHoldover
 )
 
 // PtpClockState is an enum representing all possible states of the PTP clock.

--- a/tests/cnf/ran/ptp/internal/metrics/queries.go
+++ b/tests/cnf/ran/ptp/internal/metrics/queries.go
@@ -384,6 +384,30 @@ func (query PPSStatusQuery) ToMetricQuery() MetricQuery[PtpPPSStatus] {
 	}
 }
 
+// PhaseStatusQuery is a query for the openshift_ptp_phase_status metric.
+type PhaseStatusQuery struct {
+	From      MetricLabel[PtpProcess]
+	Interface MetricLabel[iface.NICName]
+	Node      MetricLabel[string]
+	Process   MetricLabel[PtpProcess]
+}
+
+// This asserts at compile time that PhaseStatusQuery implements the Query interface.
+var _ Query[PtpPhaseState] = PhaseStatusQuery{}
+
+// ToMetricQuery converts the PhaseStatusQuery to a MetricQuery to fulfill the Query interface.
+func (query PhaseStatusQuery) ToMetricQuery() MetricQuery[PtpPhaseState] {
+	return MetricQuery[PtpPhaseState]{
+		Metric: MetricPhaseStatus,
+		Labels: map[PtpMetricKey]MetricLabel[any]{
+			KeyFrom:      query.From.ToAny(),
+			KeyInterface: query.Interface.ensureNIC().ToAny(),
+			KeyNode:      query.Node.ToAny(),
+			KeyProcess:   query.Process.ToAny(),
+		},
+	}
+}
+
 // ClockClassQuery is a query for the openshift_ptp_clock_class metric.
 type ClockClassQuery struct {
 	Node    MetricLabel[string]

--- a/tests/cnf/ran/ptp/internal/profiles/tbc.go
+++ b/tests/cnf/ran/ptp/internal/profiles/tbc.go
@@ -13,6 +13,7 @@ type HoldoverTestData struct {
 	NodeName       string
 	ProfileInfo    *ProfileInfo
 	UpstreamIfaces []iface.Name
+	ConfigFile     string
 }
 
 // HoldoverExpectedClockClasses groups the expected clock class values for each holdover state.

--- a/tests/cnf/ran/ptp/tests/ptp-dual-tbc.go
+++ b/tests/cnf/ran/ptp/tests/ptp-dual-tbc.go
@@ -104,7 +104,7 @@ func assertDualTBCFailoverToBackup(testData profiles.HoldoverTestData, timeout t
 		profiles.TBCClockClasses().HoldoverInSpec, true, timeout, false)
 
 	assertLockedState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
-		profiles.TBCClockClasses().Locked, true, timeout)
+		profiles.TBCClockClasses().Locked, true, timeout, testData.UpstreamIfaces)
 
 	By("validating interface roles after failover")
 

--- a/tests/cnf/ran/ptp/tests/ptp-dual-tbc.go
+++ b/tests/cnf/ran/ptp/tests/ptp-dual-tbc.go
@@ -101,10 +101,10 @@ func assertDualTBCFailoverToBackup(testData profiles.HoldoverTestData, timeout t
 		"Failed to set active upstream interface %s down on node %s", activeIface, testData.NodeName)
 
 	assertHoldoverState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
-		profiles.TBCClockClasses().HoldoverInSpec, true, timeout, false)
+		profiles.TBCClockClasses().HoldoverInSpec, true, timeout, false, testData.ConfigFile)
 
 	assertLockedState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
-		profiles.TBCClockClasses().Locked, true, timeout, testData.UpstreamIfaces)
+		profiles.TBCClockClasses().Locked, true, timeout, testData.UpstreamIfaces, testData.ConfigFile)
 
 	By("validating interface roles after failover")
 
@@ -150,10 +150,10 @@ func assertDualTBCHoldoverInSpecToFreerun(
 	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces down")
 
 	assertHoldoverState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
-		expected.HoldoverInSpec, true, timeout, true)
+		expected.HoldoverInSpec, true, timeout, true, testData.ConfigFile)
 
 	assertFreerunState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
-		expected.Freerun, true, timeout)
+		expected.Freerun, true, timeout, testData.ConfigFile)
 
 	By("validating both upstream interfaces are FAULTY")
 

--- a/tests/cnf/ran/ptp/tests/ptp-holdover.go
+++ b/tests/cnf/ran/ptp/tests/ptp-holdover.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/events"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/iface"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/metrics"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/processes"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/profiles"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/tsparams"
 	"k8s.io/klog/v2"
@@ -208,7 +209,7 @@ func assertHoldoverInSpecToLocked(
 	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces down")
 
 	assertHoldoverState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
-		expected.HoldoverInSpec, clockClassChanges, timeout, true)
+		expected.HoldoverInSpec, clockClassChanges, timeout, true, testData.ConfigFile)
 
 	By("setting upstream clock interfaces up to return to locked")
 
@@ -219,7 +220,7 @@ func assertHoldoverInSpecToLocked(
 	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces up")
 
 	assertLockedState(testData.PrometheusAPI, testData.NodeName, ifaceUpTime,
-		expected.Locked, clockClassChanges, timeout, testData.UpstreamIfaces)
+		expected.Locked, clockClassChanges, timeout, testData.UpstreamIfaces, testData.ConfigFile)
 
 	assertNoFreerunEvent(testData.NodeName, ifaceUpTime)
 }
@@ -250,10 +251,10 @@ func assertHoldoverInSpecToFreerun(
 	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces down")
 
 	assertHoldoverState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
-		expected.HoldoverInSpec, clockClassChanges, timeout, true)
+		expected.HoldoverInSpec, clockClassChanges, timeout, true, testData.ConfigFile)
 
 	assertFreerunState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
-		expected.Freerun, clockClassChanges, timeout)
+		expected.Freerun, clockClassChanges, timeout, testData.ConfigFile)
 
 	By("setting upstream clock interfaces up to return to locked")
 
@@ -264,7 +265,7 @@ func assertHoldoverInSpecToFreerun(
 	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces up")
 
 	assertLockedState(testData.PrometheusAPI, testData.NodeName, ifaceUpTime,
-		expected.Locked, clockClassChanges, timeout, testData.UpstreamIfaces)
+		expected.Locked, clockClassChanges, timeout, testData.UpstreamIfaces, testData.ConfigFile)
 }
 
 // assertHoldoverInSpecToOutOfSpec validates that after upstream clock loss the clock enters holdover-in-spec,
@@ -294,10 +295,10 @@ func assertHoldoverInSpecToOutOfSpec(
 	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces down")
 
 	assertHoldoverState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
-		expected.HoldoverInSpec, clockClassChanges, timeout, true)
+		expected.HoldoverInSpec, clockClassChanges, timeout, true, testData.ConfigFile)
 
 	assertHoldoverOutOfSpecClockClass(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
-		expected.HoldoverOutOfSpec, clockClassChanges, timeout)
+		expected.HoldoverOutOfSpec, clockClassChanges, timeout, testData.ConfigFile)
 
 	By("setting upstream clock interfaces up to return to locked")
 
@@ -308,7 +309,7 @@ func assertHoldoverInSpecToOutOfSpec(
 	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces up")
 
 	assertLockedState(testData.PrometheusAPI, testData.NodeName, ifaceUpTime,
-		expected.Locked, clockClassChanges, timeout, testData.UpstreamIfaces)
+		expected.Locked, clockClassChanges, timeout, testData.UpstreamIfaces, testData.ConfigFile)
 
 	assertNoFreerunEvent(testData.NodeName, ifaceUpTime)
 }
@@ -339,13 +340,13 @@ func assertHoldoverOutOfSpecToFreerun(
 	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces down")
 
 	assertHoldoverState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
-		expected.HoldoverInSpec, clockClassChanges, timeout, true)
+		expected.HoldoverInSpec, clockClassChanges, timeout, true, testData.ConfigFile)
 
 	assertHoldoverOutOfSpecClockClass(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
-		expected.HoldoverOutOfSpec, clockClassChanges, timeout)
+		expected.HoldoverOutOfSpec, clockClassChanges, timeout, testData.ConfigFile)
 
 	assertFreerunState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
-		expected.Freerun, clockClassChanges, timeout)
+		expected.Freerun, clockClassChanges, timeout, testData.ConfigFile)
 
 	By("setting upstream clock interfaces up to return to locked")
 
@@ -356,7 +357,7 @@ func assertHoldoverOutOfSpecToFreerun(
 	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces up")
 
 	assertLockedState(testData.PrometheusAPI, testData.NodeName, ifaceUpTime,
-		expected.Locked, clockClassChanges, timeout, testData.UpstreamIfaces)
+		expected.Locked, clockClassChanges, timeout, testData.UpstreamIfaces, testData.ConfigFile)
 }
 
 // assertHoldoverState waits for the HOLDOVER event and optional clock class change event, then validates
@@ -372,6 +373,7 @@ func assertHoldoverState(
 	clockClassChanges bool,
 	timeout time.Duration,
 	checkMetrics bool,
+	configFile string,
 ) {
 	GinkgoHelper()
 
@@ -415,6 +417,7 @@ func assertHoldoverState(
 	clockClassQuery := metrics.ClockClassQuery{
 		Node:    metrics.Equals(nodeName),
 		Process: metrics.Equals(metrics.ProcessPTP4L),
+		Config:  metrics.Equals(configFile),
 	}
 	err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockClassQuery, expectedClockClass,
 		metrics.AssertWithTimeout(1*time.Minute))
@@ -431,6 +434,7 @@ func assertLockedState(
 	clockClassChanges bool,
 	timeout time.Duration,
 	upstreamIfaces []iface.Name,
+	configFile string,
 ) {
 	GinkgoHelper()
 
@@ -470,6 +474,7 @@ func assertLockedState(
 	clockClassQuery := metrics.ClockClassQuery{
 		Node:    metrics.Equals(nodeName),
 		Process: metrics.Equals(metrics.ProcessPTP4L),
+		Config:  metrics.Equals(configFile),
 	}
 	err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockClassQuery, expectedClockClass,
 		metrics.AssertWithTimeout(1*time.Minute))
@@ -487,6 +492,7 @@ func assertFreerunState(
 	expectedClockClass metrics.PtpClockClass,
 	clockClassChanges bool,
 	timeout time.Duration,
+	configFile string,
 ) {
 	GinkgoHelper()
 
@@ -536,6 +542,7 @@ func assertFreerunState(
 	clockClassQuery := metrics.ClockClassQuery{
 		Node:    metrics.Equals(nodeName),
 		Process: metrics.Equals(metrics.ProcessPTP4L),
+		Config:  metrics.Equals(configFile),
 	}
 	err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockClassQuery, expectedClockClass,
 		metrics.AssertWithTimeout(1*time.Minute))
@@ -551,6 +558,7 @@ func assertHoldoverOutOfSpecClockClass(
 	expectedClockClass metrics.PtpClockClass,
 	clockClassChanges bool,
 	timeout time.Duration,
+	configFile string,
 ) {
 	GinkgoHelper()
 
@@ -581,6 +589,7 @@ func assertHoldoverOutOfSpecClockClass(
 	clockClassQuery := metrics.ClockClassQuery{
 		Node:    metrics.Equals(nodeName),
 		Process: metrics.Equals(metrics.ProcessPTP4L),
+		Config:  metrics.Equals(configFile),
 	}
 	err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockClassQuery, expectedClockClass,
 		metrics.AssertWithTimeout(1*time.Minute))
@@ -667,7 +676,7 @@ func changeHoldoverSettings(
 		restoreTime = time.Now()
 
 		assertLockedState(testData.PrometheusAPI, testData.NodeName, restoreTime,
-			expectedLockedClass, clockClassChanges, timeout, testData.UpstreamIfaces)
+			expectedLockedClass, clockClassChanges, timeout, testData.UpstreamIfaces, testData.ConfigFile)
 	})
 
 	setTime := time.Now()
@@ -679,7 +688,7 @@ func changeHoldoverSettings(
 	setTime = time.Now()
 
 	assertLockedState(testData.PrometheusAPI, testData.NodeName, setTime,
-		expectedLockedClass, clockClassChanges, timeout, testData.UpstreamIfaces)
+		expectedLockedClass, clockClassChanges, timeout, testData.UpstreamIfaces, testData.ConfigFile)
 }
 
 // discoverHoldoverTestData finds the first node with a matching profile type that supports holdover tests
@@ -719,11 +728,28 @@ func discoverHoldoverTestData(
 				NodeName:       name,
 				ProfileInfo:    profileInfo,
 				UpstreamIfaces: ports,
+				ConfigFile:     getPtp4lConfigFileForNode(name),
 			}
 		}
 	}
 
 	return nil
+}
+
+// getPtp4lConfigFileForNode returns the ptp4l.<index>.config name for the ts2phc process on the given node.
+func getPtp4lConfigFileForNode(nodeName string) string {
+	configSupported, err := version.IsVersionStringInRange(
+		RANConfig.Spoke1OperatorVersions[ranparam.PTP], "4.21.0-0", "")
+	Expect(err).ToNot(HaveOccurred(), "Failed to check PTP operator version range")
+
+	if !configSupported {
+		return ""
+	}
+
+	configFile, err := processes.GetPtp4lConfigByRelatedProcess(RANConfig.Spoke1APIClient, nodeName, processes.Ts2phc)
+	Expect(err).ToNot(HaveOccurred(), "Failed to determine ptp4l config for node %s", nodeName)
+
+	return configFile
 }
 
 // restoreInterfacesAndWaitForRelock brings the upstream interfaces back up and waits for the T-BC clock to return

--- a/tests/cnf/ran/ptp/tests/ptp-holdover.go
+++ b/tests/cnf/ran/ptp/tests/ptp-holdover.go
@@ -82,6 +82,8 @@ var _ = Describe("PTP Holdover", Label(tsparams.LabelTBCTSCHoldover), func() {
 
 			klog.V(tsparams.LogLevel).Infof(
 				"T-BC holdover test on node %s, upstream interfaces %v", testData.NodeName, testData.UpstreamIfaces)
+
+			assertDPLLPhaseLockedHoldoverAcquired(testData.PrometheusAPI, testData.NodeName, testData.UpstreamIfaces)
 		})
 
 		// 83297 - Verifies t-bc transition from holdover-in-spec to locked when upstream clock recovers
@@ -146,6 +148,8 @@ var _ = Describe("PTP Holdover", Label(tsparams.LabelTBCTSCHoldover), func() {
 
 			klog.V(tsparams.LogLevel).Infof(
 				"T-TSC holdover test on node %s, upstream interfaces %v", testData.NodeName, testData.UpstreamIfaces)
+
+			assertDPLLPhaseLockedHoldoverAcquired(testData.PrometheusAPI, testData.NodeName, testData.UpstreamIfaces)
 		})
 
 		// 88274 - Verifies t-tsc transition from holdover-in-spec to locked when upstream clock recovers
@@ -215,7 +219,7 @@ func assertHoldoverInSpecToLocked(
 	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces up")
 
 	assertLockedState(testData.PrometheusAPI, testData.NodeName, ifaceUpTime,
-		expected.Locked, clockClassChanges, timeout)
+		expected.Locked, clockClassChanges, timeout, testData.UpstreamIfaces)
 
 	assertNoFreerunEvent(testData.NodeName, ifaceUpTime)
 }
@@ -260,7 +264,7 @@ func assertHoldoverInSpecToFreerun(
 	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces up")
 
 	assertLockedState(testData.PrometheusAPI, testData.NodeName, ifaceUpTime,
-		expected.Locked, clockClassChanges, timeout)
+		expected.Locked, clockClassChanges, timeout, testData.UpstreamIfaces)
 }
 
 // assertHoldoverInSpecToOutOfSpec validates that after upstream clock loss the clock enters holdover-in-spec,
@@ -304,7 +308,7 @@ func assertHoldoverInSpecToOutOfSpec(
 	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces up")
 
 	assertLockedState(testData.PrometheusAPI, testData.NodeName, ifaceUpTime,
-		expected.Locked, clockClassChanges, timeout)
+		expected.Locked, clockClassChanges, timeout, testData.UpstreamIfaces)
 
 	assertNoFreerunEvent(testData.NodeName, ifaceUpTime)
 }
@@ -352,7 +356,7 @@ func assertHoldoverOutOfSpecToFreerun(
 	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces up")
 
 	assertLockedState(testData.PrometheusAPI, testData.NodeName, ifaceUpTime,
-		expected.Locked, clockClassChanges, timeout)
+		expected.Locked, clockClassChanges, timeout, testData.UpstreamIfaces)
 }
 
 // assertHoldoverState waits for the HOLDOVER event and optional clock class change event, then validates
@@ -426,6 +430,7 @@ func assertLockedState(
 	expectedClockClass metrics.PtpClockClass,
 	clockClassChanges bool,
 	timeout time.Duration,
+	upstreamIfaces []iface.Name,
 ) {
 	GinkgoHelper()
 
@@ -469,6 +474,8 @@ func assertLockedState(
 	err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockClassQuery, expectedClockClass,
 		metrics.AssertWithTimeout(1*time.Minute))
 	Expect(err).ToNot(HaveOccurred(), "Failed to assert clock class %d in metrics", expectedClockClass)
+
+	assertDPLLPhaseLockedHoldoverAcquired(prometheusAPI, nodeName, upstreamIfaces)
 }
 
 // assertFreerunState waits for the FREERUN event and optional clock class change event, then validates
@@ -580,6 +587,28 @@ func assertHoldoverOutOfSpecClockClass(
 	Expect(err).ToNot(HaveOccurred(), "Failed to assert clock class %d in metrics", expectedClockClass)
 }
 
+// assertDPLLPhaseLockedHoldoverAcquired validates that the DPLL phase status is LOCKED_HO_ACQ on every upstream NIC.
+func assertDPLLPhaseLockedHoldoverAcquired(
+	prometheusAPI prometheusv1.API, nodeName string, upstreamIfaces []iface.Name,
+) {
+	GinkgoHelper()
+
+	for nicName := range iface.GroupInterfacesByNIC(upstreamIfaces) {
+		By(fmt.Sprintf("validating metrics: DPLL phase LOCKED_HO_ACQ on interface %s", nicName))
+
+		phaseStatusQuery := metrics.PhaseStatusQuery{
+			Node:      metrics.Equals(nodeName),
+			Interface: metrics.Equals(nicName),
+			From:      metrics.Equals(metrics.ProcessDPLL),
+			Process:   metrics.Equals(metrics.ProcessDPLL),
+		}
+		err := metrics.AssertQuery(
+			context.TODO(), prometheusAPI, phaseStatusQuery, metrics.PhaseStateLockedHoldoverAcquired,
+			metrics.AssertWithTimeout(1*time.Minute))
+		Expect(err).ToNot(HaveOccurred(), "Failed to assert DPLL phase state LOCKED_HO_ACQ on interface %s", nicName)
+	}
+}
+
 // assertNoFreerunEvent validates that no FREERUN ptp-state-change event is generated within 30 seconds.
 func assertNoFreerunEvent(nodeName string, sinceTime time.Time) {
 	GinkgoHelper()
@@ -638,7 +667,7 @@ func changeHoldoverSettings(
 		restoreTime = time.Now()
 
 		assertLockedState(testData.PrometheusAPI, testData.NodeName, restoreTime,
-			expectedLockedClass, clockClassChanges, timeout)
+			expectedLockedClass, clockClassChanges, timeout, testData.UpstreamIfaces)
 	})
 
 	setTime := time.Now()
@@ -650,7 +679,7 @@ func changeHoldoverSettings(
 	setTime = time.Now()
 
 	assertLockedState(testData.PrometheusAPI, testData.NodeName, setTime,
-		expectedLockedClass, clockClassChanges, timeout)
+		expectedLockedClass, clockClassChanges, timeout, testData.UpstreamIfaces)
 }
 
 // discoverHoldoverTestData finds the first node with a matching profile type that supports holdover tests


### PR DESCRIPTION
Asserts DPLL phase reaches LOCKED_HO_ACQ (openshift_ptp_phase_status) on
T-BC/T-TSC holdover tests: once before each holdover Context runs, and
again after recovery to LOCKED.