### PR TITLE
global: add nmstate to eco-gotests container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ LABEL ginkgo.version=${GINKGO_VER}
 LABEL container.user=${CONTAINERUSER}
 
 ENV PATH "$PATH:/usr/local/go/bin:/root/go/bin"
-RUN dnf install -y tar gcc make && \
+RUN dnf install -y tar gcc make nmstate && \
     dnf clean metadata packages && \
     useradd -U -u 1000 -m -d /home/${CONTAINERUSER} -s /usr/bin/bash ${CONTAINERUSER}
 


### PR DESCRIPTION
This commit updates the eco-gotests container to include the nmstate package. It is necessary for creating the IBI preinstall ISO and only increases container size by about 1% so the impact is generall insignificant.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `nmstate` to the Docker image, enabling network state management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->