### PR TITLE
cnf ran: add IBI preinstall end-to-end test suite

### DIFF
--- a/tests/cnf/ran/README.md
+++ b/tests/cnf/ran/README.md
@@ -21,6 +21,7 @@ Some test suites (ZTP, TALM) require clusters to be deployed via GitOps ZTP and 
 | [powermanagement](powermanagement/powermanagement_suite_test.go) | Tests powersave settings using workload hints       |
 | [talm](talm/talm_suite_test.go)                                  | Tests the topology aware lifecycle manager (TALM)   |
 | [gitopsztp](gitopsztp/ztp_suite_test.go)                         | Tests zero touch provisioning (ZTP) and Argo CD     |
+| [ibipreinstall](ibipreinstall/ibipreinstall_suite_test.go)       | Tests IBI (Image-Based Install) preinstall workflow |
 
 ### Internal pkgs
 
@@ -52,9 +53,13 @@ Currently, only the TALM tests need more than the first spoke kubeconfig.
 * `ECO_CNF_RAN_KUBECONFIG_HUB`: For tests that need a hub cluster, this is the path to its kubeconfig.
 * `ECO_CNF_RAN_KUBECONFIG_SPOKE2`: For tests that need a second spoke cluster, this is the path to its kubeconfig.
 
+#### TLS
+
+* `ECO_CNF_RAN_SKIP_TLS_VERIFY`: Skip TLS certificate verification for HTTP fetches (e.g., fetching config files from a remote server whose CA is not in the container trust store). Defaults to `false`.
+
 #### BMC credentials
 
-Only the powermanagement and TALM pre-cache tests need BMC credentials.
+The powermanagement, TALM pre-cache, and IBI preinstall tests need BMC credentials.
 
 * `ECO_CNF_RAN_BMC_USERNAME`: Username used for the Redfish API.
 * `ECO_CNF_RAN_BMC_PASSWORD`: Password used for the Redfish API.
@@ -105,6 +110,20 @@ These inputs are all specific to the PTP test suites and are optional.
 #### ACM inputs
 
 * `ECO_CNF_RAN_ACM_OPERATOR_NAMESPACE`: Namespace that the ACM operator uses.
+
+#### IBI preinstall inputs
+
+These inputs are specific to the IBI preinstall test suite. The suite performs an Image-Based Install on a bare-metal node by generating an IBI ISO, booting the node via a BareMetalHost CR, and monitoring the preinstall service to completion.
+
+* `ECO_CNF_RAN_IBI_SEED_IMAGE`: Seed image reference (e.g., `registry:5000/ibu/seed:4.22.8`). Required.
+* `ECO_CNF_RAN_IBI_SEED_VERSION`: Overrides the version tag parsed from `ECO_CNF_RAN_IBI_SEED_IMAGE`. Only needed when the seed reference is digest-pinned.
+* `ECO_CNF_RAN_IBI_CLUSTER_INSTANCE_URL`: Raw URL to the ClusterInstance YAML file. Used to extract BMH fields (hostname, BMC address, MAC, etc.). Required.
+* `ECO_CNF_RAN_IBI_CONFIG_TEMPLATE_URL`: Raw URL to the `image-based-installation-config.yaml` Go template. If unset, it is auto-derived from `ECO_CNF_RAN_IBI_CLUSTER_INSTANCE_URL` by looking for `preinstall-test/image-based-installation-config.yaml` in the same directory.
+* `ECO_CNF_RAN_IBI_PREINSTALL_REGISTRY`: Disconnected registry `host:port` used to resolve `{{.PreinstallRegistry}}` in the IBI config template. If unset, it is auto-derived from the MCE/ACM mirror configuration on the hub.
+* `ECO_CNF_RAN_IBI_OPENSHIFT_INSTALL`: Path to the `openshift-install` binary (mounted by CI). Required.
+* `ECO_CNF_RAN_IBI_PREINSTALL_HTTP_DIR`: Local directory that the HTTP server serves from. The generated ISO is copied here so the BMH can boot from it. In CI this is a volume mount from the host's HTTP serve directory. Required.
+* `ECO_CNF_RAN_IBI_PREINSTALL_HTTP_BASE_URL`: HTTP base URL that maps to `ECO_CNF_RAN_IBI_PREINSTALL_HTTP_DIR` (e.g., `http://host:8080/images`). Required.
+* `ECO_CNF_RAN_IBI_PREINSTALL_SSH_KEY`: Path to the SSH private key for connecting to the target node. Used for preinstall status monitoring and diagnostics collection. Required.
 
 #### O-RAN inputs
 
