### PR TITLE
cnf ran oran: remove test case 78246

### DIFF
--- a/tests/cnf/ran/oran/internal/helper/helper.go
+++ b/tests/cnf/ran/oran/internal/helper/helper.go
@@ -3,7 +3,6 @@ package helper
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -11,13 +10,9 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/ocm"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran"
 	oranapi "github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran/api"
-	siteconfigv1alpha1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/siteconfig/v1alpha1"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/siteconfig"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
-	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/ranparam"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
 	mocksmo "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/oran-mock-smo"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
@@ -62,39 +57,6 @@ func NewSecondaryProvisioningRequest(
 	return prBuilder
 }
 
-// NewInlineBMCPR creates a ProvisioningRequest builder for ClusterTemplates that omit hwMgmtDefaults and rely on inline
-// BMC details in clusterInstanceParameters. All required parameters and the affix are set from RANConfig. The BMC and
-// network data are incorrect so that a ClusterInstance is generated but will not provision.
-//
-// Note that there is a similar scenario where the ProvisioningRequest includes hwMgmtParameters instead of the
-// ClusterTemplate's hwMgmtDefaults. This function is not for that scenario.
-func NewInlineBMCPR(client runtimeclient.Client, templateVersion string) *oran.ProvisioningRequestBuilder {
-	versionWithAffix := RANConfig.ClusterTemplateAffix + "-" + templateVersion
-	prBuilder := oran.NewPRBuilder(client, tsparams.TestPRName, tsparams.ClusterTemplateName, versionWithAffix).
-		WithTemplateParameter("nodeClusterName", RANConfig.Spoke1Name).
-		WithTemplateParameter("oCloudSiteId", tsparams.OCloudSiteID).
-		WithTemplateParameter("policyTemplateParameters", map[string]any{}).
-		WithTemplateParameter("clusterInstanceParameters", map[string]any{
-			"clusterName": RANConfig.Spoke1Name,
-			"nodes": []map[string]any{{
-				"hostName":   "fake.apps." + RANConfig.Spoke1Hostname,
-				"bmcAddress": "redfish-VirtualMedia://" + ranparam.UnreachableIPv4Address + "/redfish/v1/Systems/System.Embedded.1",
-				"bmcCredentialsDetails": map[string]any{
-					"username": tsparams.TestBase64Credential,
-					"password": tsparams.TestBase64Credential,
-				},
-				"bootMACAddress": "01:23:45:67:89:AB",
-				"nodeNetwork": map[string]any{
-					"interfaces": []map[string]any{{
-						"macAddress": "01:23:45:67:89:AB",
-					}},
-				},
-			}},
-		})
-
-	return prBuilder
-}
-
 // WaitForNoncompliantImmutable waits up to timeout until one of the policies in namespace is NonCompliant and the
 // message history shows it is due to an immutable field.
 func WaitForNoncompliantImmutable(client *clients.Settings, namespace string, timeout time.Duration) error {
@@ -132,25 +94,6 @@ func WaitForNoncompliantImmutable(client *clients.Settings, namespace string, ti
 			}
 
 			return false, nil
-		})
-}
-
-// WaitForValidPRClusterInstance waits up to timeout until the ClusterInstance for the ProvisioningRequest has condition
-// RenderedTemplatesApplied.
-func WaitForValidPRClusterInstance(client *clients.Settings, timeout time.Duration) error {
-	return wait.PollUntilContextTimeout(
-		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-			clusterInstance, err := siteconfig.PullClusterInstance(client, RANConfig.Spoke1Name, RANConfig.Spoke1Name)
-			if err != nil {
-				klog.V(tsparams.LogLevel).Infof("Failed to pull ClusterInstance %s: %v", RANConfig.Spoke1Name, err)
-
-				return false, nil
-			}
-
-			return slices.ContainsFunc(clusterInstance.Definition.Status.Conditions, func(condition metav1.Condition) bool {
-				return condition.Type == string(siteconfigv1alpha1.RenderedTemplatesApplied) &&
-					condition.Status == metav1.ConditionTrue
-			}), nil
 		})
 }
 

