### PR TITLE
cnf ran oran: add inventory API tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -101,6 +101,7 @@ linters:
             - github.com/go-openapi/strfmt
             - golang.org/x/oauth2
             - github.com/google/uuid
+            - github.com/google/go-cmp
             - golang.org/x/exp/constraints
             - github.com/redhat-cne/sdk-go
             - github.com/prometheus-operator/prometheus-operator

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ run-ran-pkg-unit-tests:
 	UNIT_TEST=true go test -tags=unit_test -v ./tests/cnf/ran/ptp/internal/iface
 	UNIT_TEST=true go test -tags=unit_test -v ./tests/cnf/ran/ptp/internal/profiles
 	UNIT_TEST=true go test -tags=unit_test -v ./tests/cnf/ran/ptp/internal/consumer
+	UNIT_TEST=true go test -tags=unit_test -v ./tests/cnf/ran/oran/internal/inventory
 
 run-system-tests-pkg-unit-tests:
 	@echo "Executing eco-gotests internal package unit tests"

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/go-openapi/runtime v0.32.4
 	github.com/go-openapi/strfmt v0.26.4
+	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/grafana/loki/operator/apis/loki v0.0.0-20241021105923-5e970e50b166
 	github.com/hashicorp/go-version v1.9.0
@@ -149,7 +150,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260604005048-7023385849c0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853 // indirect

--- a/tests/cnf/ran/oran/internal/auth/auth.go
+++ b/tests/cnf/ran/oran/internal/auth/auth.go
@@ -67,6 +67,26 @@ func NewClientBuilderForConfig(config *ranconfig.RANConfig) (*oranapi.ClientBuil
 	return clientBuilder, nil
 }
 
+// NewUnauthenticatedClientBuilderForConfig creates a ClientBuilder that can reach the O2IMS API over TLS/mTLS but does
+// not attach an Authorization header or OAuth token. Use this to verify that unauthenticated requests are rejected.
+func NewUnauthenticatedClientBuilderForConfig(config *ranconfig.RANConfig) (*oranapi.ClientBuilder, error) {
+	o2imsBaseURL := "https://" + config.GetAppsURL("o2ims")
+
+	if config.O2IMSOAuthClientID == "" || config.O2IMSOAuthClientSecret == "" {
+		return oranapi.NewClientBuilder(o2imsBaseURL).
+			WithTLSConfig(&tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true}), nil
+	}
+
+	tlsConfig, err := getTLSConfigFromCertificateSecret(
+		config.HubAPIClient, config.O2IMSClientCertSecret, config.O2IMSClientCertSecretNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get TLS config from certificate secret: %w", err)
+	}
+
+	return oranapi.NewClientBuilder(o2imsBaseURL).
+		WithHTTPClient(&http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}), nil
+}
+
 func getTLSConfigFromCertificateSecret(
 	hubClient *clients.Settings, certSecretName string, certSecretNamespace string) (*tls.Config, error) {
 	certSecret, err := secret.Pull(hubClient, certSecretName, certSecretNamespace)

--- a/tests/cnf/ran/oran/internal/inventory/compare.go
+++ b/tests/cnf/ran/oran/internal/inventory/compare.go
@@ -1,0 +1,47 @@
+package inventory
+
+import (
+	"fmt"
+	"maps"
+	"math"
+)
+
+// derefSlice returns the slice pointed to by s, treating a nil pointer to a slice as a nil slice.
+func derefSlice[T any](s *[]T) []T {
+	if s == nil {
+		return nil
+	}
+
+	return *s
+}
+
+// verifyStringSetEqual reports an error when want and got contain different string multisets.
+func verifyStringSetEqual(want, got []string, field string) error {
+	if len(want) != len(got) || !maps.Equal(countStrings(want), countStrings(got)) {
+		return fmt.Errorf("%s: want %v, got %v", field, want, got)
+	}
+
+	return nil
+}
+
+// countStrings returns occurrence counts for each value in values.
+func countStrings(values []string) map[string]int {
+	counts := make(map[string]int, len(values))
+	for _, value := range values {
+		counts[value]++
+	}
+
+	return counts
+}
+
+// coordinateEpsilon is the tolerance for comparing floating-point coordinates.
+const coordinateEpsilon = 0.0001
+
+// areCoordinatesEqual reports whether got is within [coordinateEpsilon] of want for both latitude and longitude.
+func areCoordinatesEqual(want, got []float64) bool {
+	if len(want) != 2 || len(got) != 2 {
+		return false
+	}
+
+	return math.Abs(want[0]-got[0]) <= coordinateEpsilon && math.Abs(want[1]-got[1]) <= coordinateEpsilon
+}

--- a/tests/cnf/ran/oran/internal/inventory/compare_test.go
+++ b/tests/cnf/ran/oran/internal/inventory/compare_test.go
@@ -1,0 +1,116 @@
+package inventory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVerifyStringSetEqual(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		want    []string
+		got     []string
+		wantErr bool
+	}{
+		{
+			name: "matching order independent",
+			want: []string{"a", "b"},
+			got:  []string{"b", "a"},
+		},
+		{
+			name: "matching with duplicates",
+			want: []string{"a", "a", "b"},
+			got:  []string{"b", "a", "a"},
+		},
+		{
+			name:    "missing element",
+			want:    []string{"a", "b"},
+			got:     []string{"a"},
+			wantErr: true,
+		},
+		{
+			name:    "extra element",
+			want:    []string{"a"},
+			got:     []string{"a", "b"},
+			wantErr: true,
+		},
+		{
+			name:    "duplicate mismatch",
+			want:    []string{"a", "a"},
+			got:     []string{"a"},
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := verifyStringSetEqual(testCase.want, testCase.got, "testField")
+			if testCase.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAreCoordinatesEqual(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		left  []float64
+		right []float64
+		want  bool
+	}{
+		{
+			name:  "matching coordinates within epsilon",
+			left:  []float64{-73.935242, 40.730610},
+			right: []float64{-73.935242, 40.730615},
+			want:  true,
+		},
+		{
+			name:  "longitude within epsilon",
+			left:  []float64{1.0, 2.0},
+			right: []float64{1.00005, 2.0},
+			want:  true,
+		},
+		{
+			name:  "longitude out of tolerance",
+			left:  []float64{1.0, 2.0},
+			right: []float64{1.001, 2.0},
+			want:  false,
+		},
+		{
+			name:  "latitude out of tolerance",
+			left:  []float64{1.0, 2.0},
+			right: []float64{1.0, 2.001},
+			want:  false,
+		},
+		{
+			name:  "wrong length want",
+			left:  []float64{1.0},
+			right: []float64{1.0, 2.0},
+			want:  false,
+		},
+		{
+			name:  "wrong length got",
+			left:  []float64{1.0, 2.0},
+			right: []float64{1.0, 2.0, 3.0},
+			want:  false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, testCase.want, areCoordinatesEqual(testCase.left, testCase.right))
+		})
+	}
+}

