### PR TITLE
system-tests: add OCM policies to failure reports

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscoreparams/rdscorevars.go
+++ b/tests/system-tests/rdscore/internal/rdscoreparams/rdscorevars.go
@@ -4,6 +4,7 @@ import (
 	"github.com/openshift-kni/k8sreporter"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 )
 
 var (
@@ -78,5 +79,6 @@ var (
 		// Storage resources for debugging PVC binding and provisioning issues
 		{Cr: &corev1.PersistentVolumeList{}},
 		{Cr: &corev1.PersistentVolumeClaimList{}},
+		{Cr: &policiesv1.PolicyList{}},
 	}
 )


### PR DESCRIPTION
Enhance failure reporting by adding Open Cluster Management (OCM) Policy resources to the k8sreporter dump.

This allows for easier debugging of policy-related test failures by including all `policy.open-cluster-management.io/v1` resources in the generated artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for collecting `PolicyList` resources in reporter data.
  * Integrated governance policy propagation API support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->