@@ -171,6 +190,23 @@ If using more selective labels that do not include TALM pre-cache, such as with 
 ```
 
 The ZTP generator test cannot be run in a container and thus has the `no-container` label. To run it, set `ECO_TEST_LABELS="ran-ztp && no-container"`.
+
+#### Running the IBI preinstall test suite
+
+```bash
+# export ECO_TEST_FEATURES=ibipreinstall
+# export ECO_CNF_RAN_KUBECONFIG_HUB=</path/to/hub/kubeconfig>
+# export ECO_CNF_RAN_BMC_USERNAME=<bmc username>
+# export ECO_CNF_RAN_BMC_PASSWORD=<bmc password>
+# export ECO_CNF_RAN_IBI_SEED_IMAGE=<registry:port/ibu/seed:version>
+# export ECO_CNF_RAN_IBI_CLUSTER_INSTANCE_URL=<url to ClusterInstance YAML>
+# export ECO_CNF_RAN_IBI_OPENSHIFT_INSTALL=</path/to/openshift-install>
+# export ECO_CNF_RAN_IBI_PREINSTALL_HTTP_DIR=</path/to/http/serve/dir>
+# export ECO_CNF_RAN_IBI_PREINSTALL_HTTP_BASE_URL=<http://host:port/path>
+# export ECO_CNF_RAN_IBI_PREINSTALL_SSH_KEY=</path/to/ssh/private/key>
+# export ECO_CNF_RAN_SKIP_TLS_VERIFY=true  # if the server CA is not in the container trust store
+# make run-tests
+```
 
 ### Additional Information
 

--- a/tests/cnf/ran/ibipreinstall/README.md
+++ b/tests/cnf/ran/ibipreinstall/README.md
@@ -1,0 +1,65 @@
+# IBI CNF RAN Preinstall
+
+End-to-end test for disconnected Image Based Install (IBI) preinstall workflow.
+
+## Overview
+
+This suite orchestrates the full preinstall lifecycle:
+1. Validates all data sources (env vars, hub API, remote YAML configs)
+2. Resolves a Go `text/template` from the config repo into `image-based-installation-config.yaml`
+3. Generates the IBI live installation ISO via pre-staged `openshift-install`
+4. Copies ISO to the local HTTP serving directory
+5. Creates BareMetalHost on the preinstall hub to boot the target
+6. Waits for the `install-rhcos-and-restore-seed` service to complete on the spoke
+
+## Template-Based Config Generation
+
+The `image-based-installation-config.yaml` is generated from a Go `text/template` file stored in
+the config repo (e.g., `siteconfig/helix54/preinstall-test/image-based-installation-config.yaml`).
+
+Placeholders like `{{.SeedImage}}`, `{{.PullSecret}}`, `{{.NetworkConfig}}`, etc. are resolved
+at runtime from hub cluster resources and environment variables. This keeps environment-specific
+values (disk paths, ignition overrides) in the config repo while secrets/mirrors are fetched live.
+
+## Environment Variables
+
+### Shared with other cnf/ran suites
+
+| Variable | Purpose |
+|----------|---------|
+| `ECO_CNF_RAN_KUBECONFIG_HUB` | Path to hub kubeconfig |
+| `ECO_CNF_RAN_BMC_USERNAME` | BMC username |
+| `ECO_CNF_RAN_BMC_PASSWORD` | BMC password |
+| `ECO_CNF_RAN_SKIP_TLS_VERIFY` | Skip TLS verification for HTTPS fetches (default: false) |
+
+### IBI preinstall specific
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `ECO_CNF_RAN_IBI_SEED_IMAGE` | Yes | Seed image reference |
+| `ECO_CNF_RAN_IBI_SEED_VERSION` | No | Explicit seed version override (needed if digest-pinned) |
+| `ECO_CNF_RAN_IBI_CLUSTER_INSTANCE_URL` | Yes | Raw URL to ClusterInstance YAML |
+| `ECO_CNF_RAN_IBI_CONFIG_TEMPLATE_URL` | No | Override URL for IBI config template (auto-derived from ClusterInstance URL) |
+| `ECO_CNF_RAN_IBI_PREINSTALL_REGISTRY` | No | Disconnected registry host:port (auto-derived from MCE mirror) |
+| `ECO_CNF_RAN_IBI_OPENSHIFT_INSTALL` | Yes | Path to `openshift-install` binary |
+| `ECO_CNF_RAN_IBI_PREINSTALL_HTTP_DIR` | Yes | Local directory served by the HTTP server |
+| `ECO_CNF_RAN_IBI_PREINSTALL_HTTP_BASE_URL` | Yes | HTTP URL mapping to the directory above |
+| `ECO_CNF_RAN_IBI_PREINSTALL_SSH_KEY` | Yes | Path to SSH private key (for spoke access) |
+
+## Constraints
+
+- Runs must be serialized per `PreinstallHTTPDir`. The published ISO uses a
+  fixed filename (`rhcos-ibi.iso`), so concurrent runs sharing the same HTTP
+  directory would overwrite each other.
+
+## Internal Hardcodes
+
+- SSH user for target node: `core`
+- Preinstall wait timeout: 60 minutes
+- ISO filename: `rhcos-ibi.iso`
+
+## Running
+
+```bash
+ginkgo --label-filter="preinstall-e2e" ./tests/cnf/ran/ibipreinstall/...
+```

--- a/tests/cnf/ran/ibipreinstall/ibipreinstall_suite_test.go
+++ b/tests/cnf/ran/ibipreinstall/ibipreinstall_suite_test.go
@@ -1,0 +1,61 @@
+package ibipreinstall_test
+
+import (
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ibipreinstall/internal/helpers"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ibipreinstall/internal/tsparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ibipreinstall/tests"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/reporter"
+)
+
+var _, currentFile, _, _ = runtime.Caller(0)
+
+// TestIBIPreinstall is the entry point for the IBI preinstall test suite.
+func TestIBIPreinstall(t *testing.T) {
+	if RANConfig == nil {
+		t.Fatal("Cannot run test suite when ran configuration failed to load")
+	}
+
+	_, reporterConfig := GinkgoConfiguration()
+	reporterConfig.JUnitReport = RANConfig.GetJunitReportPath(currentFile)
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "IBI Preinstall Suite", Label(tsparams.Labels...), reporterConfig)
+}
+
+var _ = BeforeSuite(func() {
+	By("Checking ran configuration")
+	Expect(RANConfig).ToNot(BeNil(), "Cannot run test suite when ran configuration failed to load")
+
+	By("Checking if hub cluster has valid apiClient")
+	Expect(HubAPIClient).ToNot(BeNil(),
+		"Cannot run test suite when hub cluster has nil api client (set ECO_CNF_RAN_KUBECONFIG_HUB)")
+
+	By("Checking mandatory IBI preinstall configuration")
+	Expect(RANConfig.IBIPreinstallConfig).ToNot(BeNil(),
+		"IBI preinstall config is nil")
+	Expect(RANConfig.IBIPreinstallConfig.ValidatePreinstallMandatory(
+		RANConfig.BMCUsername, RANConfig.BMCPassword)).To(Succeed(),
+		"IBI preinstall mandatory configuration incomplete")
+})
+
+var _ = ReportAfterSuite("", func(report Report) {
+	reportxml.Create(report, RANConfig.GetReportPath(), RANConfig.TCPrefix)
+})
+
+var _ = JustAfterEach(func() {
+	specReport := CurrentSpecReport()
+
+	reporter.ReportIfFailedOnCluster(
+		RANConfig.HubKubeconfig,
+		specReport, currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump)
+
+	helpers.CollectDiagnosticsIfFailed(
+		specReport, currentFile, tests.SpokeHostName, tests.WorkDir)
+})

--- a/tests/cnf/ran/ibipreinstall/internal/helpers/bmh_provisioning.go
+++ b/tests/cnf/ran/ibipreinstall/internal/helpers/bmh_provisioning.go
@@ -1,0 +1,200 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	bmhv1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/bmh"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/secret"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ibipreinstall/internal/tsparams"
+)
+
+// CreateBMCSecret creates a secret containing the BMC credentials.
+func CreateBMCSecret(apiClient *clients.Settings, name, namespace, username, password string) (*secret.Builder, error) {
+	klog.V(tsparams.LogLevel).Infof("Creating BMC secret %s in namespace %s", name, namespace)
+
+	secretBuilder := secret.NewBuilder(
+		apiClient, name, namespace, corev1.SecretTypeOpaque).WithData(map[string][]byte{
+		"username": []byte(username),
+		"password": []byte(password),
+	})
+
+	_, err := secretBuilder.Create()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create BMC secret: %w", err)
+	}
+
+	return secretBuilder, nil
+}
+
+// CreateBareMetalHost creates a BareMetalHost CR pointing to the IBI ISO.
+func CreateBareMetalHost(
+	apiClient *clients.Settings,
+	name, namespace, bmcAddress, macAddress, bmcSecretName, isoURL string) (*bmh.BmhBuilder, error) {
+	klog.V(tsparams.LogLevel).Infof("Creating BareMetalHost %s in namespace %s", name, namespace)
+
+	bmhBuilder := bmh.NewBuilder(
+		apiClient, name, namespace, bmcAddress, bmcSecretName, macAddress, "UEFI")
+
+	bmhBuilder.Definition.Spec.AutomatedCleaningMode = "disabled"
+
+	liveISO := "live-iso"
+
+	bmhBuilder.Definition.Spec.Image = &bmhv1alpha1.Image{
+		URL:        isoURL,
+		DiskFormat: &liveISO,
+	}
+
+	bmhBuilder.Definition.Spec.Online = true
+
+	if bmhBuilder.Definition.Annotations == nil {
+		bmhBuilder.Definition.Annotations = make(map[string]string)
+	}
+
+	bmhBuilder.Definition.Annotations["inspect.metal3.io"] = "disabled"
+
+	_, err := bmhBuilder.Create()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create BareMetalHost: %w", err)
+	}
+
+	return bmhBuilder, nil
+}
+
+// bmhProvisionedErrorThreshold controls how many times the BMH's own
+// ErrorCount must reach before we treat the error as permanent. Metal3
+// retries transient errors (Ironic busy, BMC hiccup) automatically and
+// increments ErrorCount each time; a low threshold risks false positives.
+const bmhProvisionedErrorThreshold = 3
+
+// WaitForBMHProvisioned polls the BareMetalHost until its provisioning state
+// reaches "provisioned". If the BMH enters an error state and its ErrorCount
+// reaches bmhProvisionedErrorThreshold, this function fails fast.
+func WaitForBMHProvisioned(
+	parentCtx context.Context,
+	apiClient *clients.Settings,
+	name, namespace string,
+	timeout, pollInterval time.Duration,
+) error {
+	klog.V(tsparams.LogLevel).Infof("Waiting for BMH %s/%s to reach provisioned state", namespace, name)
+
+	return wait.PollUntilContextTimeout(parentCtx, pollInterval, timeout, false, func(_ context.Context) (bool, error) {
+		bmhBuilder, err := bmh.Pull(apiClient, name, namespace)
+		if err != nil {
+			klog.V(tsparams.LogLevel).Infof("Could not pull BMH %s: %v (will retry)", name, err)
+
+			return false, nil
+		}
+
+		status := bmhBuilder.Object.Status
+		state := status.Provisioning.State
+		opStatus := status.OperationalStatus
+
+		klog.V(tsparams.LogLevel).Infof("BMH %s: state=%s operationalStatus=%s errorCount=%d",
+			name, state, opStatus, status.ErrorCount)
+
+		if state == bmhv1alpha1.StateProvisioned {
+			return true, nil
+		}
+
+		if opStatus == bmhv1alpha1.OperationalStatusError && status.ErrorCount >= bmhProvisionedErrorThreshold {
+			return false, fmt.Errorf(
+				"BMH %s in error state (errorCount=%d, errorType=%q): %s",
+				name, status.ErrorCount, status.ErrorType, status.ErrorMessage)
+		}
+
+		return false, nil
+	})
+}
+
+// sshFailureTimeout is the maximum duration SSH can remain unreachable.
+// This covers both the initial boot (where the node may take a while to
+// come up) and mid-run connectivity loss (node powered off/deprovisioned).
+const sshFailureTimeout = 15 * time.Minute
+
+// WaitForPreinstallCompletion polls the spoke node via SSH using
+// "systemctl is-active" for the preinstall service unit. It returns
+// success when the service reaches "active" (oneshot completed), fails
+// immediately on "failed" (with journal output), and treats any other
+// state as an unexpected error. If SSH remains unreachable for longer
+// than sshFailureTimeout, it fails early.
+func WaitForPreinstallCompletion(
+	parentCtx context.Context,
+	host, user, sshKeyPath string,
+	timeout, pollInterval time.Duration,
+) error {
+	klog.V(tsparams.LogLevel).Infof("Waiting for preinstall service to complete on %s", host)
+
+	startTime := time.Now()
+
+	var (
+		lastOutput      string
+		sshFailingSince *time.Time
+	)
+
+	err := wait.PollUntilContextTimeout(parentCtx, pollInterval, timeout, false, func(ctx context.Context) (bool, error) {
+		statusCmd := fmt.Sprintf("systemctl is-active %s 2>&1 || true", tsparams.PreinstallServiceUnit)
+
+		output, sshErr := SSHExec(ctx, host, user, sshKeyPath, statusCmd)
+		if sshErr != nil {
+			now := time.Now()
+			if sshFailingSince == nil {
+				sshFailingSince = &now
+			}
+
+			failDuration := now.Sub(*sshFailingSince)
+			klog.V(tsparams.LogLevel).Infof("SSH to %s unavailable for %v (timeout %v), waiting %v...",
+				host, failDuration.Round(time.Second), sshFailureTimeout, pollInterval)
+
+			if failDuration >= sshFailureTimeout {
+				return false, fmt.Errorf("SSH to %s unreachable for %v — node may have been powered off or deprovisioned",
+					host, failDuration.Round(time.Second))
+			}
+
+			return false, nil
+		}
+
+		sshFailingSince = nil
+
+		unitStatus := strings.TrimSpace(output)
+		klog.V(tsparams.LogLevel).Infof("%s on %s: %s", tsparams.PreinstallServiceUnit, host, unitStatus)
+
+		switch unitStatus {
+		case "activating", "inactive", "unknown", "deactivating", "reloading", "":
+			lastOutput = unitStatus
+
+			return false, nil
+
+		case "active":
+			klog.V(tsparams.LogLevel).Infof("Preinstall service completed on %s", host)
+
+			return true, nil
+
+		case "failed":
+			journalCmd := fmt.Sprintf("journalctl -u %s --no-pager -n 50 2>&1", tsparams.PreinstallServiceUnit)
+			journalOut, _ := SSHExec(ctx, host, user, sshKeyPath, journalCmd)
+			lastOutput = journalOut
+
+			return false, fmt.Errorf("preinstall service failed on %s:\n%s", host, journalOut)
+
+		default:
+			lastOutput = unitStatus
+
+			return false, fmt.Errorf("unexpected service state %q on %s", unitStatus, host)
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("waiting for preinstall on %s (started %v, timeout %v): output=%q: %w",
+			host, startTime.Format(time.RFC3339), timeout, lastOutput, err)
+	}
+
+	return nil
+}

--- a/tests/cnf/ran/ibipreinstall/internal/helpers/cluster_instance.go
+++ b/tests/cnf/ran/ibipreinstall/internal/helpers/cluster_instance.go
@@ -1,0 +1,135 @@
+package helpers
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	siteconfigv1alpha1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/siteconfig/v1alpha1"
+	yamlv3 "gopkg.in/yaml.v3"
+)
+
+// yamlDocSeparator matches only lines that are valid YAML document markers.
+var yamlDocSeparator = regexp.MustCompile(`(?m)^---[ \t]*(#.*)?\r?$`)
+
+// ClusterInstanceInstallInput holds node fields extracted from a ClusterInstance
+// that are needed for BMH provisioning and IBI config generation.
+type ClusterInstanceInstallInput struct {
+	ClusterName    string
+	HostName       string
+	BMCAddress     string
+	BootMACAddress string
+
+	// NetworkConfig is the raw NMState YAML from nodeNetwork.config,
+	// converted to a YAML string for the IBI config template.
+	// Empty if nodeNetwork is not specified (host uses DHCP).
+	NetworkConfig string
+}
+
+// PreinstallBMHName returns the BareMetalHost name for the preinstall workflow,
+// derived from the node's FQDN.
+func (c *ClusterInstanceInstallInput) PreinstallBMHName() string {
+	return c.HostName + "-preinstall"
+}
+
+// PreinstallBMCSecretName returns the BMC secret name for the preinstall workflow.
+func (c *ClusterInstanceInstallInput) PreinstallBMCSecretName() string {
+	return c.ClusterName + "-preinstall-bmc-secret"
+}
+
+// ParseClusterInstance parses YAML (single or multi-doc) and returns the ClusterInstance CR.
+func ParseClusterInstance(yamlData []byte) (*siteconfigv1alpha1.ClusterInstance, error) {
+	docs := yamlDocSeparator.Split(string(yamlData), -1)
+
+	var lastUnmarshalErr error
+
+	for _, doc := range docs {
+		if strings.TrimSpace(doc) == "" {
+			continue
+		}
+
+		var clusterInst siteconfigv1alpha1.ClusterInstance
+
+		err := unmarshalYAML([]byte(doc), &clusterInst)
+		if err != nil {
+			lastUnmarshalErr = err
+
+			continue
+		}
+
+		if clusterInst.Kind == "ClusterInstance" {
+			return &clusterInst, nil
+		}
+	}
+
+	if lastUnmarshalErr != nil {
+		return nil, fmt.Errorf("ClusterInstance not found in YAML data (last unmarshal error: %w)", lastUnmarshalErr)
+	}
+
+	return nil, fmt.Errorf("ClusterInstance not found in YAML data")
+}
+
+// ClusterInstanceInstallInputFrom extracts BMH-related fields from the first node
+// of a ClusterInstance. The image-based-installation-config fields (networkConfig,
+// installationDisk, etc.) are now managed in the config template, not extracted here.
+func ClusterInstanceInstallInputFrom(
+	clusterInst *siteconfigv1alpha1.ClusterInstance,
+) (*ClusterInstanceInstallInput, error) {
+	if clusterInst == nil {
+		return nil, fmt.Errorf("clusterinstance: nil")
+	}
+
+	nodes := clusterInst.Spec.Nodes
+	if len(nodes) == 0 {
+		return nil, fmt.Errorf("clusterinstance: spec.nodes empty")
+	}
+
+	node := &nodes[0]
+
+	if node.HostName == "" {
+		return nil, fmt.Errorf("clusterinstance: nodes[0].hostName missing or empty")
+	}
+
+	if node.BmcAddress == "" {
+		return nil, fmt.Errorf("clusterinstance: nodes[0].bmcAddress missing or empty")
+	}
+
+	if node.BootMACAddress == "" {
+		return nil, fmt.Errorf("clusterinstance: nodes[0].bootMACAddress missing or empty")
+	}
+
+	clusterName := clusterInst.Spec.ClusterName
+	if clusterName == "" {
+		return nil, fmt.Errorf("clusterinstance: spec.clusterName missing or empty")
+	}
+
+	input := &ClusterInstanceInstallInput{
+		ClusterName:    clusterName,
+		HostName:       node.HostName,
+		BMCAddress:     node.BmcAddress,
+		BootMACAddress: node.BootMACAddress,
+	}
+
+	if node.NodeNetwork != nil && len(node.NodeNetwork.NetConfig.Raw) > 0 {
+		input.NetworkConfig = string(node.NodeNetwork.NetConfig.Raw)
+	}
+
+	return input, nil
+}
+
+// unmarshalYAML decodes YAML into a Go struct that uses json struct tags
+// (standard for Kubernetes API types). It converts YAML→intermediate→JSON→struct.
+func unmarshalYAML(yamlData []byte, out interface{}) error {
+	var intermediate interface{}
+	if err := yamlv3.Unmarshal(yamlData, &intermediate); err != nil {
+		return err
+	}
+
+	jsonBytes, err := json.Marshal(intermediate)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(jsonBytes, out)
+}

--- a/tests/cnf/ran/ibipreinstall/internal/helpers/failure_diagnostics.go
+++ b/tests/cnf/ran/ibipreinstall/internal/helpers/failure_diagnostics.go
@@ -1,0 +1,123 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/onsi/ginkgo/v2/types"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ibipreinstall/internal/tsparams"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
+	"k8s.io/klog/v2"
+)
+
+const diagnosticsSSHTimeout = 5 * time.Minute
+
+// spokeJournalUnits lists the systemd units whose full journals are collected
+// from the spoke node on test failure.
+var spokeJournalUnits = []string{
+	tsparams.PreinstallServiceUnit,
+	"precache.service",
+	"set-ip-address.service",
+}
+
+// CollectDiagnosticsIfFailed collects IBI preinstall diagnostics when a test
+// fails. Hub-side cluster resources (IDMS, pods, events) are collected by the
+// k8sreporter via ReportIfFailed. This function adds spoke-specific artifacts
+// that the reporter cannot reach: systemd journals, dmesg, and the IBI config.
+func CollectDiagnosticsIfFailed(
+	report types.SpecReport,
+	testSuite string,
+	spokeHost, workDir string,
+) {
+	if !report.State.Is(types.SpecStateFailureStates) {
+		return
+	}
+
+	dumpDir := RANConfig.GetDumpFailedTestReportLocation(testSuite)
+	if dumpDir == "" {
+		klog.V(tsparams.LogLevel).Info("No dump directory configured, skipping IBI diagnostics")
+
+		return
+	}
+
+	diagDir := filepath.Join(dumpDir, "ibi-preinstall-diagnostics")
+	if err := os.MkdirAll(diagDir, 0o755); err != nil {
+		klog.V(tsparams.LogLevel).Infof("Failed to create diagnostics dir %s: %v", diagDir, err)
+
+		return
+	}
+
+	if spokeHost != "" {
+		sshKeyPath := RANConfig.IBIPreinstallConfig.PreinstallSSHKey
+		collectSpokeJournals(spokeHost, tsparams.TargetNodeSSHUser, sshKeyPath, diagDir)
+	}
+
+	if workDir != "" {
+		preserveArtifact(filepath.Join(workDir, ".openshift_install.log"), diagDir)
+		preserveArtifact(filepath.Join(workDir, RedactedIBIConfigFilename), diagDir)
+	}
+}
+
+// collectSpokeJournals retrieves systemd journal logs and dmesg from the spoke node via SSH.
+func collectSpokeJournals(host, user, sshKeyPath, destDir string) {
+	ctx, cancel := context.WithTimeout(context.TODO(), diagnosticsSSHTimeout)
+	defer cancel()
+
+	for _, unit := range spokeJournalUnits {
+		cmd := fmt.Sprintf("journalctl -u %s --no-pager 2>&1 || true", unit)
+
+		output, err := SSHExec(ctx, host, user, sshKeyPath, cmd)
+		if err != nil {
+			klog.V(tsparams.LogLevel).Infof(
+				"Could not collect journal for %s from %s: %v", unit, host, err)
+
+			continue
+		}
+
+		dest := filepath.Join(destDir, "spoke_journal_"+unit+".log")
+		if writeErr := os.WriteFile(dest, []byte(output), 0o644); writeErr != nil {
+			klog.V(tsparams.LogLevel).Infof("Failed to write journal to %s: %v", dest, writeErr)
+		}
+	}
+
+	output, err := SSHExec(ctx, host, user, sshKeyPath, "dmesg --time-format iso 2>&1 | tail -500 || true")
+	if err != nil {
+		klog.V(tsparams.LogLevel).Infof("Could not collect dmesg from %s: %v", host, err)
+	} else {
+		dest := filepath.Join(destDir, "spoke_dmesg.log")
+		if writeErr := os.WriteFile(dest, []byte(output), 0o644); writeErr != nil {
+			klog.V(tsparams.LogLevel).Infof("Failed to write dmesg to %s: %v", dest, writeErr)
+		}
+	}
+}
+
+// preserveArtifact copies a single file from srcPath into destDir for post-failure inspection.
+func preserveArtifact(srcPath, destDir string) {
+	src, err := os.Open(srcPath)
+	if err != nil {
+		klog.V(tsparams.LogLevel).Infof("Artifact %s not available: %v", srcPath, err)
+
+		return
+	}
+
+	defer src.Close()
+
+	destPath := filepath.Join(destDir, filepath.Base(srcPath))
+
+	dst, err := os.Create(destPath)
+	if err != nil {
+		klog.V(tsparams.LogLevel).Infof("Failed to create %s: %v", destPath, err)
+
+		return
+	}
+
+	defer dst.Close()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		klog.V(tsparams.LogLevel).Infof("Failed to copy artifact to %s: %v", destPath, err)
+	}
+}