--- a/tests/cnf/ran/oran/internal/inventory/compare_test.go
+++ b/tests/cnf/ran/oran/internal/inventory/compare_test.go
@@ -1,3 +1,5 @@
+//go:build unit_test
+
 package inventory
 
 import (

--- a/tests/cnf/ran/oran/internal/inventory/doc.go
+++ b/tests/cnf/ran/oran/internal/inventory/doc.go
@@ -1,0 +1,14 @@
+// Package inventory provides framework-independent verification helpers that compare O2IMS inventory API responses
+// against hub cluster state (CRs, BMHs, ManagedClusters).
+//
+// The helpers are designed to accumulate errors so that test assertions capture all possible mismatches. When the
+// helpers require cluster resources, they generally move the comparison logic into unexported functions that may be
+// unit tested independently.
+//
+// Ideally, comparisons use projections with [cmp.Diff] to handle the differences between the API and hub cluster state.
+// This avoids turning the package into an assertion framework and focuses on the core logic translating between types
+// in the O2IMS and Kubernetes APIs.
+//
+// Unit tests which would require constructing builders are excluded and these cases are covered by the broader oran
+// test suite.
+package inventory

--- a/tests/cnf/ran/oran/internal/inventory/verify_api.go
+++ b/tests/cnf/ran/oran/internal/inventory/verify_api.go
@@ -1,0 +1,49 @@
+package inventory
+
+import (
+	"errors"
+	"fmt"
+
+	oranapi "github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran/api"
+)
+
+// VerifyAPIVersions checks that the inventory API version response matches expected values.
+func VerifyAPIVersions(versions oranapi.APIVersions) error {
+	apiVersions := derefSlice(versions.ApiVersions)
+
+	var firstVersion *string
+	if len(apiVersions) > 0 {
+		firstVersion = apiVersions[0].Version
+	}
+
+	return errors.Join(
+		verifyAPIVersion(firstVersion),
+		verifyAPIURIPrefix(versions.UriPrefix),
+	)
+}
+
+// verifyAPIVersion checks that the first API version matches the expected value.
+func verifyAPIVersion(version *string) error {
+	if version == nil {
+		return fmt.Errorf("apiVersions[0].version: want non-nil, got nil")
+	}
+
+	if *version != "2.0.0" {
+		return fmt.Errorf("apiVersions[0].version: want %q, got %q", "2.0.0", *version)
+	}
+
+	return nil
+}
+
+// verifyAPIURIPrefix checks that the API URI prefix matches the expected value.
+func verifyAPIURIPrefix(uriPrefix *string) error {
+	if uriPrefix == nil {
+		return fmt.Errorf("uriPrefix: want non-nil, got nil")
+	}
+
+	if *uriPrefix != "/o2ims-infrastructureInventory/v2" {
+		return fmt.Errorf("uriPrefix: want %q, got %q", "/o2ims-infrastructureInventory/v2", *uriPrefix)
+	}
+
+	return nil
+}

--- a/tests/cnf/ran/oran/internal/inventory/verify_api_test.go
+++ b/tests/cnf/ran/oran/internal/inventory/verify_api_test.go
@@ -1,0 +1,84 @@
+package inventory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVerifyAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		version *string
+		wantErr bool
+	}{
+		{
+			name:    "valid version",
+			version: new("2.0.0"),
+		},
+		{
+			name:    "wrong version",
+			version: new("1.0.0"),
+			wantErr: true,
+		},
+		{
+			name:    "missing version",
+			version: nil,
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := verifyAPIVersion(testCase.version)
+
+			if testCase.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestVerifyAPIURIPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		uriPrefix *string
+		wantErr   bool
+	}{
+		{
+			name:      "valid uriPrefix",
+			uriPrefix: new("/o2ims-infrastructureInventory/v2"),
+		},
+		{
+			name:      "wrong uriPrefix",
+			uriPrefix: new("/wrong"),
+			wantErr:   true,
+		},
+		{
+			name:    "missing uriPrefix",
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := verifyAPIURIPrefix(testCase.uriPrefix)
+
+			if testCase.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/tests/cnf/ran/oran/internal/inventory/verify_api_test.go
+++ b/tests/cnf/ran/oran/internal/inventory/verify_api_test.go
@@ -1,3 +1,5 @@
+//go:build unit_test
+
 package inventory
 
 import (

--- a/tests/cnf/ran/oran/internal/inventory/verify_deployment.go
+++ b/tests/cnf/ran/oran/internal/inventory/verify_deployment.go
@@ -1,0 +1,58 @@
+package inventory
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/ocm"
+	oranapi "github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran/api"
+)
+
+// VerifyDeploymentManagerMatchesCluster checks that an API Deployment Manager matches a ManagedCluster.
+func VerifyDeploymentManagerMatchesCluster(
+	apiManager oranapi.DeploymentManager,
+	cluster *ocm.ManagedClusterBuilder,
+) error {
+	type view struct {
+		Name       string
+		ServiceURI string
+	}
+
+	var comparisonErr error
+	if diff := cmp.Diff(
+		view{Name: cluster.Definition.Name, ServiceURI: deriveServiceURI(cluster)},
+		view{Name: apiManager.Name, ServiceURI: apiManager.ServiceUri},
+	); diff != "" {
+		comparisonErr = fmt.Errorf("deployment manager mismatch (-want +got):\n%s", diff)
+	}
+
+	return errors.Join(comparisonErr, verifyDeploymentManagerRequiredFields(apiManager))
+}
+
+// verifyDeploymentManagerRequiredFields checks fields that must be present on an API Deployment Manager.
+func verifyDeploymentManagerRequiredFields(apiManager oranapi.DeploymentManager) error {
+	var errs []error
+
+	if apiManager.Description == "" {
+		errs = append(errs, fmt.Errorf("description: want non-empty, got empty"))
+	}
+
+	if apiManager.OCloudId == uuid.Nil {
+		errs = append(errs, fmt.Errorf("oCloudId: want non-nil UUID, got %v", apiManager.OCloudId))
+	}
+
+	return errors.Join(errs...)
+}
+
+// deriveServiceURI returns the first non-empty ManagedCluster client config URL.
+func deriveServiceURI(cluster *ocm.ManagedClusterBuilder) string {
+	for _, clientConfig := range cluster.Definition.Spec.ManagedClusterClientConfigs {
+		if clientConfig.URL != "" {
+			return clientConfig.URL
+		}
+	}
+
+	return ""
+}

--- a/tests/cnf/ran/oran/internal/inventory/verify_location.go
+++ b/tests/cnf/ran/oran/internal/inventory/verify_location.go
@@ -1,0 +1,171 @@
+package inventory
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/google/go-cmp/cmp"
+	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran"
+	oranapi "github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran/api"
+)
+
+// VerifyLocationMatchesCR checks that an API Location matches the corresponding Location CR and related OCloudSites.
+func VerifyLocationMatchesCR(
+	apiLocation oranapi.LocationInfo,
+	locationCR *oran.LocationBuilder,
+	readySites []*oran.OCloudSiteBuilder,
+) error {
+	type view struct {
+		Name        string
+		Description string
+		Address     *string
+	}
+
+	var comparisonErr error
+	if diff := cmp.Diff(
+		view{
+			Name:        locationCR.Definition.Name,
+			Description: locationCR.Definition.Spec.Description,
+			Address:     locationCR.Definition.Spec.Address,
+		},
+		view{Name: apiLocation.Name, Description: apiLocation.Description, Address: apiLocation.Address},
+	); diff != "" {
+		comparisonErr = fmt.Errorf("location mismatch (-want +got):\n%s", diff)
+	}
+
+	return errors.Join(
+		comparisonErr,
+		verifyLocationCoordinate(apiLocation, locationCR.Definition.Spec.Coordinate),
+		verifyLocationCivicAddress(apiLocation, locationCR.Definition.Spec.CivicAddress),
+		verifyStringSetEqual(
+			collectExpectedSiteIDsForLocation(locationCR, readySites), extractAPISiteIDs(apiLocation),
+			fmt.Sprintf("oCloudSiteIds for Location %s", locationCR.Definition.Name)),
+	)
+}
+
+// collectExpectedSiteIDsForLocation returns UIDs of ready OCloudSites bound to the given Location.
+func collectExpectedSiteIDsForLocation(
+	locationCR *oran.LocationBuilder, readySites []*oran.OCloudSiteBuilder) []string {
+	var siteIDs []string
+
+	for _, site := range readySites {
+		if site.Definition.Spec.GlobalLocationName == locationCR.Definition.Name {
+			siteIDs = append(siteIDs, string(site.Definition.UID))
+		}
+	}
+
+	return siteIDs
+}
+
+// extractAPISiteIDs returns string UIDs from an API Location's OCloudSiteIds.
+func extractAPISiteIDs(apiLocation oranapi.LocationInfo) []string {
+	siteIDs := make([]string, 0, len(apiLocation.OCloudSiteIds))
+	for _, siteID := range apiLocation.OCloudSiteIds {
+		siteIDs = append(siteIDs, siteID.String())
+	}
+
+	return siteIDs
+}
+
+// verifyLocationCoordinate checks that apiLocation.Coordinate matches the CR coordinate.
+func verifyLocationCoordinate(apiLocation oranapi.LocationInfo, coordinate *inventoryv1alpha1.GeoLocation) error {
+	if coordinate == nil {
+		if apiLocation.Coordinate != nil {
+			return fmt.Errorf("coordinate: want nil, got %#v", apiLocation.Coordinate)
+		}
+
+		return nil
+	}
+
+	if apiLocation.Coordinate == nil {
+		return fmt.Errorf("coordinate: want non-nil, got nil")
+	}
+
+	return verifyGeoJSONPoint(apiLocation, coordinate)
+}
+
+// parseCRGeoLocation parses latitude and longitude strings from a Location CR GeoLocation.
+func parseCRGeoLocation(coordinate *inventoryv1alpha1.GeoLocation) (float64, float64, []error) {
+	latitude, latitudeErr := strconv.ParseFloat(coordinate.Latitude, 64)
+	longitude, longitudeErr := strconv.ParseFloat(coordinate.Longitude, 64)
+
+	var parseErrors []error
+
+	if latitudeErr != nil {
+		parseErrors = append(parseErrors, fmt.Errorf(
+			"coordinate.latitude: invalid value %q: %w", coordinate.Latitude, latitudeErr))
+	}
+
+	if longitudeErr != nil {
+		parseErrors = append(parseErrors, fmt.Errorf(
+			"coordinate.longitude: invalid value %q: %w", coordinate.Longitude, longitudeErr))
+	}
+
+	return longitude, latitude, parseErrors
+}
+
+// verifyGeoJSONPoint checks that apiLocation's GeoJSON Point matches the CR coordinate.
+func verifyGeoJSONPoint(apiLocation oranapi.LocationInfo, crCoordinate *inventoryv1alpha1.GeoLocation) error {
+	apiCoordinate := apiLocation.Coordinate
+
+	var errs []error
+
+	if coordinateType := string(apiCoordinate.Type); coordinateType != "Point" {
+		errs = append(errs, fmt.Errorf("coordinate.type: want %q, got %q", "Point", coordinateType))
+	}
+
+	longitude, latitude, parseErrors := parseCRGeoLocation(crCoordinate)
+	errs = append(errs, parseErrors...)
+
+	coords := apiCoordinate.Coordinates
+	if len(coords) != 2 && len(coords) != 3 {
+		errs = append(errs, fmt.Errorf("coordinate.coordinates: want length 2 or 3, got %d", len(coords)))
+
+		return errors.Join(errs...)
+	}
+
+	if len(parseErrors) == 0 {
+		// GeoJSON Point: [longitude, latitude], with optional elevation as a third element.
+		want := []float64{longitude, latitude}
+		if !areCoordinatesEqual(want, coords[:2]) {
+			errs = append(errs, fmt.Errorf("coordinate.coordinates: want ~%v, got %v", want, coords[:2]))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// verifyLocationCivicAddress checks that apiLocation.CivicAddress matches the CR civic address.
+func verifyLocationCivicAddress(
+	apiLocation oranapi.LocationInfo, civicAddress []inventoryv1alpha1.CivicAddressElement) error {
+	apiCivicAddress := derefSlice(apiLocation.CivicAddress)
+
+	if len(civicAddress) == 0 && len(apiCivicAddress) > 0 {
+		return fmt.Errorf("civicAddress: want empty, got %#v", apiCivicAddress)
+	}
+
+	if len(apiCivicAddress) != len(civicAddress) {
+		return fmt.Errorf("civicAddress: want length %d, got %d", len(civicAddress), len(apiCivicAddress))
+	}
+
+	type view struct {
+		CaType  int
+		CaValue string
+	}
+
+	want := make([]view, 0, len(civicAddress))
+	got := make([]view, 0, len(apiCivicAddress))
+
+	for i, element := range civicAddress {
+		want = append(want, view{CaType: element.CaType, CaValue: element.CaValue})
+		got = append(got, view{CaType: apiCivicAddress[i].CaType, CaValue: apiCivicAddress[i].CaValue})
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		return fmt.Errorf("civic address mismatch (-want +got):\n%s", diff)
+	}
+
+	return nil
+}

--- a/tests/cnf/ran/oran/internal/inventory/verify_location_test.go
+++ b/tests/cnf/ran/oran/internal/inventory/verify_location_test.go
@@ -1,3 +1,5 @@
+//go:build unit_test
+
 package inventory
 
 import (

--- a/tests/cnf/ran/oran/internal/inventory/verify_location_test.go
+++ b/tests/cnf/ran/oran/internal/inventory/verify_location_test.go
@@ -1,0 +1,206 @@
+package inventory
+
+import (
+	"encoding/json"
+	"testing"
+
+	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
+	oranapi "github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mustUnmarshalLocationInfo decodes a generated API location fixture.
+func mustUnmarshalLocationInfo(t *testing.T, raw string) oranapi.LocationInfo {
+	t.Helper()
+
+	// LocationInfo.Coordinate is an anonymous generated type, so JSON is the only practical way to construct these
+	// focused fixtures without duplicating the generated type definition.
+	var location oranapi.LocationInfo
+	require.NoError(t, json.Unmarshal([]byte(raw), &location))
+
+	return location
+}
+
+// crGeoLocation creates a GeoLocation fixture from latitude and longitude strings.
+func crGeoLocation(latitude, longitude string) *inventoryv1alpha1.GeoLocation {
+	return &inventoryv1alpha1.GeoLocation{
+		Latitude:  latitude,
+		Longitude: longitude,
+	}
+}
+
+//nolint:funlen // The table keeps all coordinate validation cases together.
+func TestVerifyLocationCoordinate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		apiLocation string
+		crLocation  *inventoryv1alpha1.GeoLocation
+		wantErr     bool
+		errContains []string
+	}{
+		{
+			name:        "both nil",
+			apiLocation: `{}`,
+		},
+		{
+			name: "cr nil api has coordinate",
+			apiLocation: `{
+				"coordinate": {
+					"type": "Point",
+					"coordinates": [-73.935242, 40.730610]
+				}
+			}`,
+			wantErr:     true,
+			errContains: []string{"coordinate: want nil"},
+		},
+		{
+			name:        "cr has coordinate api nil",
+			apiLocation: `{}`,
+			crLocation:  crGeoLocation("40.730610", "-73.935242"),
+			wantErr:     true,
+			errContains: []string{"coordinate: want non-nil, got nil"},
+		},
+		{
+			name: "matching point with two coordinates",
+			apiLocation: `{
+				"coordinate": {
+					"type": "Point",
+					"coordinates": [-73.935242, 40.730610]
+				}
+			}`,
+			crLocation: crGeoLocation("40.730610", "-73.935242"),
+		},
+		{
+			name: "matching point with three coordinates",
+			apiLocation: `{
+				"coordinate": {
+					"type": "Point",
+					"coordinates": [-73.935242, 40.730610, 12.5]
+				}
+			}`,
+			crLocation: crGeoLocation("40.730610", "-73.935242"),
+		},
+		{
+			name: "matching coordinates within epsilon",
+			apiLocation: `{
+				"coordinate": {
+					"type": "Point",
+					"coordinates": [-73.935242, 40.730615]
+				}
+			}`,
+			crLocation: crGeoLocation("40.730610", "-73.935242"),
+		},
+		{
+			name: "wrong geometry type",
+			apiLocation: `{
+				"coordinate": {
+					"type": "Polygon",
+					"coordinates": [-73.935242, 40.730610]
+				}
+			}`,
+			crLocation:  crGeoLocation("40.730610", "-73.935242"),
+			wantErr:     true,
+			errContains: []string{"coordinate.type: want \"Point\", got \"Polygon\""},
+		},
+		{
+			name: "invalid latitude",
+			apiLocation: `{
+				"coordinate": {
+					"type": "Point",
+					"coordinates": [-73.935242, 40.730610]
+				}
+			}`,
+			crLocation:  crGeoLocation("not-a-number", "-73.935242"),
+			wantErr:     true,
+			errContains: []string{"coordinate.latitude: invalid value"},
+		},
+		{
+			name: "invalid longitude",
+			apiLocation: `{
+				"coordinate": {
+					"type": "Point",
+					"coordinates": [-73.935242, 40.730610]
+				}
+			}`,
+			crLocation:  crGeoLocation("40.730610", "not-a-number"),
+			wantErr:     true,
+			errContains: []string{"coordinate.longitude: invalid value"},
+		},
+		{
+			name: "coordinates length one",
+			apiLocation: `{
+				"coordinate": {
+					"type": "Point",
+					"coordinates": [-73.935242]
+				}
+			}`,
+			crLocation:  crGeoLocation("40.730610", "-73.935242"),
+			wantErr:     true,
+			errContains: []string{"coordinate.coordinates: want length 2 or 3, got 1"},
+		},
+		{
+			name: "coordinates length four",
+			apiLocation: `{
+				"coordinate": {
+					"type": "Point",
+					"coordinates": [-73.935242, 40.730610, 12.5, 99.9]
+				}
+			}`,
+			crLocation:  crGeoLocation("40.730610", "-73.935242"),
+			wantErr:     true,
+			errContains: []string{"coordinate.coordinates: want length 2 or 3, got 4"},
+		},
+		{
+			name: "coordinate values mismatch",
+			apiLocation: `{
+				"coordinate": {
+					"type": "Point",
+					"coordinates": [-73.935242, 41.0]
+				}
+			}`,
+			crLocation:  crGeoLocation("40.730610", "-73.935242"),
+			wantErr:     true,
+			errContains: []string{"coordinate.coordinates: want"},
+		},
+		{
+			name: "multiple validation errors",
+			apiLocation: `{
+				"coordinate": {
+					"type": "Polygon",
+					"coordinates": [-73.935242]
+				}
+			}`,
+			crLocation: crGeoLocation("not-a-number", "-73.935242"),
+			wantErr:    true,
+			errContains: []string{
+				"coordinate.type: want \"Point\", got \"Polygon\"",
+				"coordinate.latitude: invalid value",
+				"coordinate.coordinates: want length 2 or 3, got 1",
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			apiLocation := mustUnmarshalLocationInfo(t, testCase.apiLocation)
+			err := verifyLocationCoordinate(apiLocation, testCase.crLocation)
+
+			if testCase.wantErr {
+				require.Error(t, err)
+
+				for _, fragment := range testCase.errContains {
+					assert.ErrorContains(t, err, fragment)
+				}
+
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/tests/cnf/ran/oran/internal/inventory/verify_resource.go
+++ b/tests/cnf/ran/oran/internal/inventory/verify_resource.go
@@ -1,0 +1,195 @@
+package inventory
+
+import (
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	bmhv1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/bmh"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	oranapi "github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran/api"
+)
+
+const resourceInfoDescriptionAnnotation = "resourceinfo.clcm.openshift.io/description"
+
+const (
+	extVendor           = "vendor"
+	extModel            = "model"
+	extAdminState       = "adminState"
+	extOperationalState = "operationalState"
+	extUsageState       = "usageState"
+	extPowerState       = "powerState"
+)
+
+type resourceView struct {
+	ResourceID     string
+	ResourcePoolID uuid.UUID
+	Description    string
+	GlobalAssetID  string
+	Extensions     map[string]string
+}
+
+// VerifyResourceMatchesBMH checks that an API Resource matches the corresponding BareMetalHost.
+func VerifyResourceMatchesBMH(
+	hubClient *clients.Settings,
+	apiResource oranapi.Resource,
+	host *bmh.BmhBuilder,
+	poolID uuid.UUID,
+) error {
+	hwBuilder, err := bmh.PullHardwareData(hubClient, host.Definition.Name, host.Definition.Namespace)
+	if err != nil {
+		return fmt.Errorf("pull hardware data for BMH %s/%s: %w",
+			host.Definition.Namespace, host.Definition.Name, err)
+	}
+
+	if hwBuilder == nil || hwBuilder.Definition == nil || hwBuilder.Definition.Spec.HardwareDetails == nil {
+		return fmt.Errorf("hardware data for BMH %s/%s is incomplete",
+			host.Definition.Namespace, host.Definition.Name)
+	}
+
+	if err := verifyResourceMatchesBMH(
+		apiResource, host.Definition, poolID, hwBuilder.Definition.Spec.HardwareDetails,
+	); err != nil {
+		return fmt.Errorf("verify inventory resource %s for BMH %s/%s in resource pool %s: %w",
+			apiResource.ResourceId, host.Definition.Namespace, host.Definition.Name, poolID, err)
+	}
+
+	return nil
+}
+
+// verifyResourceMatchesBMH compares a resource projection with BareMetalHost state.
+func verifyResourceMatchesBMH(
+	apiResource oranapi.Resource,
+	host *bmhv1alpha1.BareMetalHost,
+	poolID uuid.UUID,
+	hardwareDetails *bmhv1alpha1.HardwareDetails,
+) error {
+	if diff := cmp.Diff(
+		buildResourceViewFromHost(host, poolID, hardwareDetails),
+		buildResourceViewFromAPI(apiResource),
+	); diff != "" {
+		return fmt.Errorf("resource mismatch (-want +got):\n%s", diff)
+	}
+
+	return nil
+}
+
+// buildResourceViewFromHost creates the expected resource projection from a BareMetalHost.
+func buildResourceViewFromHost(
+	host *bmhv1alpha1.BareMetalHost,
+	poolID uuid.UUID,
+	hardwareDetails *bmhv1alpha1.HardwareDetails,
+) resourceView {
+	return resourceView{
+		ResourceID:     string(host.UID),
+		ResourcePoolID: poolID,
+		Description:    host.Annotations[resourceInfoDescriptionAnnotation],
+		GlobalAssetID:  hardwareDetails.SystemVendor.SerialNumber,
+		Extensions: map[string]string{
+			extVendor:           hardwareDetails.SystemVendor.Manufacturer,
+			extModel:            hardwareDetails.SystemVendor.ProductName,
+			extAdminState:       deriveAdminState(host),
+			extOperationalState: deriveOperationalState(host),
+			extUsageState:       deriveUsageState(host),
+			extPowerState:       derivePowerState(host),
+		},
+	}
+}
+
+// buildResourceViewFromAPI creates a resource projection from an API resource.
+func buildResourceViewFromAPI(resource oranapi.Resource) resourceView {
+	return resourceView{
+		ResourceID:     resource.ResourceId.String(),
+		ResourcePoolID: resource.ResourcePoolId,
+		Description:    resource.Description,
+		GlobalAssetID:  resource.GlobalAssetId,
+		Extensions: map[string]string{
+			extVendor:           readExtensionString(resource.Extensions, extVendor),
+			extModel:            readExtensionString(resource.Extensions, extModel),
+			extAdminState:       readExtensionString(resource.Extensions, extAdminState),
+			extOperationalState: readExtensionString(resource.Extensions, extOperationalState),
+			extUsageState:       readExtensionString(resource.Extensions, extUsageState),
+			extPowerState:       readExtensionString(resource.Extensions, extPowerState),
+		},
+	}
+}
+
+// readExtensionString returns a string extension value, or an empty string when unavailable.
+func readExtensionString(extensions map[string]any, name string) string {
+	value, exists := extensions[name]
+	if !exists {
+		return ""
+	}
+
+	valueString, isString := value.(string)
+	if !isString {
+		return ""
+	}
+
+	return valueString
+}
+
+// deriveAdminState derives the inventory admin state from a BareMetalHost.
+func deriveAdminState(host *bmhv1alpha1.BareMetalHost) string {
+	if host.Spec.Online {
+		return "UNLOCKED"
+	}
+
+	return "LOCKED"
+}
+
+// deriveOperationalState derives the inventory operational state from a BareMetalHost.
+func deriveOperationalState(host *bmhv1alpha1.BareMetalHost) string {
+	if host.Status.OperationalStatus == bmhv1alpha1.OperationalStatusOK &&
+		host.Spec.Online &&
+		host.Status.PoweredOn &&
+		(host.Status.Provisioning.State == bmhv1alpha1.StateProvisioned ||
+			host.Status.Provisioning.State == bmhv1alpha1.StateExternallyProvisioned) {
+		return "ENABLED"
+	}
+
+	return "DISABLED"
+}
+
+// deriveUsageState derives the inventory usage state from a BareMetalHost.
+func deriveUsageState(host *bmhv1alpha1.BareMetalHost) string {
+	switch host.Status.Provisioning.State {
+	case bmhv1alpha1.StateProvisioned, bmhv1alpha1.StateExternallyProvisioned:
+		if host.Status.OperationalStatus == bmhv1alpha1.OperationalStatusOK &&
+			host.Spec.Online && host.Status.PoweredOn {
+			return "ACTIVE"
+		}
+
+		return "BUSY"
+	case bmhv1alpha1.StateAvailable, bmhv1alpha1.StateReady:
+		if host.Status.OperationalStatus == bmhv1alpha1.OperationalStatusOK {
+			return "IDLE"
+		}
+
+		return "BUSY"
+	case bmhv1alpha1.StateProvisioning,
+		bmhv1alpha1.StatePreparing,
+		bmhv1alpha1.StateDeprovisioning,
+		bmhv1alpha1.StateInspecting,
+		bmhv1alpha1.StatePoweringOffBeforeDelete,
+		bmhv1alpha1.StateDeleting:
+		return "BUSY"
+	case bmhv1alpha1.StateNone,
+		bmhv1alpha1.StateUnmanaged,
+		bmhv1alpha1.StateRegistering,
+		bmhv1alpha1.StateMatchProfile:
+		return "UNKNOWN"
+	}
+
+	return "UNKNOWN"
+}
+
+// derivePowerState derives the inventory power state from a BareMetalHost.
+func derivePowerState(host *bmhv1alpha1.BareMetalHost) string {
+	if host.Status.PoweredOn {
+		return "ON"
+	}
+
+	return "OFF"
+}

--- a/tests/cnf/ran/oran/internal/inventory/verify_resource_test.go
+++ b/tests/cnf/ran/oran/internal/inventory/verify_resource_test.go
@@ -1,3 +1,5 @@
+//go:build unit_test
+
 package inventory
 
 import (

--- a/tests/cnf/ran/oran/internal/inventory/verify_resource_test.go
+++ b/tests/cnf/ran/oran/internal/inventory/verify_resource_test.go
@@ -1,0 +1,234 @@
+package inventory
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	bmhv1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	oranapi "github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// createMatchingResourceFixture creates matching API, host, pool, and hardware fixtures.
+func createMatchingResourceFixture() (
+	oranapi.Resource, *bmhv1alpha1.BareMetalHost, uuid.UUID, *bmhv1alpha1.HardwareDetails) {
+	resourceID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	poolID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	host := createProvisionedOnlineHost()
+	host.ObjectMeta = metav1.ObjectMeta{
+		UID:         types.UID(resourceID.String()),
+		Annotations: map[string]string{resourceInfoDescriptionAnnotation: "server description"},
+	}
+	hardware := &bmhv1alpha1.HardwareDetails{
+		SystemVendor: bmhv1alpha1.HardwareSystemVendor{
+			SerialNumber: "serial-1",
+			Manufacturer: "Acme",
+			ProductName:  "Model A",
+		},
+	}
+	resource := oranapi.Resource{
+		ResourceId:     resourceID,
+		ResourcePoolId: poolID,
+		Description:    "server description",
+		GlobalAssetId:  "serial-1",
+		Extensions: map[string]any{
+			extVendor:           "Acme",
+			extModel:            "Model A",
+			extAdminState:       "UNLOCKED",
+			extOperationalState: "ENABLED",
+			extUsageState:       "ACTIVE",
+			extPowerState:       "ON",
+		},
+	}
+
+	return resource, host, poolID, hardware
+}
+
+func TestVerifyResourceMatchesBMHProjection(t *testing.T) {
+	t.Parallel()
+
+	resource, host, poolID, hardware := createMatchingResourceFixture()
+	require.NoError(t, verifyResourceMatchesBMH(resource, host, poolID, hardware))
+
+	resource.Description = "different description"
+	resource.Extensions[extVendor] = "Different Vendor"
+
+	err := verifyResourceMatchesBMH(resource, host, poolID, hardware)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Description")
+	assert.Contains(t, err.Error(), `"vendor"`)
+}
+
+func TestVerifyResourceMatchesBMHNilAnnotations(t *testing.T) {
+	t.Parallel()
+
+	resource, host, poolID, hardware := createMatchingResourceFixture()
+	host.Annotations = nil
+	resource.Description = ""
+
+	assert.NoError(t, verifyResourceMatchesBMH(resource, host, poolID, hardware))
+}
+
+func TestReadExtensionString(t *testing.T) {
+	t.Parallel()
+
+	extensions := map[string]any{
+		"string":    "value",
+		"notString": 123,
+	}
+
+	assert.Equal(t, "value", readExtensionString(extensions, "string"))
+	assert.Empty(t, readExtensionString(extensions, "missing"))
+	assert.Empty(t, readExtensionString(extensions, "notString"))
+}
+
+// createProvisionedOnlineHost creates a provisioned, online, powered-on host fixture.
+func createProvisionedOnlineHost() *bmhv1alpha1.BareMetalHost {
+	return &bmhv1alpha1.BareMetalHost{
+		Spec: bmhv1alpha1.BareMetalHostSpec{Online: true},
+		Status: bmhv1alpha1.BareMetalHostStatus{
+			OperationalStatus: bmhv1alpha1.OperationalStatusOK,
+			PoweredOn:         true,
+			Provisioning: bmhv1alpha1.ProvisionStatus{
+				State: bmhv1alpha1.StateProvisioned,
+			},
+		},
+	}
+}
+
+// createOfflineHost creates an offline host fixture.
+func createOfflineHost() *bmhv1alpha1.BareMetalHost {
+	return &bmhv1alpha1.BareMetalHost{
+		Spec: bmhv1alpha1.BareMetalHostSpec{Online: false},
+	}
+}
+
+func TestExpectedAdminState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		online bool
+		want   string
+	}{
+		{name: "online", online: true, want: "UNLOCKED"},
+		{name: "offline", online: false, want: "LOCKED"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			host := &bmhv1alpha1.BareMetalHost{Spec: bmhv1alpha1.BareMetalHostSpec{Online: testCase.online}}
+			assert.Equal(t, testCase.want, deriveAdminState(host))
+		})
+	}
+}
+
+func TestExpectedOperationalState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		host *bmhv1alpha1.BareMetalHost
+		want string
+	}{
+		{
+			name: "enabled when provisioned online and powered on",
+			host: createProvisionedOnlineHost(),
+			want: "ENABLED",
+		},
+		{
+			name: "disabled when offline",
+			host: createOfflineHost(),
+			want: "DISABLED",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, testCase.want, deriveOperationalState(testCase.host))
+		})
+	}
+}
+
+func TestExpectedUsageState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		host *bmhv1alpha1.BareMetalHost
+		want string
+	}{
+		{
+			name: "provisioned active",
+			host: createProvisionedOnlineHost(),
+			want: "ACTIVE",
+		},
+		{
+			name: "available idle",
+			host: &bmhv1alpha1.BareMetalHost{
+				Status: bmhv1alpha1.BareMetalHostStatus{
+					OperationalStatus: bmhv1alpha1.OperationalStatusOK,
+					Provisioning:      bmhv1alpha1.ProvisionStatus{State: bmhv1alpha1.StateAvailable},
+				},
+			},
+			want: "IDLE",
+		},
+		{
+			name: "provisioning busy",
+			host: &bmhv1alpha1.BareMetalHost{
+				Status: bmhv1alpha1.BareMetalHostStatus{
+					Provisioning: bmhv1alpha1.ProvisionStatus{State: bmhv1alpha1.StateProvisioning},
+				},
+			},
+			want: "BUSY",
+		},
+		{
+			name: "registering unknown",
+			host: &bmhv1alpha1.BareMetalHost{
+				Status: bmhv1alpha1.BareMetalHostStatus{
+					Provisioning: bmhv1alpha1.ProvisionStatus{State: bmhv1alpha1.StateRegistering},
+				},
+			},
+			want: "UNKNOWN",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, testCase.want, deriveUsageState(testCase.host))
+		})
+	}
+}
+
+func TestExpectedPowerState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		poweredOn bool
+		want      string
+	}{
+		{name: "on", poweredOn: true, want: "ON"},
+		{name: "off", poweredOn: false, want: "OFF"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			host := &bmhv1alpha1.BareMetalHost{
+				Status: bmhv1alpha1.BareMetalHostStatus{PoweredOn: testCase.poweredOn},
+			}
+			assert.Equal(t, testCase.want, derivePowerState(host))
+		})
+	}
+}

