### PR TITLE
Update oran functional tests to support MNO provisioning

### DIFF
--- a/tests/cnf/ran/README.md
+++ b/tests/cnf/ran/README.md
@@ -104,7 +104,7 @@ These inputs are all specific to the PTP test suites and are optional.
 #### Spoke inputs
 
 * `ECO_CNF_RAN_SPOKE1_NAME`: Name of the spoke 1 cluster. Automatically updated if Spoke1Kubeconfig exists, otherwise provided as input.
-* `ECO_CNF_RAN_SPOKE1_HOSTNAME`: Hostname for the spoke 1 cluster, used as input for the O-RAN suite.
+* `ECO_CNF_RAN_SPOKE1_HOSTNAME`: Hostname for the spoke 1 cluster, used as input for the O-RAN suite when a ClusterInstance file is not provided (SNO).
 * `ECO_CNF_RAN_SPOKE1_PASSWORD`: Path to the admin password for spoke 1, saved in the O-RAN suite.
 
 #### ACM inputs
@@ -136,6 +136,8 @@ These inputs are specific to the O-RAN test suite.
 * `ECO_CNF_RAN_O2IMS_OAUTH_CLIENT_SECRET`: Client secret for requesting an access token from the OAuth endpoint.
 * `ECO_CNF_RAN_O2IMS_TOKEN`: Token for authenticating with the O2IMS API (used when OAuth is not configured).
 * `ECO_CNF_RAN_CLUSTER_TEMPLATE_AFFIX`: Version-dependent affix for naming ClusterTemplates and O-RAN resources.
+* `ECO_CNF_RAN_CLUSTER_TEMPLATE_NAME`: Optional ClusterTemplate base name (without version). Defaults to `sno-ran-du`, or `mno-ran-du` when `ECO_CNF_RAN_CLUSTERINSTANCE_PATH` points to a multi-node ClusterInstance YAML.
+* `ECO_CNF_RAN_CLUSTERINSTANCE_PATH`: Optional path to a site-config `clusterinstance.yaml`. When set, ProvisioningRequest `nodes[].hostName` values are derived from `spec.nodes[].hostName` (used for MNO installs).
 * `ECO_CNF_RAN_MOCK_SMO_NAMESPACE`: Namespace where the mock SMO is deployed.
 * `ECO_CNF_RAN_MOCK_SMO_SUBDOMAIN`: Subdomain for the mock SMO route (the SMO registered in the inventory CR).
 

--- a/tests/cnf/ran/internal/ranconfig/config.go
+++ b/tests/cnf/ran/internal/ranconfig/config.go
@@ -76,6 +76,10 @@ type RANConfig struct {
 	// ClusterTemplateAffix is the version-dependent affix used for naming ClusterTemplates and other O-RAN
 	// resources.
 	ClusterTemplateAffix string `envconfig:"ECO_CNF_RAN_CLUSTER_TEMPLATE_AFFIX"`
+	// ClusterTemplateName is the ClusterTemplate base name (without version) for O-RAN ProvisioningRequests.
+	// When empty, the O-RAN suite defaults to sno-ran-du, or mno-ran-du when a multi-node ClusterInstance
+	// file is provided via ECO_CNF_RAN_CLUSTERINSTANCE_PATH.
+	ClusterTemplateName string `envconfig:"ECO_CNF_RAN_CLUSTER_TEMPLATE_NAME"`
 }
 
 // HubConfig contains the configuration for the hub cluster, if present.