--- a/tests/cnf/ran/ibipreinstall/internal/helpers/hub_resources.go
+++ b/tests/cnf/ran/ibipreinstall/internal/helpers/hub_resources.go
@@ -1,0 +1,179 @@
+package helpers
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/configmap"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/idms"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/mco"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/secret"
+	"k8s.io/klog/v2"
+
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ibipreinstall/internal/tsparams"
+)
+
+// GetPullSecretFromHub retrieves the pull secret from the hub cluster.
+func GetPullSecretFromHub(apiClient *clients.Settings) (string, error) {
+	klog.V(tsparams.LogLevel).Infof("Fetching pull secret from hub cluster")
+
+	secretBuilder, err := secret.Pull(apiClient, "pull-secret", "openshift-config")
+	if err != nil {
+		return "", fmt.Errorf("failed to pull secret: %w", err)
+	}
+
+	dockerConfigJSON, ok := secretBuilder.Object.Data[".dockerconfigjson"]
+	if !ok {
+		return "", fmt.Errorf(".dockerconfigjson key not found in pull-secret")
+	}
+
+	var pullSecretJSON any
+
+	err = json.Unmarshal(dockerConfigJSON, &pullSecretJSON)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal pull secret JSON: %w", err)
+	}
+
+	compactJSON, err := json.Marshal(pullSecretJSON)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal pull secret: %w", err)
+	}
+
+	klog.V(tsparams.LogLevel).Infof("Successfully retrieved pull secret from hub cluster")
+
+	return string(compactJSON), nil
+}
+
+// GetSSHKeyFromHub retrieves the SSH public key from the hub cluster via MachineConfig 99-master-ssh.
+func GetSSHKeyFromHub(apiClient *clients.Settings) (string, error) {
+	klog.V(tsparams.LogLevel).Infof("Fetching SSH key from hub cluster")
+
+	mcBuilder, err := mco.PullMachineConfig(apiClient, "99-master-ssh")
+	if err != nil {
+		return "", fmt.Errorf("failed to pull MachineConfig 99-master-ssh: %w", err)
+	}
+
+	if mcBuilder == nil || mcBuilder.Object == nil {
+		return "", fmt.Errorf("MachineConfig 99-master-ssh not found")
+	}
+
+	raw := mcBuilder.Object.Spec.Config.Raw
+	if len(raw) == 0 {
+		return "", fmt.Errorf("MachineConfig 99-master-ssh has missing Spec.Config.Raw")
+	}
+
+	var configData map[string]any
+
+	err = json.Unmarshal(raw, &configData)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal MachineConfig config: %w", err)
+	}
+
+	passwd, okPasswd := configData["passwd"].(map[string]any)
+	if !okPasswd {
+		return "", fmt.Errorf("failed to extract passwd from MachineConfig config")
+	}
+
+	users, okUsers := passwd["users"].([]any)
+	if !okUsers || len(users) == 0 {
+		return "", fmt.Errorf("failed to extract users from MachineConfig passwd")
+	}
+
+	firstUser, okUser := users[0].(map[string]any)
+	if !okUser {
+		return "", fmt.Errorf("failed to extract first user from MachineConfig users")
+	}
+
+	sshKeys, okKeys := firstUser["sshAuthorizedKeys"].([]any)
+	if !okKeys || len(sshKeys) == 0 {
+		return "", fmt.Errorf("failed to extract sshAuthorizedKeys from MachineConfig user")
+	}
+
+	sshKey, okKey := sshKeys[0].(string)
+	if !okKey {
+		return "", fmt.Errorf("failed to extract SSH key string")
+	}
+
+	klog.V(tsparams.LogLevel).Infof("Successfully retrieved SSH key from hub cluster")
+
+	return sshKey, nil
+}
+
+// GetCACertFromHub retrieves the CA certificate bundle from the hub cluster.
+func GetCACertFromHub(apiClient *clients.Settings) (string, error) {
+	klog.V(tsparams.LogLevel).Infof("Fetching CA certificate from hub cluster")
+
+	cmBuilder, err := configmap.Pull(apiClient, "user-ca-bundle", "openshift-config")
+	if err != nil {
+		return "", fmt.Errorf("failed to pull configmap: %w", err)
+	}
+
+	caCert, ok := cmBuilder.Object.Data["ca-bundle.crt"]
+	if !ok {
+		return "", fmt.Errorf("ca-bundle.crt key not found in user-ca-bundle configmap")
+	}
+
+	klog.V(tsparams.LogLevel).Infof("Successfully retrieved CA certificate from hub cluster")
+
+	return caCert, nil
+}
+
+const (
+	mceSourcePrefix = "registry.redhat.io/multicluster-engine"
+	acmSourcePrefix = "registry.redhat.io/rhacm2"
+)
+
+// matchesSourcePrefix returns true if source equals prefix or starts with prefix + "/".
+func matchesSourcePrefix(source, prefix string) bool {
+	return source == prefix || strings.HasPrefix(source, prefix+"/")
+}
+
+// MCEACMMirrors holds the mirror locations for MCE and ACM discovered from hub IDMS.
+type MCEACMMirrors struct {
+	MCE string
+	ACM string
+}
+
+// DiscoverMCEACMMirrorsFromHub queries the hub's IDMS resources to find
+// the mirror locations for multicluster-engine and rhacm2 images.
+func DiscoverMCEACMMirrorsFromHub(apiClient *clients.Settings) (*MCEACMMirrors, error) {
+	if apiClient == nil {
+		return nil, fmt.Errorf("hub api client is nil")
+	}
+
+	idmsBuilders, err := idms.ListImageDigestMirrorSets(apiClient)
+	if err != nil {
+		return nil, fmt.Errorf("list IDMS from hub: %w", err)
+	}
+
+	mirrors := &MCEACMMirrors{}
+
+	for _, builder := range idmsBuilders {
+		for _, idm := range builder.Object.Spec.ImageDigestMirrors {
+			if len(idm.Mirrors) == 0 {
+				continue
+			}
+
+			if matchesSourcePrefix(idm.Source, mceSourcePrefix) && mirrors.MCE == "" {
+				mirrors.MCE = string(idm.Mirrors[0])
+			}
+
+			if matchesSourcePrefix(idm.Source, acmSourcePrefix) && mirrors.ACM == "" {
+				mirrors.ACM = string(idm.Mirrors[0])
+			}
+		}
+	}
+
+	if mirrors.MCE == "" || mirrors.ACM == "" {
+		return nil, fmt.Errorf(
+			"MCE/ACM mirror locations not found in hub IDMS (mce=%q, acm=%q); "+
+				"ensure hub has IDMS entries for %s and %s",
+			mirrors.MCE, mirrors.ACM, mceSourcePrefix, acmSourcePrefix)
+	}
+
+	klog.V(tsparams.LogLevel).Infof("Discovered MCE/ACM mirrors from hub: MCE=%s, ACM=%s", mirrors.MCE, mirrors.ACM)
+
+	return mirrors, nil
+}