--- a/tests/cnf/ran/oran/internal/inventory/verify_site_pool.go
+++ b/tests/cnf/ran/oran/internal/inventory/verify_site_pool.go
@@ -1,0 +1,80 @@
+package inventory
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran"
+	oranapi "github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran/api"
+)
+
+// VerifyOCloudSiteMatchesCR checks that an API O-Cloud Site matches the corresponding OCloudSite CR and related pools.
+func VerifyOCloudSiteMatchesCR(
+	apiSite oranapi.OCloudSiteInfo,
+	siteCR *oran.OCloudSiteBuilder,
+	readyPools []*oran.ResourcePoolBuilder,
+) error {
+	type view struct {
+		Name             string
+		GlobalLocationID string
+		Description      string
+	}
+
+	var comparisonErr error
+	if diff := cmp.Diff(
+		view{siteCR.Definition.Name, siteCR.Definition.Spec.GlobalLocationName, siteCR.Definition.Spec.Description},
+		view{apiSite.Name, apiSite.GlobalLocationId, apiSite.Description},
+	); diff != "" {
+		comparisonErr = fmt.Errorf("O-Cloud site mismatch (-want +got):\n%s", diff)
+	}
+
+	return errors.Join(
+		comparisonErr,
+		verifyStringSetEqual(
+			collectExpectedPoolIDsForSite(siteCR, readyPools), extractAPIPoolIDs(apiSite),
+			fmt.Sprintf("resourcePools for OCloudSite %s", siteCR.Definition.Name)),
+	)
+}
+
+// collectExpectedPoolIDsForSite returns UIDs of ready ResourcePools bound to the given OCloudSite.
+func collectExpectedPoolIDsForSite(siteCR *oran.OCloudSiteBuilder, readyPools []*oran.ResourcePoolBuilder) []string {
+	var poolIDs []string
+
+	for _, pool := range readyPools {
+		if pool.Definition.Spec.OCloudSiteName == siteCR.Definition.Name {
+			poolIDs = append(poolIDs, string(pool.Definition.UID))
+		}
+	}
+
+	return poolIDs
+}
+
+// extractAPIPoolIDs returns string UIDs from an API OCloudSite's ResourcePools.
+func extractAPIPoolIDs(apiSite oranapi.OCloudSiteInfo) []string {
+	poolIDs := make([]string, 0, len(apiSite.ResourcePools))
+	for _, poolID := range apiSite.ResourcePools {
+		poolIDs = append(poolIDs, poolID.String())
+	}
+
+	return poolIDs
+}
+
+// VerifyResourcePoolMatchesCR checks that an API Resource Pool matches the corresponding ResourcePool CR.
+func VerifyResourcePoolMatchesCR(apiPool oranapi.ResourcePool, poolCR *oran.ResourcePoolBuilder) error {
+	type view struct {
+		Name         string
+		Description  string
+		OCloudSiteID string
+	}
+
+	if diff := cmp.Diff(
+		view{poolCR.Definition.Name, poolCR.Definition.Spec.Description,
+			poolCR.Definition.Status.ResolvedOCloudSiteUID},
+		view{apiPool.Name, apiPool.Description, apiPool.OCloudSiteId.String()},
+	); diff != "" {
+		return fmt.Errorf("resource pool mismatch (-want +got):\n%s", diff)
+	}
+
+	return nil
+}

