### PR TITLE
cnf network: fix nncp map

### DIFF
--- a/tests/cnf/core/network/metallb/tests/bgp-unnumbered.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-unnumbered.go
@@ -112,7 +112,8 @@ var _ = Describe("BGP Unnumbered", Ordered, Label(tsparams.LabelBGPUnnumbered),
 
 			By(fmt.Sprintf("Resetting ethernet interface %s on worker node %s",
 				interfacesUnderTest[0], workerNodeList[0].Definition.Name))
-			ethIntWorker0Policy := nmstate.NewPolicyBuilder(APIClient, nodeNetConfigPolicyName, NetConfig.WorkerLabelMap).
+			ethIntWorker0Policy := nmstate.NewPolicyBuilder(APIClient, nodeNetConfigPolicyName,
+				map[string]string{corev1.LabelHostname: workerNodeList[0].Definition.Name}).
 				WithEthernetDualStackInterface(interfacesUnderTest[0])
 			err := netnmstate.UpdatePolicyAndWaitUntilItsAvailable(netparam.DefaultTimeout, ethIntWorker0Policy)
 			Expect(err).ToNot(HaveOccurred(), "Failed to update NMState network policy")


### PR DESCRIPTION
PR #1559 changed cleanup from marking the interface absent to resetting it with dual-stack ethernet (ipv4/ipv6 enabled). That NNCP still used NetConfig.WorkerLabelMap (node-role.kubernetes.io/workercnf), so it applied to both workers.

worker0 — OK (node under test)
worker1 — failed: ens1f0 stayed ipv4.enabled: false (lab NM profile), policy went Degraded, wait timed out (context deadline exceeded)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NMState cleanup targeting for worker node network policies.
  * Updated test wording to clearly reference the configured peer ASN.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->