--- a/tests/cnf/ran/ibipreinstall/internal/helpers/ibi_config.go
+++ b/tests/cnf/ran/ibipreinstall/internal/helpers/ibi_config.go
@@ -1,0 +1,346 @@
+package helpers
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+	"text/template"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ibipreinstall/internal/tsparams"
+)
+
+const httpFetchTimeout = 30 * time.Second
+
+// IBIConfigTemplateData holds the values resolved at runtime to fill the
+// image-based-installation-config.yaml template stored in the config repo.
+type IBIConfigTemplateData struct {
+	SeedImage          string
+	SeedVersion        string
+	PullSecret         string
+	SSHKey             string
+	CACert             string
+	NetworkConfig      string
+	PreinstallRegistry string
+	MCEMirror          string
+	ACMMirror          string
+}
+
+// ResolveIBIConfigTemplate fetches the template from templateURL, executes it
+// with the provided data, and writes the result as image-based-installation-config.yaml
+// in workDir (the directory openshift-install reads from).
+func ResolveIBIConfigTemplate(templateURL string, data *IBIConfigTemplateData, workDir string, skipTLS bool) error {
+	klog.V(tsparams.LogLevel).Infof("Fetching IBI config template from %s", templateURL)
+
+	raw, err := FetchYAMLFromURL(templateURL, skipTLS)
+	if err != nil {
+		return fmt.Errorf("fetch IBI config template: %w", err)
+	}
+
+	data.CACert = indentBlock(data.CACert, 2)
+	data.NetworkConfig = indentBlock(data.NetworkConfig, 2)
+
+	tmpl, err := template.New("ibi-config").Option("missingkey=error").Parse(string(raw))
+	if err != nil {
+		return fmt.Errorf("parse IBI config template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return fmt.Errorf("execute IBI config template: %w", err)
+	}
+
+	outPath := filepath.Join(workDir, "image-based-installation-config.yaml")
+	if err := os.WriteFile(outPath, buf.Bytes(), 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", outPath, err)
+	}
+
+	klog.V(tsparams.LogLevel).Infof("Wrote resolved IBI config to %s (%d bytes)", outPath, buf.Len())
+
+	saveRedactedCopy(tmpl, data, workDir)
+
+	return nil
+}
+
+// ResolveIBIConfigTemplateURL returns the explicit override URL if set, otherwise
+// derives it from the ClusterInstance URL using the convention:
+//
+//	<same dir>/preinstall-test/image-based-installation-config.yaml
+//
+// Example:
+//
+//	ClusterInstance: https://gitlab.example.com/.../siteconfig/helix54/helix54.yaml
+//	Derives: <same base>/.../preinstall-test/image-based-installation-config.yaml
+func ResolveIBIConfigTemplateURL(explicitURL, clusterInstanceURL string) (string, error) {
+	if strings.TrimSpace(explicitURL) != "" {
+		return explicitURL, nil
+	}
+
+	parsed, err := url.Parse(clusterInstanceURL)
+	if err != nil {
+		return "", fmt.Errorf("parse ClusterInstance URL %q: %w", clusterInstanceURL, err)
+	}
+
+	dir := path.Dir(parsed.Path)
+	parsed.Path = path.Join(dir, "preinstall-test", "image-based-installation-config.yaml")
+
+	result := parsed.String()
+	klog.V(tsparams.LogLevel).Infof("Derived IBI config template URL: %s", result)
+
+	return result, nil
+}
+
+// ResolveSeedVersion determines the seed version from explicit override or seed image tag.
+// Priority: explicit override > tag parsed from seedImage reference.
+// Returns an error if the version cannot be determined (e.g., digest-pinned without override).
+func ResolveSeedVersion(explicitOverride, seedImage string) (string, error) {
+	if v := strings.TrimSpace(explicitOverride); v != "" {
+		return v, nil
+	}
+
+	tag := tagFromImageRef(seedImage)
+	if tag == "" {
+		return "", fmt.Errorf(
+			"cannot derive seedVersion: image %q has no tag (digest-pinned?); "+
+				"set ECO_CNF_RAN_IBI_SEED_VERSION explicitly", seedImage)
+	}
+
+	return tag, nil
+}
+
+// RegistryHostFromMirror extracts the host:port portion from a mirror URL like
+// "registry.example.com:5000/multicluster-engine". Returns everything before the
+// first "/" path component, or an error if the mirror string is empty.
+func RegistryHostFromMirror(mirror string) (string, error) {
+	if mirror == "" {
+		return "", fmt.Errorf("cannot derive registry host from empty mirror")
+	}
+
+	if idx := strings.Index(mirror, "/"); idx > 0 {
+		return mirror[:idx], nil
+	}
+
+	return mirror, nil
+}
+
+// CopyISOToHTTPDir copies the ISO file to the local HTTP serving directory so the
+// BMH can download it via PreinstallHTTPBaseURL. This replaces the previous SCP-based
+// approach and works because the test executor is co-located with the HTTP server.
+func CopyISOToHTTPDir(isoPath, httpDir string) error {
+	destPath := filepath.Join(httpDir, filepath.Base(isoPath))
+	tmpPath := destPath + ".tmp"
+
+	klog.V(tsparams.LogLevel).Infof("Copying ISO %s -> %s", isoPath, destPath)
+
+	src, err := os.Open(isoPath)
+	if err != nil {
+		return fmt.Errorf("open ISO %s: %w", isoPath, err)
+	}
+	defer src.Close()
+
+	dst, err := os.Create(tmpPath)
+	if err != nil {
+		return fmt.Errorf("create destination %s: %w", tmpPath, err)
+	}
+
+	if _, err := io.Copy(dst, src); err != nil {
+		dst.Close()
+
+		return fmt.Errorf("copy ISO to %s: %w", tmpPath, err)
+	}
+
+	if err := dst.Close(); err != nil {
+		return fmt.Errorf("close destination %s: %w", tmpPath, err)
+	}
+
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		return fmt.Errorf("rename %s -> %s: %w", tmpPath, destPath, err)
+	}
+
+	klog.V(tsparams.LogLevel).Infof("Successfully copied ISO to HTTP directory")
+
+	return nil
+}
+
+// CreateIBIISO runs openshift-install to create the image-based installation ISO.
+func CreateIBIISO(ctx context.Context, openshiftInstallPath, workDir, isoFilename string) (string, error) {
+	klog.V(tsparams.LogLevel).Infof("Creating IBI ISO using %s in %s", openshiftInstallPath, workDir)
+
+	cmd := exec.CommandContext(ctx, openshiftInstallPath, "image-based", "create", "image", "--dir", workDir)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		const maxOutputLen = 2000
+
+		sanitized := string(output)
+		if len(sanitized) > maxOutputLen {
+			sanitized = sanitized[:maxOutputLen] + "... (truncated)"
+		}
+
+		return "", fmt.Errorf("failed to create IBI ISO: %w, output: %s", err, sanitized)
+	}
+
+	isoPath := filepath.Join(workDir, isoFilename)
+
+	if _, statErr := os.Stat(isoPath); statErr != nil {
+		return "", fmt.Errorf("ISO output path %s: %w", isoPath, statErr)
+	}
+
+	klog.V(tsparams.LogLevel).Infof("Successfully created IBI ISO at %s", isoPath)
+
+	return isoPath, nil
+}
+
+// VerifyNmstatectlAvailable checks that nmstatectl is in $PATH. openshift-install
+// requires it at runtime when networkConfig is specified in the IBI config.
+func VerifyNmstatectlAvailable() error {
+	nmstatePath, err := exec.LookPath("nmstatectl")
+	if err != nil {
+		return fmt.Errorf("nmstatectl not found in $PATH: %w — "+
+			"install nmstate (dnf install -y nmstate) or remove networkConfig from the IBI config template", err)
+	}
+
+	klog.V(tsparams.LogLevel).Infof("nmstatectl found at %s", nmstatePath)
+
+	return nil
+}
+
+// FetchYAMLFromURL fetches raw YAML content from a URL. When skipTLS is true,
+// TLS certificate verification is skipped.
+func FetchYAMLFromURL(rawURL string, skipTLS bool) ([]byte, error) {
+	klog.V(tsparams.LogLevel).Infof("Fetching YAML from %s (skipTLS=%v)", rawURL, skipTLS)
+
+	client := httpClient(skipTLS)
+
+	resp, err := client.Get(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP fetch %s: %w", rawURL, err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP fetch %s: status %d", rawURL, resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response from %s: %w", rawURL, err)
+	}
+
+	return data, nil
+}
+
+// VerifyHTTPAccessible sends a HEAD request to the given URL and returns an error
+// if the server does not respond with HTTP 200. Use this to confirm that an artifact
+// (e.g., the IBI ISO) is reachable before handing the URL to an external consumer
+// like a BareMetalHost.
+func VerifyHTTPAccessible(rawURL string) error {
+	client := &http.Client{Timeout: httpFetchTimeout}
+
+	resp, err := client.Head(rawURL)
+	if err != nil {
+		return fmt.Errorf("HEAD %s: %w", rawURL, err)
+	}
+
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HEAD %s: expected 200, got %d", rawURL, resp.StatusCode)
+	}
+
+	klog.V(tsparams.LogLevel).Infof("Verified HTTP accessible: %s (%d)", rawURL, resp.StatusCode)
+
+	return nil
+}
+
+// httpClient returns an HTTP client, optionally configured to skip TLS verification.
+func httpClient(skipTLS bool) *http.Client {
+	client := &http.Client{Timeout: httpFetchTimeout}
+
+	if skipTLS {
+		client.Transport = &http.Transport{
+			//nolint:gosec // user-requested via ECO_CNF_RAN_SKIP_TLS_VERIFY
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+				MinVersion:         tls.VersionTLS12,
+			},
+		}
+	}
+
+	return client
+}
+
+// RedactedIBIConfigFilename is the name of the redacted IBI config copy that
+// survives openshift-install's "purge asset" step.  The diagnostics collector
+// looks for this file instead of the original (which is deleted).
+const RedactedIBIConfigFilename = "image-based-installation-config.redacted.yaml"
+
+// saveRedactedCopy writes a copy of the rendered IBI config with the pull secret replaced,
+// so the file survives openshift-install's asset purge and can be used for diagnostics.
+func saveRedactedCopy(tmpl *template.Template, original *IBIConfigTemplateData, workDir string) {
+	redacted := *original
+	redacted.PullSecret = "<REDACTED>"
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, &redacted); err != nil {
+		klog.V(tsparams.LogLevel).Infof("Failed to render redacted IBI config copy: %v", err)
+
+		return
+	}
+
+	dest := filepath.Join(workDir, RedactedIBIConfigFilename)
+	if err := os.WriteFile(dest, buf.Bytes(), 0o644); err != nil {
+		klog.V(tsparams.LogLevel).Infof("Failed to write redacted IBI config to %s: %v", dest, err)
+
+		return
+	}
+
+	klog.V(tsparams.LogLevel).Infof("Saved redacted IBI config to %s", dest)
+}
+
+// indentBlock prepends each non-empty line of s with the given number of spaces.
+func indentBlock(s string, spaces int) string {
+	prefix := strings.Repeat(" ", spaces)
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = prefix + line
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// tagFromImageRef extracts the tag portion (after ":") from a container image reference.
+func tagFromImageRef(imageRef string) string {
+	ref := strings.TrimSpace(imageRef)
+	if ref == "" {
+		return ""
+	}
+
+	if atIdx := strings.LastIndex(ref, "@"); atIdx >= 0 {
+		ref = ref[:atIdx]
+	}
+
+	lastSlash := strings.LastIndex(ref, "/")
+	lastColon := strings.LastIndex(ref, ":")
+
+	if lastColon > lastSlash && lastColon < len(ref)-1 {
+		return ref[lastColon+1:]
+	}
+
+	return ""
+}

--- a/tests/cnf/ran/ibipreinstall/internal/helpers/ssh_utils.go
+++ b/tests/cnf/ran/ibipreinstall/internal/helpers/ssh_utils.go
@@ -1,0 +1,48 @@
+package helpers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ibipreinstall/internal/tsparams"
+)
+
+const sshSubprocessTimeout = 3 * time.Minute
+
+// SSHExec executes a command on a remote host via SSH.
+func SSHExec(parentCtx context.Context, host, user, sshKeyPath, command string) (string, error) {
+	klog.V(tsparams.LogLevel).Infof("Executing on %s@%s: %s", user, host, command)
+
+	args := []string{
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "LogLevel=ERROR",
+		"-o", "ConnectTimeout=10",
+		"-o", "BatchMode=yes",
+		"-i", sshKeyPath,
+		fmt.Sprintf("%s@%s", user, host),
+		command,
+	}
+
+	ctx, cancel := context.WithTimeout(parentCtx, sshSubprocessTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "ssh", args...)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return string(output), fmt.Errorf(
+				"ssh timed out after %v: %w, output: %s", sshSubprocessTimeout, err, string(output))
+		}
+
+		return string(output), fmt.Errorf("ssh failed: %w, output: %s", err, string(output))
+	}
+
+	return string(output), nil
+}