--- a/tests/cnf/ran/oran/internal/tsparams/consts.go
+++ b/tests/cnf/ran/oran/internal/tsparams/consts.go
@@ -76,8 +76,6 @@ const (
 	TemplateUpdateSchema = "v11"
 	// TemplateInlineBMCMissingSchema is the ClusterTemplate version for the missing inline BMC schema test (78245).
 	TemplateInlineBMCMissingSchema = "v12"
-	// TemplateInlineBMC is the ClusterTemplate version for the successful inline BMC provisioning test (78246).
-	TemplateInlineBMC = "v13"
 	// TemplateBMCFirmwareUpdate is the ClusterTemplate version for BMC firmware upgrade test.
 	TemplateBMCFirmwareUpdate = "v14"
 	// TemplateBIOSFirmwareUpdate is the ClusterTemplate version for BIOS firmware upgrade test.
@@ -112,9 +110,6 @@ const (
 	// TestPRName2 is the second UUID used for naming ProvisioningRequests. Metal3 tests require a second PR applied
 	// to verify the case of all hardware already allocated.
 	TestPRName2 = "a1b2c3d4-e5f6-7890-1234-567890abcdef"
-	// TestBase64Credential is a base64 encoded version of the string "wrongpassword" for when an obviously invalid
-	// credential is needed.
-	TestBase64Credential = "d3JvbmdwYXNzd29yZA=="
 )
 
 // LogLevel is the glog verbosity level to use for logs in this suite or its helpers.

--- a/tests/cnf/ran/oran/tests/oran-pre-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-pre-provision.go
@@ -76,36 +76,6 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 			}
 		})
 
-		// 78246 - Successful ClusterInstance generation with inline BMC without hwMgmtDefaults
-		It("successfully generates ClusterInstance with inline BMC without hwMgmtDefaults", reportxml.ID("78246"), func() {
-			clusterTemplateName := fmt.Sprintf("%s.%s-%s",
-				tsparams.ClusterTemplateName, RANConfig.ClusterTemplateAffix, tsparams.TemplateInlineBMC)
-			clusterTemplateNamespace := tsparams.ClusterTemplateName + "-" + RANConfig.ClusterTemplateAffix
-
-			By("pulling the ClusterTemplate that defines inline BMC schema without hwMgmtDefaults")
-
-			clusterTemplate, err := oran.PullClusterTemplate(HubAPIClient, clusterTemplateName, clusterTemplateNamespace)
-			Expect(err).ToNot(HaveOccurred(), "Failed to pull ClusterTemplate with inline BMC schema")
-
-			By("verifying the ClusterTemplate omits hwMgmtDefaults and hwMgmtParameters")
-			Expect(clusterTemplate.Definition.Spec.TemplateDefaults.HwMgmtDefaults.NodeGroupData).To(BeEmpty(),
-				"ClusterTemplate defines hwMgmtDefaults nodeGroupData when it should not")
-			Expect(provisioningv1alpha1.SchemaDefinesHwMgmtParameters(clusterTemplate.Definition)).To(BeFalse(),
-				"ClusterTemplate defines hwMgmtParameters in its schema when it should not")
-
-			By("creating a ProvisioningRequest with inline BMC details in clusterInstanceParameters")
-
-			prBuilder := helper.NewInlineBMCPR(o2imsAPIClient, tsparams.TemplateInlineBMC)
-			_, err = prBuilder.Create()
-			Expect(err).ToNot(HaveOccurred(), "Failed to create a ProvisioningRequest")
-
-			By("waiting for its ClusterInstance to be created and validated")
-
-			err = helper.WaitForValidPRClusterInstance(HubAPIClient, 3*time.Minute)
-			Expect(err).ToNot(HaveOccurred(),
-				"Failed to wait for ClusterInstance to be created and have its templates applied")
-		})
-
 		// 83880 - Failed provisioning due to no hardware matching resource selector
 		It("fails when no hardware matches resource selector", reportxml.ID("83880"), func() {
 			By("creating a ProvisioningRequest with non-matching resource selector")


### PR DESCRIPTION
This commit removes O-RAN pre-provision test case 78246 and its associated helpers and parameters. The ability to provide inline BMC details was removed in openshift-kni/oran-o2ims#3233 so the code path this test case covered no longer exists. There is no similar code path where one can avoid the hardware manager anymore, so there is no possible way to update the test case to be useful.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed an outdated pre-provisioning test for cluster instances using inline BMC data.
  * Removed related test-only helpers and constants no longer needed by the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->