### PR TITLE
ocp sriov: fix flaky metrics exporter test by handling transient empt…

### DIFF
--- a/tests/cnf/core/network/sriov/tests/metricsExporter.go
+++ b/tests/cnf/core/network/sriov/tests/metricsExporter.go
@@ -523,14 +523,41 @@ func fetchScalarFromPromQLoutput(res string) int {
 
 	By("Fetch the final value from the PromQL output")
 
+	if strings.TrimSpace(res) == "" {
+		fmt.Fprintf(GinkgoWriter, "PromQL returned empty output, returning -1 to allow Eventually to retry\n")
+
+		return -1
+	}
+
 	var outValue podMetricPromQLoutput
 
 	err := json.Unmarshal([]byte(res), &outValue)
-	Expect(err).ToNot(HaveOccurred(), "Failed to Unmarshal promQL output from prometheus pod")
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter, "Failed to unmarshal PromQL output: %v, returning -1 to allow Eventually to retry\n", err)
 
-	//nolint:forcetypeassert
-	finalVal, err := strconv.Atoi(outValue[0].Value[1].(string))
-	Expect(err).To(Not(HaveOccurred()), "Failed to convert counter value to int")
+		return -1
+	}
+
+	if len(outValue) == 0 || len(outValue[0].Value) < 2 {
+		fmt.Fprintf(GinkgoWriter, "PromQL output contains no usable metrics, returning -1 to allow Eventually to retry\n")
+
+		return -1
+	}
+
+	valueStr, ok := outValue[0].Value[1].(string)
+	if !ok {
+		fmt.Fprintf(GinkgoWriter, "PromQL metric value is not a string, returning -1 to allow Eventually to retry\n")
+
+		return -1
+	}
+
+	finalVal, err := strconv.Atoi(valueStr)
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter,
+			"Failed to convert counter value to int: %v, returning -1 to allow Eventually to retry\n", err)
+
+		return -1
+	}
 
 	return finalVal
 }

--- a/tests/ocp/sriov/tests/metricsExporter.go
+++ b/tests/ocp/sriov/tests/metricsExporter.go
@@ -560,19 +560,41 @@ func fetchScalarFromPromQLoutput(res string) int {
 
 	By("Fetch the final value from the PromQL output")
 
+	if strings.TrimSpace(res) == "" {
+		fmt.Fprintf(GinkgoWriter, "PromQL returned empty output, returning -1 to allow Eventually to retry\n")
+
+		return -1
+	}
+
 	var outValue podMetricPromQLoutput
 
 	err := json.Unmarshal([]byte(res), &outValue)
-	Expect(err).ToNot(HaveOccurred(), "Failed to Unmarshal promQL output from prometheus pod")
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter, "Failed to unmarshal PromQL output: %v, returning -1 to allow Eventually to retry\n", err)
 
-	Expect(len(outValue)).To(BeNumerically(">", 0), "PromQL output contains no metrics")
-	Expect(len(outValue[0].Value)).To(BeNumerically(">", 1), "PromQL metric value array is incomplete")
+		return -1
+	}
+
+	if len(outValue) == 0 || len(outValue[0].Value) < 2 {
+		fmt.Fprintf(GinkgoWriter, "PromQL output contains no usable metrics, returning -1 to allow Eventually to retry\n")
+
+		return -1
+	}
 
 	valueStr, ok := outValue[0].Value[1].(string)
-	Expect(ok).To(BeTrue(), "PromQL metric value is not a string")
+	if !ok {
+		fmt.Fprintf(GinkgoWriter, "PromQL metric value is not a string, returning -1 to allow Eventually to retry\n")
+
+		return -1
+	}
 
 	finalVal, err := strconv.Atoi(valueStr)
-	Expect(err).To(Not(HaveOccurred()), "Failed to convert counter value to int")
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter,
+			"Failed to convert counter value to int: %v, returning -1 to allow Eventually to retry\n", err)
+
+		return -1
+	}
 
 	return finalVal
 }


### PR DESCRIPTION
…y PromQL responses

Replace hard Expect assertions in fetchScalarFromPromQLoutput with graceful error handling that returns -1 on transient failures (empty output, invalid JSON, missing metrics). Since this function is only called within Eventually retry loops, returning -1 allows the test to retry rather than immediately failing on transient Prometheus gaps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty, malformed, incomplete, and invalid metric responses.
  * Metric polling now retries when values cannot be parsed instead of failing immediately.
  * Added clearer logging for invalid monitoring data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->