--- a/tests/cnf/ran/ibipreinstall/internal/tsparams/consts.go
+++ b/tests/cnf/ran/ibipreinstall/internal/tsparams/consts.go
@@ -1,0 +1,33 @@
+package tsparams
+
+import (
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	// LabelSuite represents ibipreinstall label that can be used for test cases selection.
+	LabelSuite = "ibipreinstall"
+	// LabelEndToEndPreinstall represents e2e label that can be used for test cases selection.
+	LabelEndToEndPreinstall = "preinstall-e2e"
+
+	// LogLevel custom loglevel for ibi preinstall verbose mode.
+	LogLevel klog.Level = 90
+
+	// PreinstallBMHNamespace is the namespace for the preinstall BMH.
+	PreinstallBMHNamespace = "openshift-machine-api"
+
+	// PreinstallServiceUnit is the systemd unit that performs the IBI
+	// preinstall (RHCOS write + seed restore) on the spoke node.
+	PreinstallServiceUnit = "install-rhcos-and-restore-seed.service"
+
+	// PreinstallWaitTimeout is the timeout for preinstall completion polling.
+	PreinstallWaitTimeout = 60 * time.Minute
+
+	// TargetNodeSSHUser is the SSH user for the preinstalled target node (always core on OCP).
+	TargetNodeSSHUser = "core"
+
+	// ISOFilename is the output filename from openshift-install image-based create image.
+	ISOFilename = "rhcos-ibi.iso"
+)