--- a/tests/cnf/ran/oran/internal/tsparams/consts.go
+++ b/tests/cnf/ran/oran/internal/tsparams/consts.go
@@ -19,6 +19,8 @@ const (
 	LabelTemplateInventory = "template-inventory"
 	// LabelAlarms is the label applied to just the alarms test cases.
 	LabelAlarms = "alarms"
+	// LabelInventory is the label applied to just the inventory API test cases.
+	LabelInventory = "inventory"
 )
 
 const (
@@ -110,6 +112,17 @@ const (
 	// TestPRName2 is the second UUID used for naming ProvisioningRequests. Metal3 tests require a second PR applied
 	// to verify the case of all hardware already allocated.
 	TestPRName2 = "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+
+	// TestLocationAlpha is the first Location name used by inventory filter tests.
+	TestLocationAlpha = "test-location-alpha"
+	// TestLocationBeta is the second Location name used by inventory filter tests.
+	TestLocationBeta = "test-location-beta"
+	// TestInventoryResourcePool is the ResourcePool name used by inventory subscription notification tests.
+	TestInventoryResourcePool = "oran-test-inventory-pool"
+	// ResourcePoolNameLabel is the BMH label that associates a host with a ResourcePool.
+	ResourcePoolNameLabel = "resources.clcm.openshift.io/resourcePoolName"
+	// NonExistentUUID is a well-known UUID used for not-found inventory API requests.
+	NonExistentUUID = "00000000-0000-0000-0000-000000000000"
 )
 
 // LogLevel is the glog verbosity level to use for logs in this suite or its helpers.

--- a/tests/cnf/ran/oran/internal/tsparams/oranvars.go
+++ b/tests/cnf/ran/oran/internal/tsparams/oranvars.go
@@ -1,6 +1,7 @@
 package tsparams
 
 import (
+	bmhv1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/openshift-kni/k8sreporter"
 	hardwaremanagementv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
@@ -32,12 +33,17 @@ var (
 
 	// ReporterHubCRsToDump is the CRs the reporter should dump on the hub.
 	ReporterHubCRsToDump = []k8sreporter.CRData{
+		{Cr: &bmhv1alpha1.BareMetalHostList{}},
+		{Cr: &bmhv1alpha1.HardwareDataList{}},
 		{Cr: &provisioningv1alpha1.ClusterTemplateList{}},
 		{Cr: &provisioningv1alpha1.ProvisioningRequestList{}},
 		{Cr: &hardwaremanagementv1alpha1.HardwareProfileList{}},
 		{Cr: &hardwaremanagementv1alpha1.AllocatedNodeList{}},
 		{Cr: &hardwaremanagementv1alpha1.NodeAllocationRequestList{}},
 		{Cr: &inventoryv1alpha1.InventoryList{}},
+		{Cr: &inventoryv1alpha1.LocationList{}},
+		{Cr: &inventoryv1alpha1.OCloudSiteList{}},
+		{Cr: &inventoryv1alpha1.ResourcePoolList{}},
 		{Cr: &policiesv1.PolicyList{}},
 		{Cr: &siteconfigv1alpha1.ClusterInstanceList{}},
 	}
@@ -85,5 +91,12 @@ var (
 		Reason:  string(provisioningv1alpha1.CTconditionReasons.Failed),
 		Status:  metav1.ConditionFalse,
 		Message: "ClusterTemplate must define hardware provisioning",
+	}
+
+	// InventoryReadyCondition matches Ready=True on inventory hierarchy CRs (Location, OCloudSite,
+	// ResourcePool).
+	InventoryReadyCondition = metav1.Condition{
+		Type:   inventoryv1alpha1.ConditionTypeReady,
+		Status: metav1.ConditionTrue,
 	}
 )

--- a/tests/cnf/ran/oran/tests/oran-inventory.go
+++ b/tests/cnf/ran/oran/tests/oran-inventory.go
@@ -774,9 +774,12 @@ func collectExpectedResourceTypePairs() map[vendorModelPair]struct{} {
 
 	for _, host := range hosts {
 		hwDataBuilder, err := bmh.PullHardwareData(HubAPIClient, host.Definition.Name, host.Definition.Namespace)
-		if err != nil || hwDataBuilder.Definition == nil || hwDataBuilder.Definition.Spec.HardwareDetails == nil {
-			continue
-		}
+		Expect(err).ToNot(HaveOccurred(),
+			"Failed to pull hardware data for BMH %s while collecting expected resource type pairs", host.Definition.Name)
+		Expect(hwDataBuilder.Definition).ToNot(BeNil(),
+			"Hardware data builder for BMH %s should not be nil", host.Definition.Name)
+		Expect(hwDataBuilder.Definition.Spec.HardwareDetails).ToNot(BeNil(),
+			"Hardware details for BMH %s should not be nil", host.Definition.Name)
 
 		pair := vendorModelPair{
 			vendor: hwDataBuilder.Definition.Spec.HardwareDetails.SystemVendor.Manufacturer,

--- a/tests/cnf/ran/oran/tests/oran-inventory.go
+++ b/tests/cnf/ran/oran/tests/oran-inventory.go
@@ -1,0 +1,845 @@
+package tests
+
+import (
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/bmh"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/ocm"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran"
+	oranapi "github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran/api"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran/api/fields"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran/api/filter"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/auth"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/inventory"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
+	mocksmo "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/oran-mock-smo"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("ORAN Inventory API Tests", Label(tsparams.LabelPostProvision, tsparams.LabelInventory), func() {
+	var inventoryClient *oranapi.InventoryClient
+
+	BeforeEach(func() {
+		By("creating the O2IMS inventory API client")
+
+		clientBuilder, err := auth.NewClientBuilderForConfig(RANConfig)
+		Expect(err).ToNot(HaveOccurred(), "Failed to create the O2IMS API client builder")
+
+		inventoryClient, err = clientBuilder.BuildInventory()
+		Expect(err).ToNot(HaveOccurred(), "Failed to create the O2IMS inventory API client")
+	})
+
+	// 89890 - Retrieve O-Cloud information
+	It("retrieves O-Cloud information", reportxml.ID("89890"), func() {
+		By("getting O-Cloud information from the inventory API")
+
+		cloudInfo, err := inventoryClient.GetCloudInfo()
+		Expect(err).ToNot(HaveOccurred(), "Failed to get O-Cloud information")
+
+		By("verifying O-Cloud identity fields are populated")
+		Expect(cloudInfo.OCloudId).ToNot(Equal(uuid.Nil), "oCloudId should be populated")
+		Expect(cloudInfo.GlobalCloudId).ToNot(Equal(uuid.Nil), "globalCloudId should be populated")
+		Expect(cloudInfo.Name).ToNot(BeEmpty(), "name should be populated")
+		Expect(cloudInfo.Description).ToNot(BeEmpty(), "description should be populated")
+		Expect(cloudInfo.ServiceUri).ToNot(BeEmpty(), "serviceUri should be populated")
+	})
+
+	// 89891 - Retrieve API versions
+	It("retrieves API versions", reportxml.ID("89891"), func() {
+		By("getting all inventory API versions")
+
+		allVersions, err := inventoryClient.GetAllVersions()
+		Expect(err).ToNot(HaveOccurred(), "Failed to get all inventory API versions")
+
+		verifyErr := inventory.VerifyAPIVersions(allVersions)
+		Expect(verifyErr).ToNot(HaveOccurred(), "All API versions response failed verification")
+
+		By("getting minor inventory API versions")
+
+		minorVersions, err := inventoryClient.GetMinorVersions()
+		Expect(err).ToNot(HaveOccurred(), "Failed to get minor inventory API versions")
+
+		verifyErr = inventory.VerifyAPIVersions(minorVersions)
+		Expect(verifyErr).ToNot(HaveOccurred(), "Minor API versions response failed verification")
+	})
+
+	// 89892 - List and retrieve Locations
+	It("lists and retrieves Locations", reportxml.ID("89892"), func() {
+		By("listing Ready Location CRs on the hub")
+
+		readyLocations, err := oran.ListReadyLocations(HubAPIClient, client.InNamespace(tsparams.O2IMSNamespace))
+		Expect(err).ToNot(HaveOccurred(), "Failed to list Ready Location CRs")
+		Expect(readyLocations).ToNot(BeEmpty(), "At least one Ready Location CR is required")
+
+		By("listing Locations from the inventory API")
+
+		apiLocations, err := inventoryClient.ListLocations()
+		Expect(err).ToNot(HaveOccurred(), "Failed to list Locations from the inventory API")
+		Expect(apiLocations).To(HaveLen(len(readyLocations)),
+			"Number of API Locations should match Ready Location CRs")
+
+		By("verifying each Ready Location CR matches an API Location")
+
+		readySites, err := oran.ListReadyOCloudSites(HubAPIClient, client.InNamespace(tsparams.O2IMSNamespace))
+		Expect(err).ToNot(HaveOccurred(), "Failed to list Ready OCloudSite CRs")
+
+		for _, locationCR := range readyLocations {
+			locationIdx := slices.IndexFunc(apiLocations, func(loc oranapi.LocationInfo) bool {
+				return loc.GlobalLocationId == locationCR.Definition.Name
+			})
+			Expect(locationIdx).ToNot(Equal(-1), "Location CR %s missing from API response", locationCR.Definition.Name)
+			verifyErr := inventory.VerifyLocationMatchesCR(apiLocations[locationIdx], locationCR, readySites)
+			Expect(verifyErr).ToNot(HaveOccurred(),
+				"Location CR %s does not match API Location", locationCR.Definition.Name)
+		}
+
+		By("retrieving a Location by globalLocationId")
+
+		chosen := apiLocations[0]
+		retrieved, err := inventoryClient.GetLocation(chosen.GlobalLocationId)
+		Expect(err).ToNot(HaveOccurred(), "Failed to get Location %s", chosen.GlobalLocationId)
+		Expect(retrieved).To(Equal(chosen), "Retrieved Location should match the listed Location")
+	})
+
+	// 89893 - List and retrieve O-Cloud Sites
+	It("lists and retrieves O-Cloud Sites", reportxml.ID("89893"), func() {
+		By("listing Ready OCloudSite CRs on the hub")
+
+		readySites, err := oran.ListReadyOCloudSites(HubAPIClient, client.InNamespace(tsparams.O2IMSNamespace))
+		Expect(err).ToNot(HaveOccurred(), "Failed to list Ready OCloudSite CRs")
+		Expect(readySites).ToNot(BeEmpty(), "At least one Ready OCloudSite CR is required")
+
+		By("listing O-Cloud Sites from the inventory API")
+
+		apiSites, err := inventoryClient.ListOCloudSites()
+		Expect(err).ToNot(HaveOccurred(), "Failed to list O-Cloud Sites from the inventory API")
+		Expect(apiSites).To(HaveLen(len(readySites)),
+			"Number of API O-Cloud Sites should match Ready OCloudSite CRs")
+
+		By("verifying each Ready OCloudSite CR matches an API O-Cloud Site")
+
+		readyPools, err := oran.ListReadyResourcePools(HubAPIClient, client.InNamespace(tsparams.O2IMSNamespace))
+		Expect(err).ToNot(HaveOccurred(), "Failed to list Ready ResourcePool CRs")
+
+		for _, siteCR := range readySites {
+			siteID := string(siteCR.Definition.UID)
+			siteIdx := slices.IndexFunc(apiSites, func(site oranapi.OCloudSiteInfo) bool {
+				return site.OCloudSiteId.String() == siteID
+			})
+			Expect(siteIdx).ToNot(Equal(-1), "OCloudSite CR %s missing from API response", siteCR.Definition.Name)
+			verifyErr := inventory.VerifyOCloudSiteMatchesCR(apiSites[siteIdx], siteCR, readyPools)
+			Expect(verifyErr).ToNot(HaveOccurred(),
+				"OCloudSite CR %s does not match API O-Cloud Site", siteCR.Definition.Name)
+		}
+
+		By("retrieving an O-Cloud Site by oCloudSiteId")
+
+		chosen := apiSites[0]
+		retrieved, err := inventoryClient.GetOCloudSite(chosen.OCloudSiteId)
+		Expect(err).ToNot(HaveOccurred(), "Failed to get O-Cloud Site %s", chosen.OCloudSiteId)
+		Expect(retrieved).To(Equal(chosen), "Retrieved O-Cloud Site should match the listed site")
+	})
+
+	// 89894 - List and retrieve Resource Pools
+	It("lists and retrieves Resource Pools", reportxml.ID("89894"), func() {
+		By("listing Ready ResourcePool CRs on the hub")
+
+		readyPools, err := oran.ListReadyResourcePools(HubAPIClient, client.InNamespace(tsparams.O2IMSNamespace))
+		Expect(err).ToNot(HaveOccurred(), "Failed to list Ready ResourcePool CRs")
+		Expect(readyPools).ToNot(BeEmpty(), "At least one Ready ResourcePool CR is required")
+
+		By("listing Resource Pools from the inventory API")
+
+		apiPools, err := inventoryClient.ListResourcePools()
+		Expect(err).ToNot(HaveOccurred(), "Failed to list Resource Pools from the inventory API")
+		Expect(apiPools).To(HaveLen(len(readyPools)),
+			"Number of API Resource Pools should match Ready ResourcePool CRs")
+
+		By("verifying each Ready ResourcePool CR matches an API Resource Pool")
+
+		for _, poolCR := range readyPools {
+			poolID := string(poolCR.Definition.UID)
+			poolIdx := slices.IndexFunc(apiPools, func(pool oranapi.ResourcePool) bool {
+				return pool.ResourcePoolId.String() == poolID
+			})
+			Expect(poolIdx).ToNot(Equal(-1), "ResourcePool CR %s missing from API response", poolCR.Definition.Name)
+			verifyErr := inventory.VerifyResourcePoolMatchesCR(apiPools[poolIdx], poolCR)
+			Expect(verifyErr).ToNot(HaveOccurred(),
+				"ResourcePool CR %s does not match API Resource Pool", poolCR.Definition.Name)
+		}
+
+		By("retrieving a Resource Pool by resourcePoolId")
+
+		chosen := apiPools[0]
+		retrieved, err := inventoryClient.GetResourcePool(chosen.ResourcePoolId)
+		Expect(err).ToNot(HaveOccurred(), "Failed to get Resource Pool %s", chosen.ResourcePoolId)
+		Expect(retrieved.ResourcePoolId).To(Equal(chosen.ResourcePoolId),
+			"Retrieved Resource Pool ID should match listed pool")
+		Expect(retrieved.Name).To(Equal(chosen.Name),
+			"Retrieved Resource Pool name should match listed pool")
+		Expect(retrieved.Description).To(Equal(chosen.Description),
+			"Retrieved Resource Pool description should match listed pool")
+		Expect(retrieved.OCloudSiteId).To(Equal(chosen.OCloudSiteId),
+			"Retrieved Resource Pool oCloudSiteId should match listed pool")
+		Expect(retrieved.Extensions).ToNot(BeNil(), "Resource Pool extensions should be populated")
+	})
+
+	// 89895 - List and retrieve Resources in a Resource Pool
+	It("lists and retrieves Resources in a Resource Pool", reportxml.ID("89895"), func() {
+		By("identifying a ResourcePool with inventory-eligible BMHs")
+
+		poolCR, expectedBMHs := findResourcePoolWithInventoryBMHs()
+		Expect(poolCR).ToNot(BeNil(), "A ResourcePool with inventory-eligible BMHs is required")
+		Expect(expectedBMHs).ToNot(BeEmpty(), "At least one inventory-eligible BMH is required")
+
+		poolID, err := uuid.Parse(string(poolCR.Definition.UID))
+		Expect(err).ToNot(HaveOccurred(), "Failed to parse ResourcePool UID")
+
+		By("listing Resources from the inventory API")
+
+		apiResources, err := inventoryClient.ListResources(poolID)
+		Expect(err).ToNot(HaveOccurred(), "Failed to list Resources for pool %s", poolID)
+		Expect(apiResources).To(HaveLen(len(expectedBMHs)),
+			"Number of API Resources should match inventory-eligible BMHs")
+
+		By("verifying each BMH matches an API Resource")
+
+		for _, host := range expectedBMHs {
+			resourceID := string(host.Definition.UID)
+			resourceIdx := slices.IndexFunc(apiResources, func(resource oranapi.Resource) bool {
+				return resource.ResourceId.String() == resourceID
+			})
+			Expect(resourceIdx).ToNot(Equal(-1), "BMH %s/%s missing from API response",
+				host.Definition.Namespace, host.Definition.Name)
+			verifyErr := inventory.VerifyResourceMatchesBMH(HubAPIClient, apiResources[resourceIdx], host, poolID)
+			Expect(verifyErr).ToNot(HaveOccurred(),
+				"BMH %s/%s does not match API Resource", host.Definition.Namespace, host.Definition.Name)
+		}
+
+		By("retrieving a Resource by resourceId")
+
+		chosen := apiResources[0]
+		retrieved, err := inventoryClient.GetResource(poolID, chosen.ResourceId)
+		Expect(err).ToNot(HaveOccurred(), "Failed to get Resource %s", chosen.ResourceId)
+		Expect(retrieved).To(Equal(chosen), "Retrieved Resource should match the listed Resource")
+	})
+
+	// 89896 - List and retrieve Resource Types
+	It("lists and retrieves Resource Types", reportxml.ID("89896"), func() {
+		By("collecting distinct vendor/model pairs from inventory-eligible BMHs")
+
+		expectedPairs := collectExpectedResourceTypePairs()
+		Expect(expectedPairs).ToNot(BeEmpty(), "At least one vendor/model pair is required")
+
+		By("listing Resource Types from the inventory API")
+
+		apiResourceTypes, err := inventoryClient.ListResourceTypes()
+		Expect(err).ToNot(HaveOccurred(), "Failed to list Resource Types")
+		Expect(apiResourceTypes).To(HaveLen(len(expectedPairs)),
+			"Number of API Resource Types should match distinct vendor/model pairs")
+
+		By("verifying each vendor/model pair has a matching Resource Type")
+
+		for pair := range expectedPairs {
+			typeIdx := slices.IndexFunc(apiResourceTypes, func(resourceType oranapi.ResourceType) bool {
+				return resourceType.Vendor == pair.vendor && resourceType.Model == pair.model
+			})
+			Expect(typeIdx).ToNot(Equal(-1), "Missing ResourceType for vendor=%s model=%s", pair.vendor, pair.model)
+			Expect(string(apiResourceTypes[typeIdx].ResourceKind)).To(Equal("PHYSICAL"),
+				"ResourceType vendor=%s model=%s should have resourceKind PHYSICAL", pair.vendor, pair.model)
+			Expect(string(apiResourceTypes[typeIdx].ResourceClass)).To(Equal("COMPUTE"),
+				"ResourceType vendor=%s model=%s should have resourceClass COMPUTE", pair.vendor, pair.model)
+		}
+
+		By("retrieving a Resource Type by resourceTypeId")
+
+		chosen := apiResourceTypes[0]
+		retrieved, err := inventoryClient.GetResourceType(chosen.ResourceTypeId)
+		Expect(err).ToNot(HaveOccurred(), "Failed to get Resource Type %s", chosen.ResourceTypeId)
+		Expect(retrieved.ResourceTypeId).To(Equal(chosen.ResourceTypeId),
+			"Retrieved Resource Type ID should match listed type")
+		Expect(retrieved.Vendor).To(Equal(chosen.Vendor),
+			"Retrieved Resource Type vendor should match listed type")
+		Expect(retrieved.Model).To(Equal(chosen.Model),
+			"Retrieved Resource Type model should match listed type")
+		Expect(retrieved.Version).To(Equal(chosen.Version),
+			"Retrieved Resource Type version should match listed type")
+		Expect(retrieved.AlarmDictionaryId).ToNot(BeNil(), "alarmDictionaryId should be populated")
+	})
+
+	// 89897 - Retrieve Resource Type Alarm Dictionary
+	It("retrieves Resource Type Alarm Dictionary", reportxml.ID("89897"), func() {
+		By("listing Resource Types and selecting one with an alarm dictionary")
+
+		apiResourceTypes, err := inventoryClient.ListResourceTypes()
+		Expect(err).ToNot(HaveOccurred(), "Failed to list Resource Types")
+
+		var chosen *oranapi.ResourceType
+
+		for i := range apiResourceTypes {
+			if apiResourceTypes[i].AlarmDictionaryId != nil {
+				chosen = &apiResourceTypes[i]
+
+				break
+			}
+		}
+
+		Expect(chosen).ToNot(BeNil(), "At least one Resource Type with alarmDictionaryId is required")
+
+		By("retrieving the Resource Type alarm dictionary")
+
+		alarmDictionary, err := inventoryClient.GetResourceTypeAlarmDictionary(chosen.ResourceTypeId)
+		Expect(err).ToNot(HaveOccurred(), "Failed to get Resource Type alarm dictionary")
+		Expect(alarmDictionary.AlarmDictionaryId).To(Equal(*chosen.AlarmDictionaryId),
+			"Retrieved alarm dictionary ID should match Resource Type alarmDictionaryId")
+	})
+
+	// 89898 - List and retrieve Deployment Managers
+	It("lists and retrieves Deployment Managers", reportxml.ID("89898"), func() {
+		By("listing eligible ManagedClusters on the hub")
+
+		eligibleClusters, err := ocm.ListDeploymentManagerEligibleManagedClusters(HubAPIClient)
+		Expect(err).ToNot(HaveOccurred(), "Failed to list Deployment Manager eligible ManagedClusters")
+		Expect(eligibleClusters).ToNot(BeEmpty(), "At least one eligible ManagedCluster is required")
+
+		By("listing Deployment Managers from the inventory API")
+
+		apiManagers, err := inventoryClient.ListDeploymentManagers()
+		Expect(err).ToNot(HaveOccurred(), "Failed to list Deployment Managers")
+		Expect(apiManagers).To(HaveLen(len(eligibleClusters)),
+			"Number of API Deployment Managers should match eligible ManagedClusters")
+
+		By("verifying each eligible ManagedCluster matches an API Deployment Manager")
+
+		for _, cluster := range eligibleClusters {
+			managerIdx := slices.IndexFunc(apiManagers, func(manager oranapi.DeploymentManager) bool {
+				return manager.Name == cluster.Definition.Name
+			})
+			Expect(managerIdx).ToNot(Equal(-1), "ManagedCluster %s missing from API response", cluster.Definition.Name)
+			verifyErr := inventory.VerifyDeploymentManagerMatchesCluster(apiManagers[managerIdx], cluster)
+			Expect(verifyErr).ToNot(HaveOccurred(),
+				"ManagedCluster %s does not match API Deployment Manager", cluster.Definition.Name)
+		}
+
+		By("retrieving a Deployment Manager by deploymentManagerId")
+
+		chosen := apiManagers[0]
+		retrieved, err := inventoryClient.GetDeploymentManager(chosen.DeploymentManagerId)
+		Expect(err).ToNot(HaveOccurred(), "Failed to get Deployment Manager %s", chosen.DeploymentManagerId)
+		Expect(retrieved.DeploymentManagerId).To(Equal(chosen.DeploymentManagerId),
+			"Retrieved Deployment Manager ID should match listed manager")
+		Expect(retrieved.Name).To(Equal(chosen.Name),
+			"Retrieved Deployment Manager name should match listed manager")
+		Expect(retrieved.Extensions).ToNot(BeNil(), "extensions should be populated")
+		Expect(retrieved.Capabilities).ToNot(BeNil(), "capabilities should be present")
+		Expect(retrieved.Capacity).ToNot(BeNil(), "capacity should be present")
+	})
+
+	// 89899 - List and retrieve Alarm Dictionaries
+	It("lists and retrieves Alarm Dictionaries", reportxml.ID("89899"), func() {
+		By("listing Alarm Dictionaries from the inventory API")
+
+		alarmDictionaries, err := inventoryClient.ListInventoryAlarmDictionaries()
+		Expect(err).ToNot(HaveOccurred(), "Failed to list Alarm Dictionaries")
+		Expect(alarmDictionaries).ToNot(BeEmpty(), "At least one Alarm Dictionary is required")
+
+		By("retrieving an Alarm Dictionary by ID")
+
+		chosen := alarmDictionaries[0]
+		retrieved, err := inventoryClient.GetInventoryAlarmDictionary(chosen.AlarmDictionaryId)
+		Expect(err).ToNot(HaveOccurred(), "Failed to get Alarm Dictionary %s", chosen.AlarmDictionaryId)
+		Expect(retrieved.AlarmDictionaryId).To(Equal(chosen.AlarmDictionaryId),
+			"Retrieved Alarm Dictionary ID should match listed dictionary")
+	})
+
+	// 89900 - Subscription lifecycle (create, list, get, delete)
+	It("handles inventory subscription lifecycle", reportxml.ID("89900"), func() {
+		By("creating an inventory subscription")
+
+		consumerSubscriptionID := uuid.New()
+		created, err := inventoryClient.CreateInventorySubscription(oranapi.InventorySubscription{
+			ConsumerSubscriptionId: &consumerSubscriptionID,
+			Filter:                 new(""),
+			Callback:               mocksmo.ObserverCallbackURL(mockSMOBaseURL, consumerSubscriptionID.String()),
+		})
+		Expect(err).ToNot(HaveOccurred(), "Failed to create inventory subscription")
+		Expect(created.SubscriptionId).ToNot(BeNil(), "subscriptionId should be assigned")
+
+		subscriptionID := *created.SubscriptionId
+
+		DeferCleanup(func() {
+			_ = inventoryClient.DeleteInventorySubscription(subscriptionID)
+		})
+
+		By("listing inventory subscriptions")
+
+		subscriptions, err := inventoryClient.ListInventorySubscriptions()
+		Expect(err).ToNot(HaveOccurred(), "Failed to list inventory subscriptions")
+
+		found := slices.ContainsFunc(subscriptions, func(subscription oranapi.InventorySubscription) bool {
+			return subscription.SubscriptionId != nil &&
+				*subscription.SubscriptionId == subscriptionID &&
+				subscription.ConsumerSubscriptionId != nil &&
+				*subscription.ConsumerSubscriptionId == consumerSubscriptionID
+		})
+		Expect(found).To(BeTrue(), "Created subscription should appear in the list")
+
+		By("retrieving the inventory subscription by ID")
+
+		retrieved, err := inventoryClient.GetInventorySubscription(subscriptionID)
+		Expect(err).ToNot(HaveOccurred(), "Failed to get inventory subscription")
+		Expect(*retrieved.SubscriptionId).To(Equal(subscriptionID),
+			"Retrieved subscription ID should match created subscription")
+		Expect(*retrieved.ConsumerSubscriptionId).To(Equal(consumerSubscriptionID),
+			"Retrieved consumer subscription ID should match created subscription")
+
+		By("deleting the inventory subscription")
+
+		err = inventoryClient.DeleteInventorySubscription(subscriptionID)
+		Expect(err).ToNot(HaveOccurred(), "Failed to delete inventory subscription")
+
+		By("verifying the deleted subscription returns 404")
+
+		_, err = inventoryClient.GetInventorySubscription(subscriptionID)
+		apiErr := oranapi.AsAPIError(err)
+		Expect(apiErr).ToNot(BeNil(), "Expected API error after deleting subscription")
+		Expect(apiErr.Status).To(Equal(http.StatusNotFound),
+			"Deleted subscription should return HTTP 404")
+	})
+
+	// 89901 - Receive inventory change notification from a subscription
+	It("receives inventory change notifications from a subscription", reportxml.ID("89901"), func() {
+		By("selecting a Ready OCloudSite for the temporary ResourcePool")
+
+		readySites, err := oran.ListReadyOCloudSites(HubAPIClient, client.InNamespace(tsparams.O2IMSNamespace))
+		Expect(err).ToNot(HaveOccurred(), "Failed to list Ready OCloudSite CRs")
+		Expect(readySites).ToNot(BeEmpty(), "At least one Ready OCloudSite is required")
+		parentSite := readySites[0]
+
+		By("creating an inventory subscription")
+
+		consumerSubscriptionID := uuid.New()
+		created, err := inventoryClient.CreateInventorySubscription(oranapi.InventorySubscription{
+			ConsumerSubscriptionId: &consumerSubscriptionID,
+			Callback:               mocksmo.ObserverCallbackURL(mockSMOBaseURL, consumerSubscriptionID.String()),
+		})
+		Expect(err).ToNot(HaveOccurred(), "Failed to create inventory subscription")
+		Expect(created.SubscriptionId).ToNot(BeNil(), "subscriptionId should be assigned")
+
+		subscriptionID := *created.SubscriptionId
+
+		DeferCleanup(func() {
+			_ = inventoryClient.DeleteInventorySubscription(subscriptionID)
+			_ = oran.NewResourcePoolBuilder(
+				HubAPIClient, tsparams.TestInventoryResourcePool, tsparams.O2IMSNamespace).Delete()
+		})
+
+		By("creating a temporary ResourcePool and waiting until Ready")
+
+		createTime := time.Now()
+		poolBuilder := oran.NewResourcePoolBuilder(
+			HubAPIClient, tsparams.TestInventoryResourcePool, tsparams.O2IMSNamespace).
+			WithOCloudSiteName(parentSite.Definition.Name).
+			WithDescription("temporary pool for inventory notification test")
+		poolBuilder, err = poolBuilder.Create()
+		Expect(err).ToNot(HaveOccurred(), "Failed to create temporary ResourcePool")
+
+		poolBuilder, err = poolBuilder.WaitForCondition(tsparams.InventoryReadyCondition, 2*time.Minute)
+		Expect(err).ToNot(HaveOccurred(), "Failed to wait for temporary ResourcePool to become Ready")
+
+		poolID := string(poolBuilder.Definition.UID)
+
+		By("waiting for a CREATE inventory notification")
+
+		err = mocksmo.WaitFor(HubAPIClient, RANConfig.MockSMONamespace,
+			mocksmo.WithStart[oranapi.InventoryChangeNotification](createTime),
+			mocksmo.WithObserverID[oranapi.InventoryChangeNotification](consumerSubscriptionID.String()),
+			mocksmo.WithTimeout[oranapi.InventoryChangeNotification](2*time.Minute),
+			mocksmo.WithMatch(func(notification *oranapi.InventoryChangeNotification) bool {
+				if notification.NotificationEventType != oranapi.InventoryChangeNotificationEventTypeCreate {
+					return false
+				}
+
+				if notification.ConsumerSubscriptionId == nil ||
+					*notification.ConsumerSubscriptionId != consumerSubscriptionID {
+					return false
+				}
+
+				return inventoryNotificationRefersToPool(notification, poolID)
+			}),
+		)
+		Expect(err).ToNot(HaveOccurred(), "Failed to receive CREATE inventory notification")
+
+		By("deleting the temporary ResourcePool")
+
+		deleteTime := time.Now()
+		err = poolBuilder.Delete()
+		Expect(err).ToNot(HaveOccurred(), "Failed to delete temporary ResourcePool")
+
+		By("waiting for a DELETE inventory notification")
+
+		err = mocksmo.WaitFor(HubAPIClient, RANConfig.MockSMONamespace,
+			mocksmo.WithStart[oranapi.InventoryChangeNotification](deleteTime),
+			mocksmo.WithObserverID[oranapi.InventoryChangeNotification](consumerSubscriptionID.String()),
+			mocksmo.WithTimeout[oranapi.InventoryChangeNotification](2*time.Minute),
+			mocksmo.WithMatch(func(notification *oranapi.InventoryChangeNotification) bool {
+				if notification.NotificationEventType != oranapi.InventoryChangeNotificationEventTypeDelete {
+					return false
+				}
+
+				return inventoryNotificationRefersToPool(notification, poolID)
+			}),
+		)
+		Expect(err).ToNot(HaveOccurred(), "Failed to receive DELETE inventory notification")
+	})
+
+	// 89902 - Filter inventory resources
+	It("filters inventory Locations", reportxml.ID("89902"), func() {
+		By("creating two test Location CRs")
+
+		alpha := createTestLocation(tsparams.TestLocationAlpha, "Alpha Site")
+		beta := createTestLocation(tsparams.TestLocationBeta, "Beta Site")
+
+		DeferCleanup(func() {
+			_ = alpha.Delete()
+			_ = beta.Delete()
+		})
+
+		By("waiting for both test Locations to appear in the inventory API")
+		waitForLocationInAPI(inventoryClient, tsparams.TestLocationAlpha)
+		waitForLocationInAPI(inventoryClient, tsparams.TestLocationBeta)
+
+		By("filtering for test-location-alpha")
+
+		alphaFilter := filter.Equals("name", tsparams.TestLocationAlpha)
+		alphaLocations, err := inventoryClient.ListLocations(oranapi.WithFilter(alphaFilter))
+		Expect(err).ToNot(HaveOccurred(), "Failed to filter Locations by name equals alpha")
+		Expect(alphaLocations).To(HaveLen(1),
+			"Filter name=%s should return exactly one Location", tsparams.TestLocationAlpha)
+		Expect(alphaLocations[0].Name).To(Equal(tsparams.TestLocationAlpha),
+			"Filtered Location name should match filter value")
+
+		By("filtering to exclude test-location-alpha")
+
+		neqFilter := filter.DoesNotEqual("name", tsparams.TestLocationAlpha)
+		neqLocations, err := inventoryClient.ListLocations(oranapi.WithFilter(neqFilter))
+		Expect(err).ToNot(HaveOccurred(), "Failed to filter Locations by name not-equals alpha")
+
+		containsAlpha := slices.ContainsFunc(neqLocations, func(location oranapi.LocationInfo) bool {
+			return location.Name == tsparams.TestLocationAlpha
+		})
+		containsBeta := slices.ContainsFunc(neqLocations, func(location oranapi.LocationInfo) bool {
+			return location.Name == tsparams.TestLocationBeta
+		})
+
+		Expect(containsAlpha).To(BeFalse(), "Filtered list should not include test-location-alpha")
+		Expect(containsBeta).To(BeTrue(), "Filtered list should include test-location-beta")
+
+		By("filtering for test-location-beta")
+
+		betaFilter := filter.Equals("name", tsparams.TestLocationBeta)
+		betaLocations, err := inventoryClient.ListLocations(oranapi.WithFilter(betaFilter))
+		Expect(err).ToNot(HaveOccurred(), "Failed to filter Locations by name equals beta")
+		Expect(betaLocations).To(HaveLen(1),
+			"Filter name=%s should return exactly one Location", tsparams.TestLocationBeta)
+		Expect(betaLocations[0].Name).To(Equal(tsparams.TestLocationBeta),
+			"Filtered Location name should match filter value")
+	})
+
+	// 89903 - Field selection and exclusion
+	It("supports field selection and exclusion", reportxml.ID("89903"), func() {
+		By("listing Resource Pools with fields=name")
+
+		poolsWithFields, err := inventoryClient.ListResourcePools(oranapi.WithFields(fields.Include("name")))
+		Expect(err).ToNot(HaveOccurred(), "Failed to list Resource Pools with fields=name")
+		Expect(poolsWithFields).ToNot(BeEmpty(), "At least one Resource Pool is required")
+
+		for _, pool := range poolsWithFields {
+			Expect(pool.ResourcePoolId).ToNot(Equal(uuid.Nil), "resourcePoolId is mandatory")
+			Expect(pool.Name).ToNot(BeEmpty(), "name is mandatory")
+			Expect(pool.OCloudSiteId).ToNot(Equal(uuid.Nil), "oCloudSiteId is mandatory")
+			Expect(pool.Extensions).To(BeNil(), "extensions should be absent when not selected")
+		}
+
+		By("listing Resource Pools with exclude_fields=extensions")
+
+		poolsWithoutExtensions, err := inventoryClient.ListResourcePools(
+			oranapi.WithFields(fields.Exclude("extensions")))
+		Expect(err).ToNot(HaveOccurred(), "Failed to list Resource Pools excluding extensions")
+		Expect(poolsWithoutExtensions).ToNot(BeEmpty(),
+			"At least one Resource Pool is required when excluding extensions")
+
+		for _, pool := range poolsWithoutExtensions {
+			Expect(pool.Extensions).To(BeNil(), "extensions should be absent when excluded")
+		}
+
+		By("listing Deployment Managers excluding complex attributes")
+
+		managersWithoutComplex, err := inventoryClient.ListDeploymentManagers(
+			oranapi.WithFields(fields.Exclude("extensions", "capacity", "capabilities")))
+		Expect(err).ToNot(HaveOccurred(), "Failed to list Deployment Managers excluding complex fields")
+		Expect(managersWithoutComplex).ToNot(BeEmpty(),
+			"At least one Deployment Manager is required when excluding complex fields")
+
+		for _, manager := range managersWithoutComplex {
+			Expect(manager.DeploymentManagerId).ToNot(Equal(uuid.Nil),
+				"deploymentManagerId is mandatory")
+			Expect(manager.Name).ToNot(BeEmpty(), "name is mandatory")
+			Expect(manager.Description).ToNot(BeEmpty(), "description is mandatory")
+			Expect(manager.OCloudId).ToNot(Equal(uuid.Nil), "oCloudId is mandatory")
+			Expect(manager.ServiceUri).ToNot(BeEmpty(), "serviceUri is mandatory")
+			Expect(manager.Extensions).To(BeNil(), "extensions should be absent")
+			Expect(manager.Capacity).To(BeNil(), "capacity should be absent")
+			Expect(manager.Capabilities).To(BeNil(), "capabilities should be absent")
+		}
+
+		By("listing Deployment Managers with all_fields=true")
+
+		managersWithAllFields, err := inventoryClient.ListDeploymentManagers(oranapi.WithFields(fields.All()))
+		Expect(err).ToNot(HaveOccurred(), "Failed to list Deployment Managers with all_fields")
+		Expect(managersWithAllFields).ToNot(BeEmpty(),
+			"At least one Deployment Manager is required with all_fields")
+
+		for _, manager := range managersWithAllFields {
+			Expect(manager.Extensions).ToNot(BeNil(), "extensions should be present with all_fields")
+			Expect(manager.Capacity).ToNot(BeNil(), "capacity should be present with all_fields")
+			Expect(manager.Capabilities).ToNot(BeNil(), "capabilities should be present with all_fields")
+		}
+	})
+
+	// 89904 - Retrieve a non-existent resource by ID
+	It("returns 404 for non-existent resources", reportxml.ID("89904"), func() {
+		nonexistentID := uuid.MustParse(tsparams.NonExistentUUID)
+
+		By("requesting a non-existent Resource Pool")
+
+		_, err := inventoryClient.GetResourcePool(nonexistentID)
+		apiErr := oranapi.AsAPIError(err)
+		Expect(apiErr).ToNot(BeNil(), "Expected API error when requesting non-existent Resource Pool")
+		Expect(apiErr.Status).To(Equal(http.StatusNotFound),
+			"Expected 404 when requesting non-existent Resource Pool")
+
+		By("requesting a non-existent Deployment Manager")
+
+		_, err = inventoryClient.GetDeploymentManager(nonexistentID)
+		apiErr = oranapi.AsAPIError(err)
+		Expect(apiErr).ToNot(BeNil(), "Expected API error when requesting non-existent Deployment Manager")
+		Expect(apiErr.Status).To(Equal(http.StatusNotFound),
+			"Expected 404 when requesting non-existent Deployment Manager")
+
+		By("requesting a non-existent Location")
+
+		_, err = inventoryClient.GetLocation("nonexistent-location-id")
+		apiErr = oranapi.AsAPIError(err)
+		Expect(apiErr).ToNot(BeNil(), "Expected API error when requesting non-existent Location")
+		Expect(apiErr.Status).To(Equal(http.StatusNotFound),
+			"Expected 404 when requesting non-existent Location")
+
+		By("listing Resources under a non-existent Resource Pool")
+
+		_, err = inventoryClient.ListResources(nonexistentID)
+		apiErr = oranapi.AsAPIError(err)
+		Expect(apiErr).ToNot(BeNil(), "Expected API error when listing Resources under non-existent Resource Pool")
+		Expect(apiErr.Status).To(Equal(http.StatusNotFound),
+			"Expected 404 when listing Resources under non-existent Resource Pool")
+	})
+
+	// 89905 - Create subscription with invalid callback
+	It("rejects subscriptions with invalid callbacks", reportxml.ID("89905"), func() {
+		consumerSubscriptionID := uuid.New()
+
+		By("attempting to create a subscription with an http callback")
+
+		_, err := inventoryClient.CreateInventorySubscription(oranapi.InventorySubscription{
+			ConsumerSubscriptionId: &consumerSubscriptionID,
+			Callback: "http://" + RANConfig.GetAppsURL(RANConfig.MockSMOSubdomain) +
+				"/mock_smo/v1/observers/" + consumerSubscriptionID.String(),
+		})
+		apiErr := oranapi.AsAPIError(err)
+		Expect(apiErr).ToNot(BeNil(), "Expected API error when creating subscription with http callback")
+		Expect(apiErr.Status).To(Equal(http.StatusBadRequest),
+			"Expected 400 when creating subscription with http callback")
+
+		By("attempting to create a subscription with a mismatched SMO hostname")
+
+		_, err = inventoryClient.CreateInventorySubscription(oranapi.InventorySubscription{
+			ConsumerSubscriptionId: new(uuid.New()),
+			Callback:               "https://invalid-smo.example.com/mock_smo/v1/observers/" + uuid.NewString(),
+		})
+		apiErr = oranapi.AsAPIError(err)
+		Expect(apiErr).ToNot(BeNil(), "Expected API error when creating subscription with mismatched SMO hostname")
+		Expect(apiErr.Status).To(Equal(http.StatusBadRequest),
+			"Expected 400 when creating subscription with mismatched SMO hostname")
+
+		By("attempting to create a subscription without a callback")
+
+		_, err = inventoryClient.CreateInventorySubscription(oranapi.InventorySubscription{
+			ConsumerSubscriptionId: new(uuid.New()),
+		})
+		apiErr = oranapi.AsAPIError(err)
+		Expect(apiErr).ToNot(BeNil(), "Expected API error when creating subscription without callback")
+		Expect(apiErr.Status).To(Equal(http.StatusBadRequest),
+			"Expected 400 when creating subscription without callback")
+	})
+
+	// 89906 - Request with invalid filter syntax
+	It("rejects invalid filter syntax", reportxml.ID("89906"), func() {
+		By("requesting Resource Pools with invalid filter syntax")
+
+		_, err := inventoryClient.ListResourcePools(oranapi.WithFilter(filter.Raw("invalid-syntax")))
+		apiErr := oranapi.AsAPIError(err)
+		Expect(apiErr).ToNot(BeNil(), "Expected API error when using invalid filter syntax")
+		Expect(apiErr.Status).To(Equal(http.StatusBadRequest),
+			"Expected 400 when using invalid filter syntax")
+
+		By("requesting Resource Pools with an invalid filter field")
+
+		_, err = inventoryClient.ListResourcePools(
+			oranapi.WithFilter(filter.Raw("(eq,nonexistentField,value)")))
+		apiErr = oranapi.AsAPIError(err)
+		Expect(apiErr).ToNot(BeNil(), "Expected API error when filtering on invalid field")
+		Expect(apiErr.Status).To(Equal(http.StatusBadRequest),
+			"Expected 400 when filtering on invalid field")
+	})
+
+	// 89907 - Unauthenticated API request
+	It("rejects unauthenticated API requests", reportxml.ID("89907"), func() {
+		By("creating an unauthenticated inventory API client")
+
+		clientBuilder, err := auth.NewUnauthenticatedClientBuilderForConfig(RANConfig)
+		Expect(err).ToNot(HaveOccurred(), "Failed to create unauthenticated O2IMS client builder")
+
+		unauthenticatedClient, err := clientBuilder.BuildInventory()
+		Expect(err).ToNot(HaveOccurred(), "Failed to create unauthenticated inventory client")
+
+		By("requesting Resource Pools without an Authorization header")
+
+		_, err = unauthenticatedClient.ListResourcePools()
+		apiErr := oranapi.AsAPIError(err)
+		Expect(apiErr).ToNot(BeNil(), "Expected API error for unauthenticated request")
+		Expect(apiErr.Status).To(Equal(http.StatusUnauthorized),
+			"Unauthenticated request should return HTTP 401")
+	})
+})
+
+func findResourcePoolWithInventoryBMHs() (*oran.ResourcePoolBuilder, []*bmh.BmhBuilder) {
+	GinkgoHelper()
+
+	readyPools, err := oran.ListReadyResourcePools(HubAPIClient, client.InNamespace(tsparams.O2IMSNamespace))
+	Expect(err).ToNot(HaveOccurred(), "Failed to list Ready ResourcePool CRs")
+
+	for _, pool := range readyPools {
+		eligible, err := bmh.ListInventoryEligibleBMH(HubAPIClient, client.ListOptions{
+			LabelSelector: labels.SelectorFromSet(labels.Set{
+				tsparams.ResourcePoolNameLabel: pool.Definition.Name,
+			}),
+		})
+		Expect(err).ToNot(HaveOccurred(),
+			"Failed to list inventory-eligible BMHs for ResourcePool %s", pool.Definition.Name)
+
+		if len(eligible) > 0 {
+			return pool, eligible
+		}
+	}
+
+	return nil, nil
+}
+
+type vendorModelPair struct {
+	vendor string
+	model  string
+}
+
+func collectExpectedResourceTypePairs() map[vendorModelPair]struct{} {
+	GinkgoHelper()
+
+	hosts, err := bmh.ListInventoryEligibleBMH(HubAPIClient)
+	Expect(err).ToNot(HaveOccurred(), "Failed to list inventory-eligible BareMetalHosts")
+
+	pairs := make(map[vendorModelPair]struct{})
+
+	for _, host := range hosts {
+		hwDataBuilder, err := bmh.PullHardwareData(HubAPIClient, host.Definition.Name, host.Definition.Namespace)
+		if err != nil || hwDataBuilder.Definition == nil || hwDataBuilder.Definition.Spec.HardwareDetails == nil {
+			continue
+		}
+
+		pair := vendorModelPair{
+			vendor: hwDataBuilder.Definition.Spec.HardwareDetails.SystemVendor.Manufacturer,
+			model:  hwDataBuilder.Definition.Spec.HardwareDetails.SystemVendor.ProductName,
+		}
+		pairs[pair] = struct{}{}
+	}
+
+	return pairs
+}
+
+func createTestLocation(name, address string) *oran.LocationBuilder {
+	GinkgoHelper()
+
+	location := oran.NewLocationBuilder(HubAPIClient, name, tsparams.O2IMSNamespace).
+		WithDescription(fmt.Sprintf("test location %s", name)).
+		WithAddress(address)
+
+	created, err := location.Create()
+	Expect(err).ToNot(HaveOccurred(), "Failed to create Location %s", name)
+
+	created, err = created.WaitForCondition(tsparams.InventoryReadyCondition, 2*time.Minute)
+	Expect(err).ToNot(HaveOccurred(), "Failed to wait for Location %s to become Ready", name)
+
+	return created
+}
+
+func waitForLocationInAPI(inventoryClient *oranapi.InventoryClient, name string) {
+	GinkgoHelper()
+
+	Eventually(func(g Gomega) {
+		locations, err := inventoryClient.ListLocations()
+		g.Expect(err).ToNot(HaveOccurred(), "Failed to list Locations while waiting for %s", name)
+		g.Expect(slices.IndexFunc(locations, func(loc oranapi.LocationInfo) bool {
+			return loc.GlobalLocationId == name
+		})).ToNot(Equal(-1), "Location %s not yet in API", name)
+	}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).
+		Should(Succeed(), "Timeout waiting for Location %s to appear in API", name)
+}
+
+func inventoryNotificationRefersToPool(
+	notification *oranapi.InventoryChangeNotification, poolID string) bool {
+	if notification.ObjectRef != nil && strings.Contains(*notification.ObjectRef, poolID) {
+		return true
+	}
+
+	if notification.PostObjectState != nil {
+		if value, ok := (*notification.PostObjectState)["resourcePoolId"]; ok && fmt.Sprint(value) == poolID {
+			return true
+		}
+
+		if value, ok := (*notification.PostObjectState)["name"]; ok &&
+			fmt.Sprint(value) == tsparams.TestInventoryResourcePool {
+			return true
+		}
+	}
+
+	if notification.PriorObjectState != nil {
+		if value, ok := (*notification.PriorObjectState)["resourcePoolId"]; ok && fmt.Sprint(value) == poolID {
+			return true
+		}
+
+		if value, ok := (*notification.PriorObjectState)["name"]; ok &&
+			fmt.Sprint(value) == tsparams.TestInventoryResourcePool {
+			return true
+		}
+	}
+
+	return false
+}

--- a/tests/cnf/ran/oran/tests/oran-inventory.go
+++ b/tests/cnf/ran/oran/tests/oran-inventory.go
@@ -442,6 +442,10 @@ var _ = Describe("ORAN Inventory API Tests", Label(tsparams.LabelPostProvision, 
 			_ = inventoryClient.DeleteInventorySubscription(subscriptionID)
 			_ = oran.NewResourcePoolBuilder(
 				HubAPIClient, tsparams.TestInventoryResourcePool, tsparams.O2IMSNamespace).Delete()
+
+			// ResourcePool deletion is asynchronous. Wait for both the Ready CR and the inventory API entry
+			// to disappear before the next spec starts.
+			waitForResourcePoolDeletion(inventoryClient, tsparams.TestInventoryResourcePool)
 		})
 
 		By("creating a temporary ResourcePool and waiting until Ready")
@@ -497,6 +501,11 @@ var _ = Describe("ORAN Inventory API Tests", Label(tsparams.LabelPostProvision, 
 					return false
 				}
 
+				if notification.ConsumerSubscriptionId == nil ||
+					*notification.ConsumerSubscriptionId != consumerSubscriptionID {
+					return false
+				}
+
 				return inventoryNotificationRefersToPool(notification, poolID)
 			}),
 		)
@@ -507,13 +516,8 @@ var _ = Describe("ORAN Inventory API Tests", Label(tsparams.LabelPostProvision, 
 	It("filters inventory Locations", reportxml.ID("89902"), func() {
 		By("creating two test Location CRs")
 
-		alpha := createTestLocation(tsparams.TestLocationAlpha, "Alpha Site")
-		beta := createTestLocation(tsparams.TestLocationBeta, "Beta Site")
-
-		DeferCleanup(func() {
-			_ = alpha.Delete()
-			_ = beta.Delete()
-		})
+		createTestLocation(inventoryClient, tsparams.TestLocationAlpha, "Alpha Site")
+		createTestLocation(inventoryClient, tsparams.TestLocationBeta, "Beta Site")
 
 		By("waiting for both test Locations to appear in the inventory API")
 		waitForLocationInAPI(inventoryClient, tsparams.TestLocationAlpha)
@@ -784,7 +788,7 @@ func collectExpectedResourceTypePairs() map[vendorModelPair]struct{} {
 	return pairs
 }
 
-func createTestLocation(name, address string) *oran.LocationBuilder {
+func createTestLocation(inventoryClient *oranapi.InventoryClient, name, address string) {
 	GinkgoHelper()
 
 	location := oran.NewLocationBuilder(HubAPIClient, name, tsparams.O2IMSNamespace).
@@ -794,10 +798,30 @@ func createTestLocation(name, address string) *oran.LocationBuilder {
 	created, err := location.Create()
 	Expect(err).ToNot(HaveOccurred(), "Failed to create Location %s", name)
 
-	created, err = created.WaitForCondition(tsparams.InventoryReadyCondition, 2*time.Minute)
-	Expect(err).ToNot(HaveOccurred(), "Failed to wait for Location %s to become Ready", name)
+	DeferCleanup(func() {
+		Expect(created.Delete()).To(Succeed(), "Failed to delete Location %s", name)
 
-	return created
+		// We wait for the Location to be deleted both from the Ready CRs and the inventory API. This ensures
+		// they cannot leak into other tests.
+		Eventually(func(gomega Gomega) {
+			readyLocations, err := oran.ListReadyLocations(HubAPIClient,
+				client.InNamespace(tsparams.O2IMSNamespace))
+			gomega.Expect(err).ToNot(HaveOccurred(), "Failed to list Ready Locations while waiting for %s deletion", name)
+			gomega.Expect(slices.IndexFunc(readyLocations, func(location *oran.LocationBuilder) bool {
+				return location.Definition.Name == name
+			})).To(Equal(-1), "Location %s still in Ready Location CR list", name)
+
+			apiLocations, err := inventoryClient.ListLocations()
+			gomega.Expect(err).ToNot(HaveOccurred(), "Failed to list Locations while waiting for %s deletion", name)
+			gomega.Expect(slices.IndexFunc(apiLocations, func(location oranapi.LocationInfo) bool {
+				return location.GlobalLocationId == name
+			})).To(Equal(-1), "Location %s still in inventory API", name)
+		}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).
+			Should(Succeed(), "Timeout waiting for Location %s to be deleted", name)
+	})
+
+	_, err = created.WaitForCondition(tsparams.InventoryReadyCondition, 2*time.Minute)
+	Expect(err).ToNot(HaveOccurred(), "Failed to wait for Location %s to become Ready", name)
 }
 
 func waitForLocationInAPI(inventoryClient *oranapi.InventoryClient, name string) {
@@ -811,6 +835,30 @@ func waitForLocationInAPI(inventoryClient *oranapi.InventoryClient, name string)
 		})).ToNot(Equal(-1), "Location %s not yet in API", name)
 	}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).
 		Should(Succeed(), "Timeout waiting for Location %s to appear in API", name)
+}
+
+func waitForResourcePoolDeletion(inventoryClient *oranapi.InventoryClient, name string) {
+	GinkgoHelper()
+
+	// Similar to the createTestLocation helper, we wait for the ResourcePool to be deleted both from the Ready CRs
+	// and the inventory API. This ensures they cannot leak into other tests.
+	Eventually(func(gomega Gomega) {
+		readyPools, err := oran.ListReadyResourcePools(HubAPIClient,
+			client.InNamespace(tsparams.O2IMSNamespace))
+		gomega.Expect(err).ToNot(HaveOccurred(),
+			"Failed to list Ready Resource Pools while waiting for %s deletion", name)
+		gomega.Expect(slices.IndexFunc(readyPools, func(pool *oran.ResourcePoolBuilder) bool {
+			return pool.Definition.Name == name
+		})).To(Equal(-1), "ResourcePool %s still in Ready ResourcePool CR list", name)
+
+		apiPools, err := inventoryClient.ListResourcePools()
+		gomega.Expect(err).ToNot(HaveOccurred(),
+			"Failed to list Resource Pools while waiting for %s deletion", name)
+		gomega.Expect(slices.IndexFunc(apiPools, func(pool oranapi.ResourcePool) bool {
+			return pool.Name == name
+		})).To(Equal(-1), "ResourcePool %s still in inventory API", name)
+	}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).
+		Should(Succeed(), "Timeout waiting for ResourcePool %s to be deleted", name)
 }
 
 func inventoryNotificationRefersToPool(

--- a/tests/internal/oran-mock-smo/observer_test.go
+++ b/tests/internal/oran-mock-smo/observer_test.go
@@ -43,6 +43,29 @@ func TestParseNotifications(t *testing.T) {
 	assert.Equal(t, "abc", notification.Extensions["tracker"])
 }
 
+func TestParseInventoryChangeNotifications(t *testing.T) {
+	t.Parallel()
+
+	logs := []byte(
+		`{"time":"2026-07-28T12:25:10.000000000Z","level":"INFO","msg":"Observer echo notification",` +
+			`"observerId":"sub-1","body":{"notificationEventType":0,"notificationId":` +
+			`"11111111-1111-1111-1111-111111111111","objectRef":"/resourcePools/abc",` +
+			`"postObjectState":{"name":"oran-test-inventory-pool"}}}` + "\n" +
+			`{"time":"2026-07-28T12:25:11.000000000Z","level":"INFO","msg":"Observer echo notification",` +
+			`"observerId":"sub-2","body":{"notificationEventType":2,"notificationId":` +
+			`"22222222-2222-2222-2222-222222222222","priorObjectState":{"name":"other"}}}` + "\n",
+	)
+
+	notifications, err := parseNotifications[oranapi.InventoryChangeNotification](logs, "sub-1")
+	require.NoError(t, err)
+	require.Len(t, notifications, 1)
+
+	notification := notifications[0]
+	assert.Equal(t, oranapi.InventoryChangeNotificationEventTypeCreate, notification.NotificationEventType)
+	require.NotNil(t, notification.ObjectRef)
+	assert.Equal(t, "/resourcePools/abc", *notification.ObjectRef)
+}
+
 func TestParseNotificationsFiltersByObserverID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This PR introduces the tests for the o2ims-infrstructureInventory API. It covers all the endpoints and has two main parts: the internal package which handles validation, matching the fields from the o2ims API with those from the Kubernetes API, and the test file.

The logic for deleting resources is made more complex by the need to verify they are gone in both the Kubernetes API and the o2ims API. Since the o2ims API lags behind the Kubernetes API, it's possible for flakes to occur if the next test picks up the o2ims resource but not the Kubernetes resource.

Tested: https://jenkins-csb-kniqe-auto.dno.corp.redhat.com/job/ocp-far-edge-vran-tests/1243/