@@ -129,11 +133,17 @@ type Spoke1Config struct {
 	Spoke1OCPVersion       string
 	Spoke1OperatorVersions map[ranparam.SpokeOperatorName]string
 
-	// Spoke1Name is automatically updated if Spoke1Kubeconfig exists, otherwise it can be provided as an input.
+	// Spoke1Name can be provided via ECO_CNF_RAN_SPOKE1_NAME. If unset and Spoke1Kubeconfig exists, it is
+	// derived from that kubeconfig. An explicitly set name is never overwritten (hub KUBECONFIG would otherwise
+	// replace the intended spoke name during Day0 provisioning).
 	Spoke1Name string `envconfig:"ECO_CNF_RAN_SPOKE1_NAME"`
-	// Spoke1Hostname is not automatically updated but instead used as an input for the O-RAN suite.
-	Spoke1Hostname   string `envconfig:"ECO_CNF_RAN_SPOKE1_HOSTNAME"`
-	Spoke1Kubeconfig string `envconfig:"KUBECONFIG"`
+	// Spoke1Hostname is not automatically updated but instead used as an input for the O-RAN suite when a
+	// ClusterInstance file is not provided.
+	Spoke1Hostname string `envconfig:"ECO_CNF_RAN_SPOKE1_HOSTNAME"`
+	// ClusterInstancePath is an optional path to a site-config ClusterInstance YAML. When set, the O-RAN suite
+	// derives ProvisioningRequest node hostnames from spec.nodes[].hostName (used for MNO installs).
+	ClusterInstancePath string `envconfig:"ECO_CNF_RAN_CLUSTERINSTANCE_PATH"`
+	Spoke1Kubeconfig    string `envconfig:"KUBECONFIG"`
 	// Spoke1Password is the path to the admin password, saved in the O-RAN suite.
 	Spoke1Password string `envconfig:"ECO_CNF_RAN_SPOKE1_PASSWORD"`
 
@@ -296,15 +306,21 @@ func (ranconfig *RANConfig) newSpoke1Config(configFile string) {
 
 	ranconfig.Spoke1Config.Spoke1APIClient = inittools.APIClient
 
-	if spoke1Kubeconfig := ranconfig.Spoke1Config.Spoke1Kubeconfig; spoke1Kubeconfig != "" {
-		spoke1Name, err := version.GetClusterName(spoke1Kubeconfig)
-		if err != nil {
-			klog.V(ranparam.LogLevel).Infof("Failed to get spoke 1 name from kubeconfig at %s: %v", spoke1Kubeconfig, err)
+	if ranconfig.Spoke1Config.Spoke1Name == "" {
+		if spoke1Kubeconfig := ranconfig.Spoke1Config.Spoke1Kubeconfig; spoke1Kubeconfig != "" {
+			spoke1Name, err := version.GetClusterName(spoke1Kubeconfig)
+			if err != nil {
+				klog.V(ranparam.LogLevel).Infof(
+					"Failed to get spoke 1 name from kubeconfig at %s: %v", spoke1Kubeconfig, err)
+			} else {
+				ranconfig.Spoke1Config.Spoke1Name = spoke1Name
+			}
 		} else {
-			ranconfig.Spoke1Config.Spoke1Name = spoke1Name
+			klog.V(ranparam.LogLevel).Infof("No spoke 1 kubeconfig specified in KUBECONFIG environment variable")
 		}
 	} else {
-		klog.V(ranparam.LogLevel).Infof("No spoke 1 kubeconfig specified in KUBECONFIG environment variable")
+		klog.V(ranparam.LogLevel).Infof(
+			"Using explicit Spoke1Name %q (not derived from KUBECONFIG)", ranconfig.Spoke1Config.Spoke1Name)
 	}
 
 	ranconfig.Spoke1Config.Spoke1OCPVersion, err = version.GetOCPVersion(ranconfig.Spoke1Config.Spoke1APIClient)

--- a/tests/cnf/ran/internal/version/version.go
+++ b/tests/cnf/ran/internal/version/version.go
@@ -97,6 +97,10 @@ func GetZTPVersionFromArgoCd(client *clients.Settings, name, namespace string) (
 	}
 
 	// The format here will be like vX.Y.Z so we need to remove the v at the start.
+	if len(ztpVersion) < 2 || ztpVersion[0] != 'v' {
+		return "", fmt.Errorf("unexpected ztp-site-generate version tag %q", ztpVersion)
+	}
+
 	return ztpVersion[1:], nil
 }
 
@@ -106,6 +110,12 @@ func GetZTPSiteGenerateImage(client *clients.Settings) (string, error) {
 	gitops, err := argocd.Pull(client, ranparam.OpenshiftGitOpsNamespace, ranparam.OpenshiftGitOpsNamespace)
 	if err != nil {
 		return "", err
+	}
+
+	// argocd.Pull can return a nil Definition when Get fails with a non-NotFound error (Exists treats that as
+	// present). Guard so hub config init logs an error instead of panicking.
+	if gitops == nil || gitops.Definition == nil {
+		return "", errors.New("argocd object is nil after pull; cannot read ztp-site-generate image")
 	}
 
 	for _, container := range gitops.Definition.Spec.Repo.InitContainers {

--- a/tests/cnf/ran/oran/internal/helper/clusterinstance.go
+++ b/tests/cnf/ran/oran/internal/helper/clusterinstance.go
@@ -1,0 +1,101 @@
+package helper
+
+import (
+	"fmt"
+	"os"
+
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
+	"sigs.k8s.io/yaml"
+)
+
+// clusterInstanceFile is a minimal decode target for site-config ClusterInstance YAML. Only the fields needed to
+// derive ProvisioningRequest node hostnames (and optional cluster name) are parsed.
+type clusterInstanceFile struct {
+	Spec struct {
+		ClusterName string `json:"clusterName"`
+		Nodes       []struct {
+			HostName string `json:"hostName"`
+		} `json:"nodes"`
+	} `json:"spec"`
+}
+
+// LoadSpokeHostnamesFromClusterInstance reads a ClusterInstance YAML and returns spec.nodes[].hostName in file order.
+func LoadSpokeHostnamesFromClusterInstance(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read ClusterInstance file %s: %w", path, err)
+	}
+
+	var clusterInstance clusterInstanceFile
+
+	if err := yaml.Unmarshal(data, &clusterInstance); err != nil {
+		return nil, fmt.Errorf("parse ClusterInstance file %s: %w", path, err)
+	}
+
+	if len(clusterInstance.Spec.Nodes) == 0 {
+		return nil, fmt.Errorf("ClusterInstance file %s has no spec.nodes entries", path)
+	}
+
+	hostnames := make([]string, 0, len(clusterInstance.Spec.Nodes))
+
+	for i, node := range clusterInstance.Spec.Nodes {
+		if node.HostName == "" {
+			return nil, fmt.Errorf("ClusterInstance file %s spec.nodes[%d] has empty hostName", path, i)
+		}
+
+		hostnames = append(hostnames, node.HostName)
+	}
+
+	return hostnames, nil
+}
+
+// GetSpokeHostnames returns the hostnames for the primary ProvisioningRequest nodes[]. When
+// ECO_CNF_RAN_CLUSTERINSTANCE_PATH is set, hostnames are read from that ClusterInstance YAML. Otherwise the single
+// ECO_CNF_RAN_SPOKE1_HOSTNAME value is used (SNO).
+func GetSpokeHostnames() ([]string, error) {
+	if RANConfig.ClusterInstancePath != "" {
+		return LoadSpokeHostnamesFromClusterInstance(RANConfig.ClusterInstancePath)
+	}
+
+	if RANConfig.Spoke1Hostname == "" {
+		return nil, fmt.Errorf("ECO_CNF_RAN_SPOKE1_HOSTNAME must be set when ECO_CNF_RAN_CLUSTERINSTANCE_PATH is unset")
+	}
+
+	return []string{RANConfig.Spoke1Hostname}, nil
+}
+
+// GetClusterTemplateName returns the ClusterTemplate base name for O-RAN ProvisioningRequests.
+// Precedence: ECO_CNF_RAN_CLUSTER_TEMPLATE_NAME if set; else mno-ran-du when a ClusterInstance file yields more than
+// one hostname; else sno-ran-du.
+func GetClusterTemplateName() string {
+	if RANConfig.ClusterTemplateName != "" {
+		return RANConfig.ClusterTemplateName
+	}
+
+	if RANConfig.ClusterInstancePath != "" {
+		hostnames, err := LoadSpokeHostnamesFromClusterInstance(RANConfig.ClusterInstancePath)
+		if err == nil && len(hostnames) > 1 {
+			return tsparams.MNOClusterTemplateName
+		}
+	}
+
+	return tsparams.ClusterTemplateName
+}
+
+// GetExtraManifestsName returns the expected extra-manifests ConfigMap name for the resolved ClusterTemplate.
+func GetExtraManifestsName() string {
+	return GetClusterTemplateName() + "-extra-manifest-1"
+}
+
+// buildClusterInstanceNodes builds the clusterInstanceParameters.nodes slice for a ProvisioningRequest.
+func buildClusterInstanceNodes(hostnames []string) []map[string]any {
+	nodes := make([]map[string]any, 0, len(hostnames))
+	for _, hostname := range hostnames {
+		nodes = append(nodes, map[string]any{
+			"hostName": hostname,
+		})
+	}
+
+	return nodes
+}

--- a/tests/cnf/ran/oran/internal/helper/clusterinstance.go
+++ b/tests/cnf/ran/oran/internal/helper/clusterinstance.go
@@ -206,6 +206,7 @@ func buildClusterInstanceNodeGroups(nodes []SpokeNode) []map[string]any {
 		nodeEntry := map[string]any{
 			"hostName": node.HostName,
 		}
+
 		if node.NodeNetwork != nil {
 			nodeEntry["nodeNetwork"] = node.NodeNetwork
 		}

--- a/tests/cnf/ran/oran/internal/helper/clusterinstance.go
+++ b/tests/cnf/ran/oran/internal/helper/clusterinstance.go
@@ -6,22 +6,31 @@ import (
 
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
-	"sigs.k8s.io/yaml"
+	"gopkg.in/yaml.v3"
 )
 
 // clusterInstanceFile is a minimal decode target for site-config ClusterInstance YAML. Only the fields needed to
 // derive ProvisioningRequest node hostnames (and optional cluster name) are parsed.
 type clusterInstanceFile struct {
 	Spec struct {
-		ClusterName string `json:"clusterName"`
+		ClusterName string `yaml:"clusterName"`
 		Nodes       []struct {
-			HostName string `json:"hostName"`
-		} `json:"nodes"`
-	} `json:"spec"`
+			HostName    string         `yaml:"hostName"`
+			Role        string         `yaml:"role"`
+			NodeNetwork map[string]any `yaml:"nodeNetwork,omitempty"`
+		} `yaml:"nodes"`
+	} `yaml:"spec"`
 }
 
-// LoadSpokeHostnamesFromClusterInstance reads a ClusterInstance YAML and returns spec.nodes[].hostName in file order.
-func LoadSpokeHostnamesFromClusterInstance(path string) ([]string, error) {
+// SpokeNode is a hostname, optional role, and optional nodeNetwork from a ClusterInstance file or SNO hostname input.
+type SpokeNode struct {
+	HostName    string
+	Role        string
+	NodeNetwork map[string]any
+}
+
+// loadClusterInstanceFile reads and parses a ClusterInstance YAML from path.
+func loadClusterInstanceFile(path string) (*clusterInstanceFile, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read ClusterInstance file %s: %w", path, err)
@@ -37,55 +46,136 @@ func LoadSpokeHostnamesFromClusterInstance(path string) ([]string, error) {
 		return nil, fmt.Errorf("ClusterInstance file %s has no spec.nodes entries", path)
 	}
 
-	hostnames := make([]string, 0, len(clusterInstance.Spec.Nodes))
+	return &clusterInstance, nil
+}
+
+// LoadSpokeNodesFromClusterInstance reads a ClusterInstance YAML and returns spec.nodes[] with hostname and role.
+func LoadSpokeNodesFromClusterInstance(path string) ([]SpokeNode, error) {
+	clusterInstance, err := loadClusterInstanceFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	nodes := make([]SpokeNode, 0, len(clusterInstance.Spec.Nodes))
 
 	for i, node := range clusterInstance.Spec.Nodes {
 		if node.HostName == "" {
 			return nil, fmt.Errorf("ClusterInstance file %s spec.nodes[%d] has empty hostName", path, i)
 		}
 
+		nodes = append(nodes, SpokeNode{
+			HostName:    node.HostName,
+			Role:        node.Role,
+			NodeNetwork: node.NodeNetwork,
+		})
+	}
+
+	return nodes, nil
+}
+
+// LoadSpokeHostnamesFromClusterInstance reads a ClusterInstance YAML and returns spec.nodes[].hostName in file order.
+func LoadSpokeHostnamesFromClusterInstance(path string) ([]string, error) {
+	nodes, err := LoadSpokeNodesFromClusterInstance(path)
+	if err != nil {
+		return nil, err
+	}
+
+	hostnames := make([]string, 0, len(nodes))
+	for _, node := range nodes {
 		hostnames = append(hostnames, node.HostName)
 	}
 
 	return hostnames, nil
 }
 
-// GetSpokeHostnames returns the hostnames for the primary ProvisioningRequest nodes[]. When
-// ECO_CNF_RAN_CLUSTERINSTANCE_PATH is set, hostnames are read from that ClusterInstance YAML. Otherwise the single
-// ECO_CNF_RAN_SPOKE1_HOSTNAME value is used (SNO).
-func GetSpokeHostnames() ([]string, error) {
+// GetClusterInstanceClusterName returns spec.clusterName from the ClusterInstance file when
+// ECO_CNF_RAN_CLUSTERINSTANCE_PATH is set and the field is non-empty; otherwise RANConfig.Spoke1Name.
+func GetClusterInstanceClusterName() (string, error) {
 	if RANConfig.ClusterInstancePath != "" {
-		return LoadSpokeHostnamesFromClusterInstance(RANConfig.ClusterInstancePath)
+		clusterInstance, err := loadClusterInstanceFile(RANConfig.ClusterInstancePath)
+		if err != nil {
+			return "", err
+		}
+
+		if clusterInstance.Spec.ClusterName != "" {
+			return clusterInstance.Spec.ClusterName, nil
+		}
+	}
+
+	if RANConfig.Spoke1Name == "" {
+		return "", fmt.Errorf("ECO_CNF_RAN_SPOKE1_NAME must be set when ClusterInstance file omits spec.clusterName")
+	}
+
+	return RANConfig.Spoke1Name, nil
+}
+
+// GetSpokeNodes returns nodes for ProvisioningRequest generation. When ECO_CNF_RAN_CLUSTERINSTANCE_PATH is set, nodes
+// are read from that file; otherwise a single SNO node is built from ECO_CNF_RAN_SPOKE1_HOSTNAME.
+func GetSpokeNodes() ([]SpokeNode, error) {
+	if RANConfig.ClusterInstancePath != "" {
+		return LoadSpokeNodesFromClusterInstance(RANConfig.ClusterInstancePath)
 	}
 
 	if RANConfig.Spoke1Hostname == "" {
 		return nil, fmt.Errorf("ECO_CNF_RAN_SPOKE1_HOSTNAME must be set when ECO_CNF_RAN_CLUSTERINSTANCE_PATH is unset")
 	}
 
-	return []string{RANConfig.Spoke1Hostname}, nil
+	return []SpokeNode{{
+		HostName: RANConfig.Spoke1Hostname,
+		Role:     "master",
+	}}, nil
+}
+
+// GetSpokeHostnames returns the hostnames for the primary ProvisioningRequest nodes[]. When
+// ECO_CNF_RAN_CLUSTERINSTANCE_PATH is set, hostnames are read from that ClusterInstance YAML. Otherwise the single
+// ECO_CNF_RAN_SPOKE1_HOSTNAME value is used (SNO).
+func GetSpokeHostnames() ([]string, error) {
+	nodes, err := GetSpokeNodes()
+	if err != nil {
+		return nil, err
+	}
+
+	hostnames := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		hostnames = append(hostnames, node.HostName)
+	}
+
+	return hostnames, nil
 }
 
 // GetClusterTemplateName returns the ClusterTemplate base name for O-RAN ProvisioningRequests.
 // Precedence: ECO_CNF_RAN_CLUSTER_TEMPLATE_NAME if set; else mno-ran-du when a ClusterInstance file yields more than
-// one hostname; else sno-ran-du.
-func GetClusterTemplateName() string {
+// one hostname; else sno-ran-du. When ECO_CNF_RAN_CLUSTERINSTANCE_PATH is set, a load error is returned instead of
+// falling back to sno-ran-du.
+func GetClusterTemplateName() (string, error) {
 	if RANConfig.ClusterTemplateName != "" {
-		return RANConfig.ClusterTemplateName
+		return RANConfig.ClusterTemplateName, nil
 	}
 
 	if RANConfig.ClusterInstancePath != "" {
 		hostnames, err := LoadSpokeHostnamesFromClusterInstance(RANConfig.ClusterInstancePath)
-		if err == nil && len(hostnames) > 1 {
-			return tsparams.MNOClusterTemplateName
+		if err != nil {
+			return "", err
 		}
+
+		if len(hostnames) > 1 {
+			return tsparams.MNOClusterTemplateName, nil
+		}
+
+		return tsparams.ClusterTemplateName, nil
 	}
 
-	return tsparams.ClusterTemplateName
+	return tsparams.ClusterTemplateName, nil
 }
 
 // GetExtraManifestsName returns the expected extra-manifests ConfigMap name for the resolved ClusterTemplate.
-func GetExtraManifestsName() string {
-	return GetClusterTemplateName() + "-extra-manifest-1"
+func GetExtraManifestsName() (string, error) {
+	clusterTemplateName, err := GetClusterTemplateName()
+	if err != nil {
+		return "", err
+	}
+
+	return clusterTemplateName + "-extra-manifest-1", nil
 }
 
 // buildClusterInstanceNodes builds the clusterInstanceParameters.nodes slice for a ProvisioningRequest.
@@ -98,4 +188,64 @@ func buildClusterInstanceNodes(hostnames []string) []map[string]any {
 	}
 
 	return nodes
+}
+
+// buildClusterInstanceNodeGroups builds clusterInstanceParameters.nodeGroups for MNO templates.
+func buildClusterInstanceNodeGroups(nodes []SpokeNode) []map[string]any {
+	grouped := map[string][]map[string]any{
+		"master": {},
+		"worker": {},
+	}
+
+	for _, node := range nodes {
+		role := node.Role
+		if role != "master" && role != "worker" {
+			role = "master"
+		}
+
+		nodeEntry := map[string]any{
+			"hostName": node.HostName,
+		}
+		if node.NodeNetwork != nil {
+			nodeEntry["nodeNetwork"] = node.NodeNetwork
+		}
+
+		grouped[role] = append(grouped[role], nodeEntry)
+	}
+
+	nodeGroups := make([]map[string]any, 0, 2)
+	if len(grouped["master"]) > 0 {
+		nodeGroups = append(nodeGroups, map[string]any{
+			"name":  "master",
+			"role":  "master",
+			"nodes": grouped["master"],
+		})
+	}
+
+	if len(grouped["worker"]) > 0 {
+		nodeGroups = append(nodeGroups, map[string]any{
+			"name":  "worker",
+			"role":  "worker",
+			"nodes": grouped["worker"],
+		})
+	}
+
+	return nodeGroups
+}
+
+// buildSecondarySpokeNodes returns spoke nodes with distinct hostnames for a secondary ProvisioningRequest.
+func buildSecondarySpokeNodes(spokeNodes []SpokeNode) []SpokeNode {
+	if len(spokeNodes) == 0 {
+		return []SpokeNode{{HostName: tsparams.TestName2, Role: "master"}}
+	}
+
+	secondaryNodes := make([]SpokeNode, 0, len(spokeNodes))
+	for i, node := range spokeNodes {
+		secondaryNodes = append(secondaryNodes, SpokeNode{
+			HostName: fmt.Sprintf("%s-%d", tsparams.TestName2, i),
+			Role:     node.Role,
+		})
+	}
+
+	return secondaryNodes
 }

--- a/tests/cnf/ran/oran/internal/helper/helper.go
+++ b/tests/cnf/ran/oran/internal/helper/helper.go
@@ -20,21 +20,27 @@ import (
 )
 
 // NewProvisioningRequest creates a ProvisioningRequest builder with templateVersion, setting all the required
-// parameters and using the affix from RANConfig.
-func NewProvisioningRequest(client runtimeclient.Client, templateVersion string) *oran.ProvisioningRequestBuilder {
+// parameters and using the affix from RANConfig. Node hostnames come from ECO_CNF_RAN_CLUSTERINSTANCE_PATH when set,
+// otherwise from ECO_CNF_RAN_SPOKE1_HOSTNAME. The ClusterTemplate name resolves to mno-ran-du for multi-node
+// ClusterInstance files unless ECO_CNF_RAN_CLUSTER_TEMPLATE_NAME overrides it.
+func NewProvisioningRequest(
+	client runtimeclient.Client, templateVersion string) (*oran.ProvisioningRequestBuilder, error) {
+	hostnames, err := GetSpokeHostnames()
+	if err != nil {
+		return nil, fmt.Errorf("resolve spoke hostnames for ProvisioningRequest: %w", err)
+	}
+
 	versionWithAffix := RANConfig.ClusterTemplateAffix + "-" + templateVersion
-	prBuilder := oran.NewPRBuilder(client, tsparams.TestPRName, tsparams.ClusterTemplateName, versionWithAffix).
+	prBuilder := oran.NewPRBuilder(client, tsparams.TestPRName, GetClusterTemplateName(), versionWithAffix).
 		WithTemplateParameter("nodeClusterName", RANConfig.Spoke1Name).
 		WithTemplateParameter("oCloudSiteId", tsparams.OCloudSiteID).
 		WithTemplateParameter("policyTemplateParameters", map[string]any{}).
 		WithTemplateParameter("clusterInstanceParameters", map[string]any{
 			"clusterName": RANConfig.Spoke1Name,
-			"nodes": []map[string]any{{
-				"hostName": RANConfig.Spoke1Hostname,
-			}},
+			"nodes":       buildClusterInstanceNodes(hostnames),
 		})
 
-	return prBuilder
+	return prBuilder, nil
 }
 
 // NewSecondaryProvisioningRequest creates a ProvisioningRequest builder for a secondary PR using TestPRName2 and
@@ -43,7 +49,7 @@ func NewProvisioningRequest(client runtimeclient.Client, templateVersion string)
 func NewSecondaryProvisioningRequest(
 	client runtimeclient.Client, templateVersion string) *oran.ProvisioningRequestBuilder {
 	versionWithAffix := RANConfig.ClusterTemplateAffix + "-" + templateVersion
-	prBuilder := oran.NewPRBuilder(client, tsparams.TestPRName2, tsparams.ClusterTemplateName, versionWithAffix).
+	prBuilder := oran.NewPRBuilder(client, tsparams.TestPRName2, GetClusterTemplateName(), versionWithAffix).
 		WithTemplateParameter("nodeClusterName", tsparams.TestName2).
 		WithTemplateParameter("oCloudSiteId", tsparams.OCloudSiteID).
 		WithTemplateParameter("policyTemplateParameters", map[string]any{}).

--- a/tests/cnf/ran/oran/internal/helper/helper.go
+++ b/tests/cnf/ran/oran/internal/helper/helper.go
@@ -25,42 +25,86 @@ import (
 // ClusterInstance files unless ECO_CNF_RAN_CLUSTER_TEMPLATE_NAME overrides it.
 func NewProvisioningRequest(
 	client runtimeclient.Client, templateVersion string) (*oran.ProvisioningRequestBuilder, error) {
-	hostnames, err := GetSpokeHostnames()
+	spokeNodes, err := GetSpokeNodes()
 	if err != nil {
-		return nil, fmt.Errorf("resolve spoke hostnames for ProvisioningRequest: %w", err)
+		return nil, fmt.Errorf("resolve spoke nodes for ProvisioningRequest: %w", err)
+	}
+
+	clusterTemplateName, err := GetClusterTemplateName()
+	if err != nil {
+		return nil, fmt.Errorf("resolve ClusterTemplate name for ProvisioningRequest: %w", err)
+	}
+
+	clusterName, err := GetClusterInstanceClusterName()
+	if err != nil {
+		return nil, fmt.Errorf("resolve cluster name for ProvisioningRequest: %w", err)
 	}
 
 	versionWithAffix := RANConfig.ClusterTemplateAffix + "-" + templateVersion
-	prBuilder := oran.NewPRBuilder(client, tsparams.TestPRName, GetClusterTemplateName(), versionWithAffix).
+	clusterInstanceParams := map[string]any{
+		"clusterName": clusterName,
+	}
+
+	if clusterTemplateName == tsparams.MNOClusterTemplateName {
+		clusterInstanceParams["nodeGroups"] = buildClusterInstanceNodeGroups(spokeNodes)
+	} else {
+		hostnames := make([]string, 0, len(spokeNodes))
+		for _, node := range spokeNodes {
+			hostnames = append(hostnames, node.HostName)
+		}
+
+		clusterInstanceParams["nodes"] = buildClusterInstanceNodes(hostnames)
+	}
+
+	prBuilder := oran.NewPRBuilder(client, tsparams.TestPRName, clusterTemplateName, versionWithAffix).
 		WithTemplateParameter("nodeClusterName", RANConfig.Spoke1Name).
 		WithTemplateParameter("oCloudSiteId", tsparams.OCloudSiteID).
 		WithTemplateParameter("policyTemplateParameters", map[string]any{}).
-		WithTemplateParameter("clusterInstanceParameters", map[string]any{
-			"clusterName": RANConfig.Spoke1Name,
-			"nodes":       buildClusterInstanceNodes(hostnames),
-		})
+		WithTemplateParameter("clusterInstanceParameters", clusterInstanceParams)
 
 	return prBuilder, nil
 }
 
 // NewSecondaryProvisioningRequest creates a ProvisioningRequest builder for a secondary PR using TestPRName2 and
 // distinct cluster/node names so the request does not fail on clusterName ownership before hardware allocation is
-// attempted.
+// attempted. Node count matches the primary spoke topology so MNO pools remain fully claimed.
 func NewSecondaryProvisioningRequest(
-	client runtimeclient.Client, templateVersion string) *oran.ProvisioningRequestBuilder {
+	client runtimeclient.Client, templateVersion string) (*oran.ProvisioningRequestBuilder, error) {
+	clusterTemplateName, err := GetClusterTemplateName()
+	if err != nil {
+		return nil, fmt.Errorf("resolve ClusterTemplate name for secondary ProvisioningRequest: %w", err)
+	}
+
+	spokeNodes, err := GetSpokeNodes()
+	if err != nil {
+		return nil, fmt.Errorf("resolve spoke nodes for secondary ProvisioningRequest: %w", err)
+	}
+
+	secondaryNodes := buildSecondarySpokeNodes(spokeNodes)
 	versionWithAffix := RANConfig.ClusterTemplateAffix + "-" + templateVersion
-	prBuilder := oran.NewPRBuilder(client, tsparams.TestPRName2, GetClusterTemplateName(), versionWithAffix).
+
+	clusterInstanceParams := map[string]any{
+		"clusterName": tsparams.TestName2,
+	}
+
+	if clusterTemplateName == tsparams.MNOClusterTemplateName {
+		clusterInstanceParams["nodeGroups"] = buildClusterInstanceNodeGroups(secondaryNodes)
+	} else {
+		hostnames := make([]string, 0, len(secondaryNodes))
+		for _, node := range secondaryNodes {
+			hostnames = append(hostnames, node.HostName)
+		}
+
+		clusterInstanceParams["nodes"] = buildClusterInstanceNodes(hostnames)
+	}
+
+	prBuilder := oran.NewPRBuilder(client, tsparams.TestPRName2, clusterTemplateName, versionWithAffix).
 		WithTemplateParameter("nodeClusterName", tsparams.TestName2).
 		WithTemplateParameter("oCloudSiteId", tsparams.OCloudSiteID).
 		WithTemplateParameter("policyTemplateParameters", map[string]any{}).
-		WithTemplateParameter("clusterInstanceParameters", map[string]any{
-			"clusterName": tsparams.TestName2,
-			"nodes": []map[string]any{{
-				"hostName": tsparams.TestName2,
-			}},
-		})
+		WithTemplateParameter("clusterInstanceParameters", clusterInstanceParams)
 
-	return prBuilder
+	return prBuilder, nil
 }
 
 // WaitForNoncompliantImmutable waits up to timeout until one of the policies in namespace is NonCompliant and the

--- a/tests/cnf/ran/oran/internal/helper/helper.go
+++ b/tests/cnf/ran/oran/internal/helper/helper.go
@@ -41,6 +41,7 @@ func NewProvisioningRequest(
 	}
 
 	versionWithAffix := RANConfig.ClusterTemplateAffix + "-" + templateVersion
+
 	clusterInstanceParams := map[string]any{
 		"clusterName": clusterName,
 	}
@@ -81,6 +82,7 @@ func NewSecondaryProvisioningRequest(
 	}
 
 	secondaryNodes := buildSecondarySpokeNodes(spokeNodes)
+
 	versionWithAffix := RANConfig.ClusterTemplateAffix + "-" + templateVersion
 
 	clusterInstanceParams := map[string]any{

--- a/tests/cnf/ran/oran/internal/tsparams/consts.go
+++ b/tests/cnf/ran/oran/internal/tsparams/consts.go
@@ -22,12 +22,16 @@ const (
 )
 
 const (
-	// ClusterTemplateName is the name without the version of the ClusterTemplate used in the ORAN tests. It is also
-	// the namespace the ClusterTemplates are in.
+	// ClusterTemplateName is the default ClusterTemplate base name (without version) for SNO O-RAN tests. It is also
+	// the namespace the ClusterTemplates are in. Prefer helper.GetClusterTemplateName() when building PRs so MNO labs
+	// can resolve to MNOClusterTemplateName.
 	ClusterTemplateName = "sno-ran-du"
+	// MNOClusterTemplateName is the default ClusterTemplate base name for multi-node O-RAN provision tests.
+	MNOClusterTemplateName = "mno-ran-du"
 	// O2IMSNamespace is the namespace used by the oran-o2ims operator.
 	O2IMSNamespace = "oran-o2ims"
-	// ExtraManifestsName is the name of the generated extra manifests ConfigMap in the cluster Namespace.
+	// ExtraManifestsName is the default generated extra manifests ConfigMap name for SNO. Prefer
+	// helper.GetExtraManifestsName() so the name matches the resolved ClusterTemplate.
 	ExtraManifestsName = "sno-ran-du-extra-manifest-1"
 	// ClusterInstanceParamsKey is the key in the TemplateParameters map for the ClusterInstance parameters.
 	ClusterInstanceParamsKey = "clusterInstanceParameters"

--- a/tests/cnf/ran/oran/tests/oran-day2-metal3.go
+++ b/tests/cnf/ran/oran/tests/oran-day2-metal3.go
@@ -47,8 +47,10 @@ var _ = Describe("ORAN Metal3 Day2 Tests", Label(tsparams.LabelMetal3Day2), Orde
 	It("fails when all matching hardware is already allocated", reportxml.ID("83883"), func() {
 		By("creating a second ProvisioningRequest when hardware is already allocated")
 
-		prBuilder2 := helper.NewSecondaryProvisioningRequest(o2imsAPIClient, tsparams.TemplateHardwareAllocated)
-		prBuilder2, err := prBuilder2.Create()
+		prBuilder2, err := helper.NewSecondaryProvisioningRequest(o2imsAPIClient, tsparams.TemplateHardwareAllocated)
+		Expect(err).ToNot(HaveOccurred(), "Failed to build second ProvisioningRequest when hardware is allocated")
+
+		prBuilder2, err = prBuilder2.Create()
 		Expect(err).ToNot(HaveOccurred(), "Failed to create second ProvisioningRequest when hardware is allocated")
 
 		DeferCleanup(func() {

--- a/tests/cnf/ran/oran/tests/oran-pre-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-pre-provision.go
@@ -35,8 +35,10 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 	It("fails to create ProvisioningRequest with invalid ClusterTemplate", reportxml.ID("77392"), func() {
 		By("attempting to create a ProvisioningRequest")
 
-		prBuilder := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateInvalid)
-		_, err := prBuilder.Create()
+		prBuilder, err := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateInvalid)
+		Expect(err).ToNot(HaveOccurred(), "Failed to build ProvisioningRequest")
+
+		_, err = prBuilder.Create()
 		Expect(err).To(HaveOccurred(), "Creating a ProvisioningRequest with an invalid ClusterTemplate should fail")
 	})
 
@@ -44,8 +46,8 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 	It("fails ClusterTemplate validation when inline BMC schema is missing without hwMgmtDefaults",
 		reportxml.ID("78245"), func() {
 			clusterTemplateName := fmt.Sprintf("%s.%s-%s",
-				tsparams.ClusterTemplateName, RANConfig.ClusterTemplateAffix, tsparams.TemplateInlineBMCMissingSchema)
-			clusterTemplateNamespace := tsparams.ClusterTemplateName + "-" + RANConfig.ClusterTemplateAffix
+				helper.GetClusterTemplateName(), RANConfig.ClusterTemplateAffix, tsparams.TemplateInlineBMCMissingSchema)
+			clusterTemplateNamespace := helper.GetClusterTemplateName() + "-" + RANConfig.ClusterTemplateAffix
 
 			By("pulling the ClusterTemplate that omits hwMgmtDefaults and inline BMC schema")
 
@@ -80,8 +82,10 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 		It("fails when no hardware matches resource selector", reportxml.ID("83880"), func() {
 			By("creating a ProvisioningRequest with non-matching resource selector")
 
-			prBuilder := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateNoHardwareMatch)
-			_, err := prBuilder.Create()
+			prBuilder, err := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateNoHardwareMatch)
+			Expect(err).ToNot(HaveOccurred(), "Failed to build ProvisioningRequest")
+
+			_, err = prBuilder.Create()
 			Expect(err).ToNot(HaveOccurred(), "Failed to create ProvisioningRequest with non-matching resource selector")
 
 			By("waiting for ProvisioningRequest to fail due to no matching hardware")
@@ -104,8 +108,10 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 		It("fails when boot interface label is missing", reportxml.ID("83881"), func() {
 			By("creating a ProvisioningRequest with missing boot interface label")
 
-			prBuilder := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateMissingBootInterface)
-			_, err := prBuilder.Create()
+			prBuilder, err := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateMissingBootInterface)
+			Expect(err).ToNot(HaveOccurred(), "Failed to build ProvisioningRequest")
+
+			_, err = prBuilder.Create()
 			Expect(err).ToNot(HaveOccurred(), "Failed to create ProvisioningRequest with missing boot interface label")
 
 			By("waiting for ProvisioningRequest to fail due to missing boot interface")
@@ -128,8 +134,10 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 		It("fails when hardware profile does not exist", reportxml.ID("83882"), func() {
 			By("attempting to create a ProvisioningRequest with nonexistent hardware profile")
 
-			prBuilder := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateNonexistentHWProfile)
-			_, err := prBuilder.Create()
+			prBuilder, err := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateNonexistentHWProfile)
+			Expect(err).ToNot(HaveOccurred(), "Failed to build ProvisioningRequest")
+
+			_, err = prBuilder.Create()
 			Expect(err).To(HaveOccurred(),
 				"Creating a ProvisioningRequest with a nonexistent hardware profile should be rejected by the admission webhook")
 			Expect(err.Error()).To(ContainSubstring("does not exist"),

--- a/tests/cnf/ran/oran/tests/oran-pre-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-pre-provision.go
@@ -45,9 +45,12 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 	// 78245 - ClusterTemplate validation fails when inline BMC schema is missing without hwMgmtDefaults
 	It("fails ClusterTemplate validation when inline BMC schema is missing without hwMgmtDefaults",
 		reportxml.ID("78245"), func() {
+			clusterTemplateBaseName, err := helper.GetClusterTemplateName()
+			Expect(err).ToNot(HaveOccurred(), "Failed to resolve ClusterTemplate name")
+
 			clusterTemplateName := fmt.Sprintf("%s.%s-%s",
-				helper.GetClusterTemplateName(), RANConfig.ClusterTemplateAffix, tsparams.TemplateInlineBMCMissingSchema)
-			clusterTemplateNamespace := helper.GetClusterTemplateName() + "-" + RANConfig.ClusterTemplateAffix
+				clusterTemplateBaseName, RANConfig.ClusterTemplateAffix, tsparams.TemplateInlineBMCMissingSchema)
+			clusterTemplateNamespace := clusterTemplateBaseName + "-" + RANConfig.ClusterTemplateAffix
 
 			By("pulling the ClusterTemplate that omits hwMgmtDefaults and inline BMC schema")
 

--- a/tests/cnf/ran/oran/tests/oran-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-provision.go
@@ -10,7 +10,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/configmap"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/ocm"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
@@ -19,6 +21,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/auth"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/helper"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -50,12 +53,14 @@ var _ = Describe("ORAN Provision Tests", Label(tsparams.LabelProvision), Ordered
 
 		By("creating a ProvisioningRequest with invalid policyTemplateParameters")
 
-		prBuilder := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateValid).
-			WithTemplateParameter(tsparams.PolicyTemplateParamsKey, map[string]any{
-				// By using an integer when the schema specifies a string we can create an invalid
-				// ProvisioningRequest without being stopped by the webhook.
-				tsparams.TestName: 1,
-			})
+		prBuilder, err := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateValid)
+		Expect(err).ToNot(HaveOccurred(), "Failed to build ProvisioningRequest")
+
+		prBuilder = prBuilder.WithTemplateParameter(tsparams.PolicyTemplateParamsKey, map[string]any{
+			// By using an integer when the schema specifies a string we can create an invalid
+			// ProvisioningRequest without being stopped by the webhook.
+			tsparams.TestName: 1,
+		})
 
 		prBuilder, err = prBuilder.Create()
 		Expect(err).ToNot(HaveOccurred(), "Failed to create an invalid ProvisioningRequest")
@@ -110,7 +115,10 @@ var _ = Describe("ORAN Provision Tests", Label(tsparams.LabelProvision), Ordered
 			if err != nil {
 				By("creating the ProvisioningRequest since it does not exist")
 
-				prBuilder, err = helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateValid).Create()
+				prBuilder, err = helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateValid)
+				Expect(err).ToNot(HaveOccurred(), "Failed to build ProvisioningRequest")
+
+				prBuilder, err = prBuilder.Create()
 				Expect(err).ToNot(HaveOccurred(), "Failed to create ProvisioningRequest since it does not exist")
 			}
 
@@ -183,9 +191,13 @@ func verifyProvisioningRequestFulfilled(prBuilder *oran.ProvisioningRequestBuild
 	By("verifying the InfrastructureResourceStatuses are set")
 
 	resourceStatuses := status.Extensions.InfrastructureResourceStatuses
-	if len(resourceStatuses) == 0 {
-		accumulatedErrors = append(accumulatedErrors,
-			fmt.Errorf("expected provisioned infrastructure nodes in extensions"))
+	expectedHostnames, err := helper.GetSpokeHostnames()
+	if err != nil {
+		accumulatedErrors = append(accumulatedErrors, fmt.Errorf("resolve expected node count: %w", err))
+	} else if len(resourceStatuses) != len(expectedHostnames) {
+		accumulatedErrors = append(accumulatedErrors, fmt.Errorf(
+			"expected %d provisioned infrastructure nodes in extensions, got %d",
+			len(expectedHostnames), len(resourceStatuses)))
 	}
 
 	By("verifying the InfrastructureResourceStatuses are provisioned")
@@ -245,7 +257,7 @@ func verifySpokeProvisioning() error {
 
 	By("verifying spoke 1 extra-manifests was created")
 
-	_, err = configmap.Pull(HubAPIClient, tsparams.ExtraManifestsName, RANConfig.Spoke1Name)
+	_, err = configmap.Pull(HubAPIClient, helper.GetExtraManifestsName(), RANConfig.Spoke1Name)
 	if err != nil {
 		klog.V(tsparams.LogLevel).Infof("Failed to verify the extra-manifests ConfigMap was created: %v", err)
 
@@ -255,7 +267,7 @@ func verifySpokeProvisioning() error {
 
 	By("verifying spoke 1 policy ConfigMap was created")
 
-	ztpNamespace := fmt.Sprintf("ztp-%s-%s", tsparams.ClusterTemplateName, RANConfig.ClusterTemplateAffix)
+	ztpNamespace := fmt.Sprintf("ztp-%s-%s", helper.GetClusterTemplateName(), RANConfig.ClusterTemplateAffix)
 
 	_, err = configmap.Pull(HubAPIClient, RANConfig.Spoke1Name+"-pg", ztpNamespace)
 	if err != nil {
@@ -275,5 +287,72 @@ func verifySpokeProvisioning() error {
 		accumulatedErrors = append(accumulatedErrors, fmt.Errorf("failed to verify all policies are compliant: %w", err))
 	}
 
+	if err := verifySpokeNodesReady(); err != nil {
+		accumulatedErrors = append(accumulatedErrors, err)
+	}
+
 	return errors.Join(accumulatedErrors...)
+}
+
+// verifySpokeNodesReady checks that the provisioned spoke has the expected number of Ready nodes, using the existing
+// spoke client when available or a temporary client built from the hub admin-kubeconfig secret.
+func verifySpokeNodesReady() error {
+	expectedHostnames, err := helper.GetSpokeHostnames()
+	if err != nil {
+		return fmt.Errorf("resolve expected spoke node count: %w", err)
+	}
+
+	spokeClient := Spoke1APIClient
+	if spokeClient == nil {
+		By("building a temporary spoke client from the admin-kubeconfig secret")
+
+		kubeconfigPath, err := os.CreateTemp("", "oran-spoke-kubeconfig-*.yaml")
+		if err != nil {
+			return fmt.Errorf("create temp kubeconfig file: %w", err)
+		}
+
+		defer os.Remove(kubeconfigPath.Name())
+
+		if err := kubeconfigPath.Close(); err != nil {
+			return fmt.Errorf("close temp kubeconfig file: %w", err)
+		}
+
+		if err := saveSpoke1Secret("-admin-kubeconfig", "kubeconfig", kubeconfigPath.Name()); err != nil {
+			return fmt.Errorf("save admin kubeconfig for spoke node verification: %w", err)
+		}
+
+		spokeClient = clients.New(kubeconfigPath.Name())
+		if spokeClient == nil {
+			return fmt.Errorf("failed to create spoke API client from admin kubeconfig")
+		}
+	}
+
+	By("verifying spoke nodes are Ready")
+
+	nodeList, err := nodes.List(spokeClient)
+	if err != nil {
+		return fmt.Errorf("list spoke nodes: %w", err)
+	}
+
+	if len(nodeList) != len(expectedHostnames) {
+		return fmt.Errorf("expected %d spoke nodes, got %d", len(expectedHostnames), len(nodeList))
+	}
+
+	for _, node := range nodeList {
+		ready := false
+
+		for _, condition := range node.Object.Status.Conditions {
+			if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+				ready = true
+
+				break
+			}
+		}
+
+		if !ready {
+			return fmt.Errorf("spoke node %s is not Ready", node.Object.Name)
+		}
+	}
+
+	return nil
 }

--- a/tests/cnf/ran/oran/tests/oran-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-provision.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -22,10 +23,13 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/helper"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const spokeNodesReadyTimeout = 30 * time.Minute
 
 var _ = Describe("ORAN Provision Tests", Label(tsparams.LabelProvision), Ordered, ContinueOnFailure, func() {
 	var o2imsAPIClient runtimeclient.Client
@@ -191,6 +195,7 @@ func verifyProvisioningRequestFulfilled(prBuilder *oran.ProvisioningRequestBuild
 	By("verifying the InfrastructureResourceStatuses are set")
 
 	resourceStatuses := status.Extensions.InfrastructureResourceStatuses
+
 	expectedHostnames, err := helper.GetSpokeHostnames()
 	if err != nil {
 		accumulatedErrors = append(accumulatedErrors, fmt.Errorf("resolve expected node count: %w", err))
@@ -306,65 +311,155 @@ func verifySpokeProvisioning() error {
 	return errors.Join(accumulatedErrors...)
 }
 
-// verifySpokeNodesReady checks that the provisioned spoke has the expected number of Ready nodes, using the existing
-// spoke client when available or a temporary client built from the hub admin-kubeconfig secret.
+// verifySpokeNodesReady polls until the provisioned spoke has the expected Ready nodes, using the existing spoke client
+// when available or a temporary client built from the hub admin-kubeconfig secret.
 func verifySpokeNodesReady() error {
 	expectedHostnames, err := helper.GetSpokeHostnames()
 	if err != nil {
 		return fmt.Errorf("resolve expected spoke node count: %w", err)
 	}
 
-	spokeClient := Spoke1APIClient
-	if spokeClient == nil {
-		By("building a temporary spoke client from the admin-kubeconfig secret")
-
-		kubeconfigPath, err := os.CreateTemp("", "oran-spoke-kubeconfig-*.yaml")
-		if err != nil {
-			return fmt.Errorf("create temp kubeconfig file: %w", err)
-		}
-
-		defer os.Remove(kubeconfigPath.Name())
-
-		if err := kubeconfigPath.Close(); err != nil {
-			return fmt.Errorf("close temp kubeconfig file: %w", err)
-		}
-
-		if err := saveSpoke1Secret("-admin-kubeconfig", "kubeconfig", kubeconfigPath.Name()); err != nil {
-			return fmt.Errorf("save admin kubeconfig for spoke node verification: %w", err)
-		}
-
-		spokeClient = clients.New(kubeconfigPath.Name())
-		if spokeClient == nil {
-			return fmt.Errorf("failed to create spoke API client from admin kubeconfig")
-		}
-	}
-
-	By("verifying spoke nodes are Ready")
-
-	nodeList, err := nodes.List(spokeClient)
+	spokeClient, cleanup, err := spokeClientForNodeVerification()
 	if err != nil {
-		return fmt.Errorf("list spoke nodes: %w", err)
+		return err
 	}
 
-	if len(nodeList) != len(expectedHostnames) {
-		return fmt.Errorf("expected %d spoke nodes, got %d", len(expectedHostnames), len(nodeList))
+	if cleanup != nil {
+		defer cleanup()
 	}
 
-	for _, node := range nodeList {
-		ready := false
+	By("waiting for spoke nodes to become Ready")
 
-		for _, condition := range node.Object.Status.Conditions {
-			if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
-				ready = true
+	err = wait.PollUntilContextTimeout(
+		context.TODO(), 15*time.Second, spokeNodesReadyTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			nodeList, err := nodes.List(spokeClient)
+			if err != nil {
+				klog.V(tsparams.LogLevel).Infof("Failed to list spoke nodes: %v", err)
+
+				return false, nil
+			}
+
+			if len(nodeList) != len(expectedHostnames) {
+				klog.V(tsparams.LogLevel).Infof(
+					"Waiting for spoke nodes: expected %d, got %d",
+					len(expectedHostnames), len(nodeList))
+
+				return false, nil
+			}
+
+			if err := validateSpokeNodeIdentities(nodeList, expectedHostnames); err != nil {
+				klog.V(tsparams.LogLevel).Infof("Spoke node identity check: %v", err)
+
+				return false, nil
+			}
+
+			for _, node := range nodeList {
+				if !isSpokeNodeReady(node) {
+					klog.V(tsparams.LogLevel).Infof("Waiting for spoke node %s to become Ready", node.Object.Name)
+
+					return false, nil
+				}
+			}
+
+			return true, nil
+		})
+	if err != nil {
+		return fmt.Errorf("timed out waiting for spoke nodes to become Ready: %w", err)
+	}
+
+	return nil
+}
+
+// spokeClientForNodeVerification returns the spoke API client, building a temporary client from the hub
+// admin-kubeconfig secret when Spoke1APIClient is not configured. When a temp kubeconfig is created, cleanup removes
+// the file and must be called after node verification completes.
+func spokeClientForNodeVerification() (*clients.Settings, func(), error) {
+	if Spoke1APIClient != nil {
+		return Spoke1APIClient, nil, nil
+	}
+
+	By("building a temporary spoke client from the admin-kubeconfig secret")
+
+	kubeconfigPath, err := os.CreateTemp("", "oran-spoke-kubeconfig-*.yaml")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create temp kubeconfig file: %w", err)
+	}
+
+	kubeconfigFile := kubeconfigPath.Name()
+
+	if err := kubeconfigPath.Close(); err != nil {
+		return nil, nil, fmt.Errorf("close temp kubeconfig file: %w", err)
+	}
+
+	if err := saveSpoke1Secret("-admin-kubeconfig", "kubeconfig", kubeconfigFile); err != nil {
+		return nil, nil, fmt.Errorf("save admin kubeconfig for spoke node verification: %w", err)
+	}
+
+	spokeClient := clients.New(kubeconfigFile)
+	if spokeClient == nil {
+		return nil, nil, fmt.Errorf("failed to create spoke API client from admin kubeconfig")
+	}
+
+	return spokeClient, func() { os.Remove(kubeconfigFile) }, nil
+}
+
+// spokeNodeNameMatches reports whether a Kubernetes node name corresponds to an expected ClusterInstance hostname.
+// Node objects use the short hostname while ClusterInstance files may specify an FQDN.
+func spokeNodeNameMatches(expectedHostname, nodeName string) bool {
+	if nodeName == expectedHostname {
+		return true
+	}
+
+	shortExpectedHostname, _, _ := strings.Cut(expectedHostname, ".")
+
+	return nodeName == shortExpectedHostname
+}
+
+// validateSpokeNodeIdentities ensures every expected hostname maps to a cluster node and no unexpected nodes exist.
+func validateSpokeNodeIdentities(nodeList []*nodes.Builder, expectedHostnames []string) error {
+	for _, expectedHostname := range expectedHostnames {
+		found := false
+
+		for _, node := range nodeList {
+			if spokeNodeNameMatches(expectedHostname, node.Object.Name) {
+				found = true
 
 				break
 			}
 		}
 
-		if !ready {
-			return fmt.Errorf("spoke node %s is not Ready", node.Object.Name)
+		if !found {
+			return fmt.Errorf("expected spoke node %q not found in cluster", expectedHostname)
+		}
+	}
+
+	for _, node := range nodeList {
+		matched := false
+
+		for _, expectedHostname := range expectedHostnames {
+			if spokeNodeNameMatches(expectedHostname, node.Object.Name) {
+				matched = true
+
+				break
+			}
+		}
+
+		if !matched {
+			return fmt.Errorf("unexpected spoke node %q found in cluster", node.Object.Name)
 		}
 	}
 
 	return nil
+}
+
+// isSpokeNodeReady reports whether the node has a True NodeReady condition.
+func isSpokeNodeReady(node *nodes.Builder) bool {
+	for _, condition := range node.Object.Status.Conditions {
+		if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
 }

--- a/tests/cnf/ran/oran/tests/oran-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-provision.go
@@ -257,24 +257,36 @@ func verifySpokeProvisioning() error {
 
 	By("verifying spoke 1 extra-manifests was created")
 
-	_, err = configmap.Pull(HubAPIClient, helper.GetExtraManifestsName(), RANConfig.Spoke1Name)
+	extraManifestsName, err := helper.GetExtraManifestsName()
 	if err != nil {
-		klog.V(tsparams.LogLevel).Infof("Failed to verify the extra-manifests ConfigMap was created: %v", err)
-
 		accumulatedErrors = append(accumulatedErrors,
-			fmt.Errorf("failed to verify the extra-manifests ConfigMap was created: %w", err))
+			fmt.Errorf("resolve extra-manifests ConfigMap name: %w", err))
+	} else {
+		_, err = configmap.Pull(HubAPIClient, extraManifestsName, RANConfig.Spoke1Name)
+		if err != nil {
+			klog.V(tsparams.LogLevel).Infof("Failed to verify the extra-manifests ConfigMap was created: %v", err)
+
+			accumulatedErrors = append(accumulatedErrors,
+				fmt.Errorf("failed to verify the extra-manifests ConfigMap was created: %w", err))
+		}
 	}
 
 	By("verifying spoke 1 policy ConfigMap was created")
 
-	ztpNamespace := fmt.Sprintf("ztp-%s-%s", helper.GetClusterTemplateName(), RANConfig.ClusterTemplateAffix)
-
-	_, err = configmap.Pull(HubAPIClient, RANConfig.Spoke1Name+"-pg", ztpNamespace)
+	clusterTemplateName, err := helper.GetClusterTemplateName()
 	if err != nil {
-		klog.V(tsparams.LogLevel).Infof("Failed to verify spoke 1 policy ConfigMap was created: %v", err)
-
 		accumulatedErrors = append(accumulatedErrors,
-			fmt.Errorf("failed to verify spoke 1 policy ConfigMap was created: %w", err))
+			fmt.Errorf("resolve ClusterTemplate name for policy ConfigMap verification: %w", err))
+	} else {
+		ztpNamespace := fmt.Sprintf("ztp-%s-%s", clusterTemplateName, RANConfig.ClusterTemplateAffix)
+
+		_, err = configmap.Pull(HubAPIClient, RANConfig.Spoke1Name+"-pg", ztpNamespace)
+		if err != nil {
+			klog.V(tsparams.LogLevel).Infof("Failed to verify spoke 1 policy ConfigMap was created: %v", err)
+
+			accumulatedErrors = append(accumulatedErrors,
+				fmt.Errorf("failed to verify spoke 1 policy ConfigMap was created: %w", err))
+		}
 	}
 
 	By("verifying all the policies are compliant")

--- a/tests/cnf/ran/oran/tests/oran-template-inventory.go
+++ b/tests/cnf/ran/oran/tests/oran-template-inventory.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/auth"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/helper"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
 	"gopkg.in/yaml.v3"
 )
@@ -67,9 +68,9 @@ var _ = Describe("ORAN Template Inventory", Label(tsparams.LabelPreProvision, ts
 	It("successfully filters ManagedInfrastructureTemplates", reportxml.ID("82941"), func() {
 		By("getting the specific ClusterTemplate resource for the valid template")
 
-		clusterTemplateNamespace := tsparams.ClusterTemplateName + "-" + RANConfig.ClusterTemplateAffix
+		clusterTemplateNamespace := helper.GetClusterTemplateName() + "-" + RANConfig.ClusterTemplateAffix
 		clusterTemplateName := fmt.Sprintf("%s.%s-%s",
-			tsparams.ClusterTemplateName, RANConfig.ClusterTemplateAffix, tsparams.TemplateValid)
+			helper.GetClusterTemplateName(), RANConfig.ClusterTemplateAffix, tsparams.TemplateValid)
 
 		chosenClusterTemplate, err := oran.PullClusterTemplate(HubAPIClient, clusterTemplateName, clusterTemplateNamespace)
 		Expect(err).ToNot(HaveOccurred(),
@@ -104,9 +105,9 @@ var _ = Describe("ORAN Template Inventory", Label(tsparams.LabelPreProvision, ts
 	It("successfully retrieves ManagedInfrastructureTemplate defaults", reportxml.ID("82942"), func() {
 		By("getting the specific ClusterTemplate resource for the valid template")
 
-		clusterTemplateNamespace := tsparams.ClusterTemplateName + "-" + RANConfig.ClusterTemplateAffix
+		clusterTemplateNamespace := helper.GetClusterTemplateName() + "-" + RANConfig.ClusterTemplateAffix
 		clusterTemplateName := fmt.Sprintf("%s.%s-%s",
-			tsparams.ClusterTemplateName, RANConfig.ClusterTemplateAffix, tsparams.TemplateValid)
+			helper.GetClusterTemplateName(), RANConfig.ClusterTemplateAffix, tsparams.TemplateValid)
 
 		chosenClusterTemplate, err := oran.PullClusterTemplate(HubAPIClient, clusterTemplateName, clusterTemplateNamespace)
 		Expect(err).ToNot(HaveOccurred(),

--- a/tests/cnf/ran/oran/tests/oran-template-inventory.go
+++ b/tests/cnf/ran/oran/tests/oran-template-inventory.go
@@ -68,9 +68,12 @@ var _ = Describe("ORAN Template Inventory", Label(tsparams.LabelPreProvision, ts
 	It("successfully filters ManagedInfrastructureTemplates", reportxml.ID("82941"), func() {
 		By("getting the specific ClusterTemplate resource for the valid template")
 
-		clusterTemplateNamespace := helper.GetClusterTemplateName() + "-" + RANConfig.ClusterTemplateAffix
+		clusterTemplateBaseName, err := helper.GetClusterTemplateName()
+		Expect(err).ToNot(HaveOccurred(), "Failed to resolve ClusterTemplate name")
+
+		clusterTemplateNamespace := clusterTemplateBaseName + "-" + RANConfig.ClusterTemplateAffix
 		clusterTemplateName := fmt.Sprintf("%s.%s-%s",
-			helper.GetClusterTemplateName(), RANConfig.ClusterTemplateAffix, tsparams.TemplateValid)
+			clusterTemplateBaseName, RANConfig.ClusterTemplateAffix, tsparams.TemplateValid)
 
 		chosenClusterTemplate, err := oran.PullClusterTemplate(HubAPIClient, clusterTemplateName, clusterTemplateNamespace)
 		Expect(err).ToNot(HaveOccurred(),
@@ -105,9 +108,12 @@ var _ = Describe("ORAN Template Inventory", Label(tsparams.LabelPreProvision, ts
 	It("successfully retrieves ManagedInfrastructureTemplate defaults", reportxml.ID("82942"), func() {
 		By("getting the specific ClusterTemplate resource for the valid template")
 
-		clusterTemplateNamespace := helper.GetClusterTemplateName() + "-" + RANConfig.ClusterTemplateAffix
+		clusterTemplateBaseName, err := helper.GetClusterTemplateName()
+		Expect(err).ToNot(HaveOccurred(), "Failed to resolve ClusterTemplate name")
+
+		clusterTemplateNamespace := clusterTemplateBaseName + "-" + RANConfig.ClusterTemplateAffix
 		clusterTemplateName := fmt.Sprintf("%s.%s-%s",
-			helper.GetClusterTemplateName(), RANConfig.ClusterTemplateAffix, tsparams.TemplateValid)
+			clusterTemplateBaseName, RANConfig.ClusterTemplateAffix, tsparams.TemplateValid)
 
 		chosenClusterTemplate, err := oran.PullClusterTemplate(HubAPIClient, clusterTemplateName, clusterTemplateNamespace)
 		Expect(err).ToNot(HaveOccurred(),


### PR DESCRIPTION
This PR includes the minimum changes to support provisioning of an MNO cluster via o-ran, test case 77394.
A later PR will update the other tests to ad MNO support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for ClusterInstance URLs or file paths, configurable ClusterTemplate names, and dynamic SNO/MNO node resolution.
  * Added validation of provisioned node counts, hostnames, roles, and Kubernetes Ready status.
  * Added support for optional node network data.

* **Bug Fixes**
  * Improved handling of invalid version tags, missing deployment data, and provisioning request construction errors.

* **Documentation**
  * Updated O-RAN guidance for ClusterInstance inputs, ClusterTemplate selection, and hostname configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->