--- a/tests/cnf/ran/ibipreinstall/internal/tsparams/ibipreinstallvars.go
+++ b/tests/cnf/ran/ibipreinstall/internal/tsparams/ibipreinstallvars.go
@@ -1,0 +1,26 @@
+package tsparams
+
+import (
+	bmhv1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/openshift-kni/k8sreporter"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/ranparam"
+)
+
+var (
+	// Labels represents the range of labels that can be used for test cases selection.
+	Labels = []string{ranparam.Label, LabelSuite}
+
+	// ReporterNamespacesToDump tells the reporter from where to collect logs on failure.
+	ReporterNamespacesToDump = map[string]string{
+		"openshift-machine-api": "machine-api",
+		"openshift-config":      "openshift-config",
+	}
+
+	// ReporterCRDsToDump lists additional custom resources to dump on failure.
+	ReporterCRDsToDump = []k8sreporter.CRData{
+		{Cr: &bmhv1alpha1.BareMetalHostList{}},
+		{Cr: &bmhv1alpha1.PreprovisioningImageList{}},
+		{Cr: &configv1.ImageDigestMirrorSetList{}},
+	}
+)

--- a/tests/cnf/ran/ibipreinstall/tests/preinstall-e2e-test.go
+++ b/tests/cnf/ran/ibipreinstall/tests/preinstall-e2e-test.go
@@ -1,0 +1,238 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/bmh"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/secret"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ibipreinstall/internal/helpers"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ibipreinstall/internal/tsparams"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
+)
+
+const (
+	isoOperationTimeout       = 30 * time.Minute
+	deleteResourceWaitTimeout = 5 * time.Minute
+)
+
+// SpokeHostName is the resolved spoke hostname, set in BeforeAll for use by the
+// suite-level diagnostics collector.
+var SpokeHostName string
+
+// WorkDir is the temporary directory created for openshift-install artifacts,
+// set in BeforeAll for use by the suite-level diagnostics collector.
+var WorkDir string
+
+var _ = Describe(
+	"IBI preinstall",
+	Ordered,
+	Label(tsparams.LabelEndToEndPreinstall),
+	func() {
+		var (
+			nodeInput     *helpers.ClusterInstanceInstallInput
+			bmhName       string
+			bmcSecretName string
+		)
+
+		BeforeAll(func() {
+			var err error
+
+			WorkDir, err = os.MkdirTemp("", "ibi-preinstall-*")
+			Expect(err).NotTo(HaveOccurred(), "create work dir")
+
+			ibiCfg := RANConfig.IBIPreinstallConfig
+
+			By("Phase 1: Resolving all data sources before expensive operations")
+
+			By("Resolving seed version from env override or image tag")
+
+			seedVersion, err := helpers.ResolveSeedVersion(
+				ibiCfg.SeedVersion,
+				ibiCfg.SeedImage,
+			)
+			Expect(err).NotTo(HaveOccurred(), "resolve seed version")
+
+			By("Fetching hub resources (pull-secret, SSH key, CA bundle)")
+
+			pullSecret, err := helpers.GetPullSecretFromHub(HubAPIClient)
+			Expect(err).NotTo(HaveOccurred(), "hub pull secret")
+
+			sshKey, err := helpers.GetSSHKeyFromHub(HubAPIClient)
+			Expect(err).NotTo(HaveOccurred(), "hub ssh key")
+
+			caBundle, err := helpers.GetCACertFromHub(HubAPIClient)
+			Expect(err).NotTo(HaveOccurred(), "hub CA bundle")
+
+			By("Discovering MCE/ACM mirror locations from hub IDMS")
+
+			mceACMMirrors, err := helpers.DiscoverMCEACMMirrorsFromHub(HubAPIClient)
+			Expect(err).NotTo(HaveOccurred(), "discover MCE/ACM mirrors from hub")
+
+			By("Fetching ClusterInstance for BMH provisioning fields")
+
+			ciData, err := helpers.FetchYAMLFromURL(ibiCfg.ClusterInstanceURL, RANConfig.SkipTLSVerify)
+			Expect(err).NotTo(HaveOccurred(), "fetch ClusterInstance YAML")
+
+			clusterInstance, err := helpers.ParseClusterInstance(ciData)
+			Expect(err).NotTo(HaveOccurred(), "parse ClusterInstance")
+
+			nodeInput, err = helpers.ClusterInstanceInstallInputFrom(clusterInstance)
+			Expect(err).NotTo(HaveOccurred(), "extract node input from ClusterInstance")
+
+			bmhName = nodeInput.PreinstallBMHName()
+			bmcSecretName = nodeInput.PreinstallBMCSecretName()
+			SpokeHostName = nodeInput.HostName
+
+			if nodeInput.NetworkConfig != "" {
+				By("Verifying nmstatectl is available (required by openshift-install for networkConfig)")
+				Expect(helpers.VerifyNmstatectlAvailable()).To(Succeed(),
+					"nmstatectl must be installed when networkConfig is specified — run: dnf install -y nmstate")
+			}
+
+			By("Resolving IBI config template URL")
+
+			templateURL, err := helpers.ResolveIBIConfigTemplateURL(
+				ibiCfg.IBIConfigTemplateURL, ibiCfg.ClusterInstanceURL)
+			Expect(err).NotTo(HaveOccurred(), "resolve IBI config template URL")
+
+			preinstallRegistry := ibiCfg.PreinstallRegistry
+			if preinstallRegistry == "" {
+				preinstallRegistry, err = helpers.RegistryHostFromMirror(mceACMMirrors.MCE)
+				Expect(err).NotTo(HaveOccurred(), "derive preinstall registry from MCE mirror")
+
+				klog.V(tsparams.LogLevel).Infof(
+					"Derived preinstall registry from MCE mirror: %s", preinstallRegistry)
+			}
+
+			By("Resolving IBI config template and writing to work dir")
+
+			err = helpers.ResolveIBIConfigTemplate(
+				templateURL,
+				&helpers.IBIConfigTemplateData{
+					SeedImage:          ibiCfg.SeedImage,
+					SeedVersion:        seedVersion,
+					PullSecret:         pullSecret,
+					SSHKey:             sshKey,
+					CACert:             caBundle,
+					NetworkConfig:      nodeInput.NetworkConfig,
+					PreinstallRegistry: preinstallRegistry,
+					MCEMirror:          mceACMMirrors.MCE,
+					ACMMirror:          mceACMMirrors.ACM,
+				},
+				WorkDir,
+				RANConfig.SkipTLSVerify,
+			)
+			Expect(err).NotTo(HaveOccurred(), "resolve IBI config template")
+
+			By("Phase 1 complete - all data sources resolved, config written")
+		})
+
+		AfterAll(func() {
+			if WorkDir != "" {
+				_ = os.RemoveAll(WorkDir)
+			}
+
+			if httpDir := RANConfig.IBIPreinstallConfig.PreinstallHTTPDir; httpDir != "" {
+				_ = os.Remove(filepath.Join(httpDir, tsparams.ISOFilename))
+			}
+		})
+
+		AfterEach(func() {
+			if bmhName == "" {
+				return
+			}
+
+			bmhBuilder, err := bmh.Pull(HubAPIClient, bmhName, tsparams.PreinstallBMHNamespace)
+			if err == nil {
+				if _, delErr := bmhBuilder.DeleteAndWaitUntilDeleted(deleteResourceWaitTimeout); delErr != nil {
+					klog.V(tsparams.LogLevel).Infof("Cleanup: failed to delete BMH %s: %v", bmhName, delErr)
+				}
+			}
+
+			if delErr := secret.NewBuilder(
+				HubAPIClient, bmcSecretName, tsparams.PreinstallBMHNamespace, corev1.SecretTypeOpaque,
+			).Delete(); delErr != nil {
+				klog.V(tsparams.LogLevel).Infof("Cleanup: failed to delete BMC secret %s: %v", bmcSecretName, delErr)
+			}
+		})
+
+		It("performs disconnected IBI cluster node preinstall end to end", reportxml.ID("89666"), func() {
+			ibiCfg := RANConfig.IBIPreinstallConfig
+
+			By("Running openshift-install image-based create image")
+
+			isoCtx, cancelISO := context.WithTimeout(context.TODO(), isoOperationTimeout)
+			defer cancelISO()
+
+			isoPath, err := helpers.CreateIBIISO(isoCtx, ibiCfg.OpenshiftInstallPath, WorkDir, tsparams.ISOFilename)
+			Expect(err).NotTo(HaveOccurred(), "openshift-install image-based create image failed")
+
+			By("Copying ISO to local HTTP serving directory")
+
+			err = helpers.CopyISOToHTTPDir(isoPath, ibiCfg.PreinstallHTTPDir)
+			Expect(err).NotTo(HaveOccurred(), "failed to copy ISO to HTTP serving directory")
+
+			isoURL := ibiCfg.ISOArtifactURL(tsparams.ISOFilename)
+
+			By(fmt.Sprintf("Verifying ISO is accessible at %s", isoURL))
+			Expect(helpers.VerifyHTTPAccessible(isoURL)).To(Succeed(),
+				"ISO must be reachable via HTTP before creating BMH")
+
+			By("Creating BMC secret and BareMetalHost on the hub")
+
+			_, err = helpers.CreateBMCSecret(
+				HubAPIClient,
+				bmcSecretName,
+				tsparams.PreinstallBMHNamespace,
+				RANConfig.BMCUsername,
+				RANConfig.BMCPassword,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create BMC secret")
+
+			_, err = helpers.CreateBareMetalHost(
+				HubAPIClient,
+				bmhName,
+				tsparams.PreinstallBMHNamespace,
+				nodeInput.BMCAddress,
+				nodeInput.BootMACAddress,
+				bmcSecretName,
+				isoURL,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create BareMetalHost")
+
+			By("Waiting for BMH to reach provisioned state")
+
+			err = helpers.WaitForBMHProvisioned(
+				context.TODO(),
+				HubAPIClient,
+				bmhName, tsparams.PreinstallBMHNamespace,
+				20*time.Minute,
+				30*time.Second,
+			)
+			Expect(err).NotTo(HaveOccurred(), "BMH must reach provisioned state")
+
+			By("Waiting for " + tsparams.PreinstallServiceUnit + " on " + nodeInput.HostName)
+
+			err = helpers.WaitForPreinstallCompletion(
+				context.TODO(),
+				nodeInput.HostName,
+				tsparams.TargetNodeSSHUser,
+				ibiCfg.PreinstallSSHKey,
+				tsparams.PreinstallWaitTimeout,
+				time.Minute,
+			)
+			Expect(err).NotTo(HaveOccurred(),
+				tsparams.PreinstallServiceUnit+" must complete successfully on "+nodeInput.HostName)
+		})
+	},
+)

--- a/tests/cnf/ran/internal/ranconfig/config.go
+++ b/tests/cnf/ran/internal/ranconfig/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
@@ -29,6 +30,7 @@ type RANConfig struct {
 	*HubConfig
 	*Spoke1Config
 	*Spoke2Config
+	*IBIPreinstallConfig
 
 	MetricSamplingInterval string        `yaml:"metricSamplingInterval" envconfig:"ECO_CNF_RAN_METRIC_SAMPLING_INTERVAL"`
 	NoWorkloadDuration     string        `yaml:"noWorkloadDuration" envconfig:"ECO_CNF_RAN_NO_WORKLOAD_DURATION"`
@@ -51,6 +53,10 @@ type RANConfig struct {
 	// MockSMOSubdomain is the subdomain for the mock SMO route. It should be the SMO registered in the inventory CR. It
 	// is optional and only used for the O-RAN suite.
 	MockSMOSubdomain string `yaml:"mockSmoSubdomain" envconfig:"ECO_CNF_RAN_MOCK_SMO_SUBDOMAIN"`
+
+	// SkipTLSVerify skips TLS certificate verification for HTTP fetches (e.g., fetching
+	// ClusterInstance YAML from a remote server whose CA is not in the container trust store).
+	SkipTLSVerify bool `default:"false" envconfig:"ECO_CNF_RAN_SKIP_TLS_VERIFY"`
 
 	// PtpEventConsumerImage is the URL of the PTP event consumer image. It should not have a tag, since the
 	// expectation is that the program uses v1 or v2 as a tag.
@@ -145,6 +151,34 @@ type Spoke2Config struct {
 	Spoke2Kubeconfig string `envconfig:"ECO_CNF_RAN_KUBECONFIG_SPOKE2"`
 }
 
+// IBIPreinstallConfig contains configuration specific to IBI preinstall workflows.
+type IBIPreinstallConfig struct {
+	// SeedImage is the seed image reference (e.g., registry:5000/ibu/seed:4.22.8).
+	SeedImage string `envconfig:"ECO_CNF_RAN_IBI_SEED_IMAGE"`
+	// SeedVersion overrides the tag parsed from SeedImage (needed when the seed ref is digest-pinned).
+	SeedVersion string `envconfig:"ECO_CNF_RAN_IBI_SEED_VERSION"`
+	// ClusterInstanceURL is the raw URL to the ClusterInstance YAML file (used for BMH fields).
+	ClusterInstanceURL string `envconfig:"ECO_CNF_RAN_IBI_CLUSTER_INSTANCE_URL"`
+	// IBIConfigTemplateURL is the raw URL to the image-based-installation-config.yaml template.
+	// The template uses Go text/template placeholders ({{.SeedImage}}, {{.PullSecret}}, etc.)
+	// that are resolved at runtime from hub cluster resources and env vars.
+	IBIConfigTemplateURL string `envconfig:"ECO_CNF_RAN_IBI_CONFIG_TEMPLATE_URL"`
+	// PreinstallRegistry is the disconnected registry host:port (e.g. registry.example.com:5000)
+	// used to resolve {{.PreinstallRegistry}} in the IBI config template.
+	PreinstallRegistry string `envconfig:"ECO_CNF_RAN_IBI_PREINSTALL_REGISTRY"`
+	// OpenshiftInstallPath is the path to the openshift-install binary (mounted by CI).
+	OpenshiftInstallPath string `envconfig:"ECO_CNF_RAN_IBI_OPENSHIFT_INSTALL"`
+	// PreinstallHTTPDir is the local directory that the HTTP server serves from.
+	// The generated ISO is copied here so the BMH can boot from it via PreinstallHTTPBaseURL.
+	// In CI this is a volume mount from the host's HTTP serve directory.
+	PreinstallHTTPDir string `envconfig:"ECO_CNF_RAN_IBI_PREINSTALL_HTTP_DIR"`
+	// PreinstallHTTPBaseURL is the HTTP URL that maps to PreinstallHTTPDir.
+	PreinstallHTTPBaseURL string `envconfig:"ECO_CNF_RAN_IBI_PREINSTALL_HTTP_BASE_URL"`
+	// PreinstallSSHKey is the path to the SSH private key (mounted into the container).
+	// Used to SSH into the target node for preinstall status monitoring and diagnostics.
+	PreinstallSSHKey string `envconfig:"ECO_CNF_RAN_IBI_PREINSTALL_SSH_KEY"`
+}
+
 // NewRANConfig returns an instance of RANConfig.
 func NewRANConfig() *RANConfig {
 	klog.V(ranparam.LogLevel).Infof("Creating new RANConfig struct")
@@ -167,8 +201,20 @@ func NewRANConfig() *RANConfig {
 	ranConfig.newHubConfig(configFile)
 	ranConfig.newSpoke1Config(configFile)
 	ranConfig.newSpoke2Config(configFile)
+	ranConfig.newIBIPreinstallConfig(configFile)
 
 	return &ranConfig
+}
+
+func (ranconfig *RANConfig) newIBIPreinstallConfig(configFile string) {
+	klog.V(ranparam.LogLevel).Infof("Creating new IBIPreinstallConfig struct from file %s", configFile)
+
+	ranconfig.IBIPreinstallConfig = new(IBIPreinstallConfig)
+
+	err := readConfig(ranconfig.IBIPreinstallConfig, configFile)
+	if err != nil {
+		klog.V(ranparam.LogLevel).Infof("Failed to instantiate IBIPreinstallConfig: %v", err)
+	}
 }
 
 func (ranconfig *RANConfig) newHubConfig(configFile string) {
@@ -355,4 +401,58 @@ func readEnv[C any](config *C) error {
 	err := envconfig.Process("", config)
 
 	return err
+}
+
+// ISOArtifactURL builds the full HTTP URL for the IBI ISO file.
+func (c *IBIPreinstallConfig) ISOArtifactURL(isoFilename string) string {
+	base := strings.TrimSuffix(c.PreinstallHTTPBaseURL, "/")
+
+	return fmt.Sprintf("%s/%s", base, isoFilename)
+}
+
+// ValidatePreinstallMandatory returns an error listing any mandatory IBI preinstall settings that are unset.
+func (c *IBIPreinstallConfig) ValidatePreinstallMandatory(bmcUsername, bmcPassword string) error {
+	if c == nil {
+		return fmt.Errorf("IBI preinstall config is nil")
+	}
+
+	var missing []string
+
+	if c.SeedImage == "" {
+		missing = append(missing, "ECO_CNF_RAN_IBI_SEED_IMAGE")
+	}
+
+	if c.ClusterInstanceURL == "" {
+		missing = append(missing, "ECO_CNF_RAN_IBI_CLUSTER_INSTANCE_URL")
+	}
+
+	if c.OpenshiftInstallPath == "" {
+		missing = append(missing, "ECO_CNF_RAN_IBI_OPENSHIFT_INSTALL")
+	}
+
+	if c.PreinstallHTTPDir == "" {
+		missing = append(missing, "ECO_CNF_RAN_IBI_PREINSTALL_HTTP_DIR")
+	}
+
+	if c.PreinstallHTTPBaseURL == "" {
+		missing = append(missing, "ECO_CNF_RAN_IBI_PREINSTALL_HTTP_BASE_URL")
+	}
+
+	if c.PreinstallSSHKey == "" {
+		missing = append(missing, "ECO_CNF_RAN_IBI_PREINSTALL_SSH_KEY")
+	}
+
+	if bmcUsername == "" {
+		missing = append(missing, "ECO_CNF_RAN_BMC_USERNAME")
+	}
+
+	if bmcPassword == "" {
+		missing = append(missing, "ECO_CNF_RAN_BMC_PASSWORD")
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required IBI preinstall configuration: %s", strings.Join(missing, ", "))
+	}
+
+	return nil
 }

--- a/vendor/github.com/rh-ecosystem-edge/eco-goinfra/pkg/idms/idms.go
+++ b/vendor/github.com/rh-ecosystem-edge/eco-goinfra/pkg/idms/idms.go
@@ -1,0 +1,281 @@
+package idms
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
+	"k8s.io/klog/v2"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Builder provides struct for configmap object containing connection to the cluster and the configmap definitions.
+type Builder struct {
+	// ConfigMap definition. Used to create configmap object.
+	Definition *configv1.ImageDigestMirrorSet
+	// Created configmap object.
+	Object *configv1.ImageDigestMirrorSet
+	// Used in functions that defines or mutates configmap definition. errorMsg is processed before the configmap
+	// object is created.
+	errorMsg  string
+	apiClient runtimeClient.Client
+}
+
+// NewBuilder creates a new instance of Builder.
+func NewBuilder(apiClient *clients.Settings, name string, mirror configv1.ImageDigestMirrors) *Builder {
+	klog.V(100).Infof(
+		"Initializing new imagedigestmirrorset structure with the following params: "+
+			"name: %s, mirror: %v", name, mirror)
+
+	if apiClient == nil {
+		klog.V(100).Info("The apiClient cannot be nil")
+
+		return nil
+	}
+
+	if err := apiClient.AttachScheme(configv1.AddToScheme); err != nil {
+		klog.V(100).Infof(
+			"Failed to add configv1 scheme to client schemes")
+
+		return nil
+	}
+
+	builder := &Builder{
+		apiClient: apiClient.Client,
+		Definition: &configv1.ImageDigestMirrorSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: configv1.ImageDigestMirrorSetSpec{
+				ImageDigestMirrors: []configv1.ImageDigestMirrors{
+					mirror,
+				},
+			},
+		},
+	}
+
+	if name == "" {
+		klog.V(100).Info("The name of the imagedigestmirrorset is empty")
+
+		builder.errorMsg = "imagedigestmirrorset 'name' cannot be empty"
+
+		return builder
+	}
+
+	return builder
+}
+
+// Pull retrieves an existing imagedigestmirrorset from the cluster.
+func Pull(apiClient *clients.Settings, name string) (*Builder, error) {
+	klog.V(100).Infof(
+		"Pulling existing imagedigestmirrorset with name %s", name)
+
+	if apiClient == nil {
+		klog.V(100).Info("The apiClient is nil")
+
+		return nil, fmt.Errorf("apiClient cannot be nil")
+	}
+
+	if err := apiClient.AttachScheme(configv1.AddToScheme); err != nil {
+		klog.V(100).Infof(
+			"Failed to add configv1 scheme to client schemes")
+
+		return nil, fmt.Errorf("failed to add configv1 to client schemes")
+	}
+
+	builder := &Builder{
+		apiClient: apiClient.Client,
+		Definition: &configv1.ImageDigestMirrorSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		},
+	}
+
+	if name == "" {
+		klog.V(100).Info("The name of the imagedigestmirrorset is empty")
+
+		return nil, fmt.Errorf("imagedigestmirrorset 'name' cannot be empty")
+	}
+
+	if !builder.Exists() {
+		return nil, fmt.Errorf("imagedigestmirrorset object %s does not exist", name)
+	}
+
+	builder.Definition = builder.Object
+
+	return builder, nil
+}
+
+// WithMirror adds an imagedigestmirror for mirroring images.
+func (builder *Builder) WithMirror(mirror configv1.ImageDigestMirrors) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return nil
+	}
+
+	klog.V(100).Infof("Adding imagedigestmirror to imagedigestmirrorset %s: %v",
+		builder.Definition.Name, mirror)
+
+	builder.Definition.Spec.ImageDigestMirrors = append(builder.Definition.Spec.ImageDigestMirrors, mirror)
+
+	return builder
+}
+
+// Get fetches the defined imagedigestmirrorset from the cluster.
+func (builder *Builder) Get() (*configv1.ImageDigestMirrorSet, error) {
+	if valid, err := builder.validate(); !valid {
+		return nil, err
+	}
+
+	klog.V(100).Infof("Getting imagedigestmirrorset %s",
+		builder.Definition.Name)
+
+	imageDigestMirrorSet := &configv1.ImageDigestMirrorSet{}
+
+	err := builder.apiClient.Get(logging.DiscardContext(), runtimeClient.ObjectKey{
+		Name: builder.Definition.Name,
+	}, imageDigestMirrorSet)
+	if err != nil {
+		return nil, err
+	}
+
+	return imageDigestMirrorSet, err
+}
+
+// Create generates an imagedigestmirrorset on the cluster.
+func (builder *Builder) Create() (*Builder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	klog.V(100).Infof("Creating the imagedigestmirrorset %s",
+		builder.Definition.Name)
+
+	var err error
+	if !builder.Exists() {
+		err = builder.apiClient.Create(logging.DiscardContext(), builder.Definition)
+		if err == nil {
+			builder.Object = builder.Definition
+		}
+	}
+
+	return builder, err
+}
+
+// Update modifies an existing imagedigestmirrorset on the cluster.
+func (builder *Builder) Update(force bool) (*Builder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	klog.V(100).Infof("Updating imagedigestmirrorset %s",
+		builder.Definition.Name)
+
+	if !builder.Exists() {
+		klog.V(100).Infof("imagedigestmirrorset %s does not exist",
+			builder.Definition.Name)
+
+		return builder, fmt.Errorf("cannot update non-existent imagedigestmirrorset")
+	}
+
+	err := builder.apiClient.Update(logging.DiscardContext(), builder.Definition)
+	if err != nil {
+		if force {
+			klog.V(100).Infof("%v", msg.FailToUpdateNotification("imagedigestmirrorset", builder.Definition.Name))
+
+			err := builder.Delete()
+			if err != nil {
+				klog.V(100).Infof("%v", msg.FailToUpdateError("imagedigestmirrorset", builder.Definition.Name))
+
+				return nil, err
+			}
+
+			return builder.Create()
+		}
+	}
+
+	if err == nil {
+		builder.Object = builder.Definition
+	}
+
+	return builder, err
+}
+
+// Delete removes an imagedigestmirrorset from the cluster.
+func (builder *Builder) Delete() error {
+	if valid, err := builder.validate(); !valid {
+		return err
+	}
+
+	klog.V(100).Infof("Deleting the imagedigestmirrorset %s",
+		builder.Definition.Name)
+
+	if !builder.Exists() {
+		klog.V(100).Infof("imagedigestmirrorset %s does not exist",
+			builder.Definition.Name)
+
+		return nil
+	}
+
+	err := builder.apiClient.Delete(logging.DiscardContext(), builder.Definition)
+	if err != nil {
+		return fmt.Errorf("cannot delete imagedigestmirrorset: %w", err)
+	}
+
+	builder.Object = nil
+
+	return nil
+}
+
+// Exists checks if the defined imagedigestmirrorset has already been created.
+func (builder *Builder) Exists() bool {
+	if valid, _ := builder.validate(); !valid {
+		return false
+	}
+
+	klog.V(100).Infof("Checking if imagedigestmirrorset %s exists",
+		builder.Definition.Name)
+
+	var err error
+
+	builder.Object, err = builder.Get()
+
+	return err == nil || !k8serrors.IsNotFound(err)
+}
+
+// validate will check that the builder and builder definition are properly initialized before
+// accessing any member fields.
+func (builder *Builder) validate() (bool, error) {
+	resourceCRD := "ImageDigestMirrorSet"
+
+	if builder == nil {
+		klog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
+
+		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
+	}
+
+	if builder.Definition == nil {
+		klog.V(100).Infof("The %s is undefined", resourceCRD)
+
+		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceCRD))
+	}
+
+	if builder.apiClient == nil {
+		klog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
+
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
+	}
+
+	if builder.errorMsg != "" {
+		klog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
+
+		return false, fmt.Errorf("%s", builder.errorMsg)
+	}
+
+	return true, nil
+}

--- a/vendor/github.com/rh-ecosystem-edge/eco-goinfra/pkg/idms/list.go
+++ b/vendor/github.com/rh-ecosystem-edge/eco-goinfra/pkg/idms/list.go
@@ -1,0 +1,70 @@
+package idms
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
+	"k8s.io/klog/v2"
+
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ListImageDigestMirrorSets returns a cluster-wide imagedigestmirrorset inventory.
+func ListImageDigestMirrorSets(
+	apiClient *clients.Settings,
+	options ...runtimeClient.ListOptions) ([]*Builder, error) {
+	passedOptions := runtimeClient.ListOptions{}
+	logMessage := "Listing all imagedigestmirrorsets"
+
+	if apiClient == nil {
+		klog.V(100).Info("The apiClient is nil")
+
+		return nil, fmt.Errorf("apiClient cannot be nil")
+	}
+
+	if err := apiClient.AttachScheme(configv1.AddToScheme); err != nil {
+		klog.V(100).Infof(
+			"Failed to add configv1 scheme to client schemes")
+
+		return nil, fmt.Errorf("failed to add configv1 to client schemes")
+	}
+
+	if len(options) > 1 {
+		klog.V(100).Info("'options' parameter must be empty or single-valued")
+
+		return nil, fmt.Errorf("error: more than one ListOptions was passed")
+	}
+
+	if len(options) == 1 {
+		passedOptions = options[0]
+		logMessage += fmt.Sprintf(" with the options %v", passedOptions)
+	}
+
+	klog.V(100).Infof("%v", logMessage)
+
+	imageDigestMirrorSets := new(configv1.ImageDigestMirrorSetList)
+
+	err := apiClient.List(logging.DiscardContext(), imageDigestMirrorSets, &passedOptions)
+	if err != nil {
+		klog.V(100).Infof("Failed to list all imageDigestMirrorSets due to %s", err.Error())
+
+		return nil, err
+	}
+
+	var IDMSObjects []*Builder
+
+	for _, idms := range imageDigestMirrorSets.Items {
+		copiedIDMS := idms
+		idmsBuilder := &Builder{
+			apiClient:  apiClient.Client,
+			Object:     &copiedIDMS,
+			Definition: &copiedIDMS,
+		}
+
+		IDMSObjects = append(IDMSObjects, idmsBuilder)
+	}
+
+	return IDMSObjects, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1014,6 +1014,7 @@ github.com/rh-ecosystem-edge/eco-goinfra/pkg/events
 github.com/rh-ecosystem-edge/eco-goinfra/pkg/hive
 github.com/rh-ecosystem-edge/eco-goinfra/pkg/ibgu
 github.com/rh-ecosystem-edge/eco-goinfra/pkg/ibi
+github.com/rh-ecosystem-edge/eco-goinfra/pkg/idms
 github.com/rh-ecosystem-edge/eco-goinfra/pkg/imageregistry
 github.com/rh-ecosystem-edge/eco-goinfra/pkg/imagestream
 github.com/rh-ecosystem-edge/eco-goinfra/pkg/infrastructure


### PR DESCRIPTION
Add an Image-Based Installation (IBI) preinstall test suite under tests/cnf/ran/ibipreinstall that automates the full preinstall workflow: resolve hub resources, generate the IBI config from a templated YAML, build the install ISO, provision a BareMetalHost, and wait for the preinstall service to complete on the spoke node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an end-to-end test for disconnected IBI node preinstallation.
  - Added automated configuration generation, ISO creation and serving, BareMetalHost provisioning, and preinstall completion checks.
  - Added retrieval of required hub resources and mirror locations.
  - Added failure diagnostics, including system journals, kernel messages, installer artifacts, and cluster resource summaries.

- **Documentation**
  - Added setup, configuration, environment variable, and execution guidance for the preinstall test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->