### PR TITLE
cnf network: add cni sysctl api

### DIFF
--- a/tests/cnf/core/network/cni/internal/tsparams/cnivars.go
+++ b/tests/cnf/core/network/cni/internal/tsparams/cnivars.go
@@ -13,6 +13,8 @@ import (
 const (
 	// MultusFirstInterfaceName is the default name of the first secondary network interface.
 	MultusFirstInterfaceName = "net1"
+	// MultusSecondInterfaceName is the default name of the second secondary network interface.
+	MultusSecondInterfaceName = "net2"
 	// ClientIPv4 is the sysctl client address on the secondary network.
 	ClientIPv4 = "10.100.100.210"
 	// ServerIPv4 is the sysctl server address on the secondary network.
@@ -54,6 +56,16 @@ var (
 	NetworkWithoutSysctlMutation = "test-no-sysct-mutation"
 	// FirstSysctlNetworkName is the primary NAD name used by sysctl API tests.
 	FirstSysctlNetworkName = "test-nad-sysctl-first"
+	// SecondSysctlNetworkName is the secondary NAD name used by sysctl API tests.
+	SecondSysctlNetworkName = "test-nad-sysctl-second"
+	// FirstSysctlNetworkIPv4 is the static IP for the first sysctl API NAD.
+	FirstSysctlNetworkIPv4 = "10.100.100.200"
+	// SecondSysctlNetworkIPv4 is the static IP for the second sysctl API NAD.
+	SecondSysctlNetworkIPv4 = "10.100.200.200"
+	// FirstSysctlNetworkIPv4CIDR is FirstSysctlNetworkIPv4 with the secondary-network prefix.
+	FirstSysctlNetworkIPv4CIDR = FirstSysctlNetworkIPv4 + "/24"
+	// SecondSysctlNetworkIPv4CIDR is SecondSysctlNetworkIPv4 with the secondary-network prefix.
+	SecondSysctlNetworkIPv4CIDR = SecondSysctlNetworkIPv4 + "/24"
 	// AllFlagsSysctlPluginConfig contains all valid interface-level sysctl flags.
 	AllFlagsSysctlPluginConfig = map[string]string{
 		"net.ipv4.conf.IFNAME.accept_redirects":        "0",
@@ -68,6 +80,15 @@ var (
 	}
 	// GlobalSysctlFlag is a global kernel sysctl that is not permitted via the tuning CNI.
 	GlobalSysctlFlag = "kernel.shm_rmid_forced"
+	// TCPFastopenSysctlFlag is a network-wide sysctl that is not permitted via the tuning CNI.
+	TCPFastopenSysctlFlag = "net.ipv4.tcp_fastopen"
+	// MultipleFlagsSysctl contains multiple valid interface-level sysctl flags.
+	MultipleFlagsSysctl = map[string]string{
+		"net.ipv4.conf.IFNAME.accept_redirects":    "0",
+		"net.ipv4.conf.IFNAME.accept_source_route": "0",
+		"net.ipv4.conf.IFNAME.disable_policy":      "1",
+		"net.ipv4.conf.IFNAME.secure_redirects":    "0",
+	}
 	// SingleSysctlFlag sets accept_redirects=0 on the pod interface.
 	SingleSysctlFlag = map[string]string{
 		"net.ipv4.conf.IFNAME.accept_redirects": "0",

--- a/tests/cnf/core/network/cni/tests/sysctl/api.go
+++ b/tests/cnf/core/network/cni/tests/sysctl/api.go
@@ -1,13 +1,15 @@
 package tests
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/cni/internal/tsparams"
 )
 
-var _ = Describe("CNF Sysctl API", Ordered, Label(tsparams.LabelSysctlTestCases), ContinueOnFailure, func() {
+var _ = Describe("CNF Sysctl", Ordered, Label(tsparams.LabelSysctlTestCases), ContinueOnFailure, func() {
 	var validMacVlanInterfaces []nodeInterface
 
 	BeforeAll(func() {
@@ -35,10 +37,108 @@ var _ = Describe("CNF Sysctl API", Ordered, Label(tsparams.LabelSysctlTestCases)
 				pod.StaticIPAnnotationWithNamespace(
 					tsparams.FirstSysctlNetworkName,
 					tsparams.TestNamespaceName,
-					[]string{tsparams.ClientIPv4CIDR}))
+					[]string{tsparams.FirstSysctlNetworkIPv4CIDR}))
 
 			By("Wait until sysctl failed event")
 			waitUntilEventListContainsSysctlFailedCreatePodSandBoxMessage(tsparams.GlobalSysctlFlag)
+		})
+
+		It("one NAD, forward interface level duplicated flags", reportxml.ID("50346"), func() {
+			By("Define and create NAD with duplicated sysctl flag")
+
+			createSysctlTuningNadWithDuplicatedKernelArg(
+				tsparams.FirstSysctlNetworkName,
+				validMacVlanInterfaces[0].Name,
+				tsparams.AllFlagsSysctlPluginConfig)
+
+			By("Define and create pod")
+
+			runningPod := defineCreatePodWithNetworksAndWaitUntilRunning(
+				pod.StaticIPAnnotationWithNamespace(
+					tsparams.FirstSysctlNetworkName,
+					tsparams.TestNamespaceName,
+					[]string{tsparams.FirstSysctlNetworkIPv4CIDR}))
+
+			By("Verify pod received expected sysctl configuration on secondary interface")
+			assertSysctlConfiguredOnPodInterface(
+				runningPod, tsparams.AllFlagsSysctlPluginConfig, tsparams.MultusFirstInterfaceName)
+		})
+	})
+
+	Context("pod multiple secondary interfaces,", func() {
+		It("two NADs, Forward all valid interface level flags to one interface and multiple flags to the "+
+			"second interface with one general network kernel flag", reportxml.ID("50432"), func() {
+			By("Define and create NAD with all valid interface level flags")
+			createSysctlTuningNad(
+				tsparams.FirstSysctlNetworkName,
+				tsparams.AllFlagsSysctlPluginConfig,
+				validMacVlanInterfaces[0].Name)
+
+			By("Define and create NAD with multiple valid interface level flags plus single network kernel flag")
+
+			multipleFlagsSysctlOneGlobal := copySysctlMap(tsparams.MultipleFlagsSysctl)
+			multipleFlagsSysctlOneGlobal[tsparams.TCPFastopenSysctlFlag] = "0"
+			createSysctlTuningNad(
+				tsparams.SecondSysctlNetworkName,
+				multipleFlagsSysctlOneGlobal,
+				validMacVlanInterfaces[0].Name)
+
+			By("Define and create pod")
+			defineCreatePodWithNetworksAndWaitUntilPending(defineDualSysctlNetPodNetworks())
+
+			By("Wait until sysctl failed event")
+			waitUntilEventListContainsSysctlFailedCreatePodSandBoxMessage(tsparams.TCPFastopenSysctlFlag)
+		})
+
+		It("two NADs, try to inject static interface level flag for net1 interface using net2 NAD",
+			reportxml.ID("50434"), func() {
+				By("Define and create NAD")
+				createSysctlTuningNad(
+					tsparams.FirstSysctlNetworkName,
+					tsparams.SingleSysctlFlag,
+					validMacVlanInterfaces[0].Name)
+
+				By("Define and create NAD with static sysctl interface flag")
+
+				staticSysctlInterfaceKernelKey := fmt.Sprintf(
+					"net.ipv4.conf.%s.accept_redirects", tsparams.MultusFirstInterfaceName)
+				oneStaticInterfaceSysctlFlag := map[string]string{staticSysctlInterfaceKernelKey: "0"}
+				createSysctlTuningNad(
+					tsparams.SecondSysctlNetworkName,
+					oneStaticInterfaceSysctlFlag,
+					validMacVlanInterfaces[0].Name)
+
+				By("Define and create pod")
+				defineCreatePodWithNetworksAndWaitUntilPending(defineDualSysctlNetPodNetworks())
+
+				By("Wait until sysctl failed event")
+				waitUntilEventListContainsSysctlFailedCreatePodSandBoxMessage(staticSysctlInterfaceKernelKey)
+			})
+
+		It("two NADs, forward all valid flags to both interfaces and the second "+
+			"interface has static interface level duplicated flag", reportxml.ID("50435"), func() {
+			By("Define and create NAD with all sysctl flags")
+			createSysctlTuningNadWithDuplicatedKernelArg(
+				tsparams.FirstSysctlNetworkName,
+				validMacVlanInterfaces[0].Name,
+				tsparams.AllFlagsSysctlPluginConfig)
+
+			By("Define and create NAD with static interface duplicated sysctl flags")
+
+			staticSysctlInterfaceKernelKey := fmt.Sprintf(
+				"net.ipv4.conf.%s.accept_redirects", tsparams.MultusFirstInterfaceName)
+			allFlagsWithOneStaticInterfaceSysctlFlag := copySysctlMap(tsparams.AllFlagsSysctlPluginConfig)
+			allFlagsWithOneStaticInterfaceSysctlFlag[staticSysctlInterfaceKernelKey] = "0"
+			createSysctlTuningNadWithDuplicatedKernelArg(
+				tsparams.SecondSysctlNetworkName,
+				validMacVlanInterfaces[0].Name,
+				allFlagsWithOneStaticInterfaceSysctlFlag)
+
+			By("Define and create pod")
+			defineCreatePodWithNetworksAndWaitUntilPending(defineDualSysctlNetPodNetworks())
+
+			By("Wait until sysctl failed event")
+			waitUntilEventListContainsSysctlFailedCreatePodSandBoxMessage(staticSysctlInterfaceKernelKey)
 		})
 	})
 })

--- a/tests/cnf/core/network/cni/tests/sysctl/common.go
+++ b/tests/cnf/core/network/cni/tests/sysctl/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -219,6 +220,94 @@ func createSysctlTuningNad(nadName string, sysctlConfig map[string]string, macVl
 	assertSysctlNADConfig(nadName, macVlanIf, true, sysctlConfig)
 }
 
+func marshalSysctlTuningNadConfig(nadName string, sysctlConfig map[string]string, macVlanIf string) (string, error) {
+	plugins := []nad.Plugin{
+		{
+			Type:   "macvlan",
+			Master: macVlanIf,
+			Mode:   "bridge",
+			Ipam:   nad.IPAMStatic(),
+		},
+		*nad.TuningSysctlPlugin(false, sysctlConfig),
+	}
+
+	pluginsConfig := nad.MasterPlugin{
+		CniVersion: "0.4.0",
+		Name:       nadName,
+		Plugins:    &plugins,
+	}
+
+	configJSON, err := json.Marshal(pluginsConfig)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal sysctl NAD %s config: %w", nadName, err)
+	}
+
+	return string(configJSON), nil
+}
+
+// createSysctlTuningNadWithDuplicatedKernelArg creates a tuning NAD with one duplicated sysctl
+// key in the raw JSON config and returns the duplicated sysctl key.
+func createSysctlTuningNadWithDuplicatedKernelArg(
+	nadName, macVlanIf string, sysctlConfig map[string]string) string {
+	configJSON, err := marshalSysctlTuningNadConfig(nadName, sysctlConfig, macVlanIf)
+	Expect(err).ToNot(HaveOccurred(), "Failed to marshal sysctl NAD config")
+
+	sysctlKey, jsonFragment := prepDuplicatedSysctlConfig(sysctlConfig)
+	dupConfigJSON := strings.Replace(
+		configJSON, jsonFragment, fmt.Sprintf("%s,%s", jsonFragment, jsonFragment), 1)
+
+	builder := nad.NewBuilder(APIClient, nadName, tsparams.TestNamespaceName)
+	Expect(builder).NotTo(BeNil(), "Failed to initialize NAD builder for %s", nadName)
+	builder.Definition.Spec.Config = dupConfigJSON
+
+	_, err = builder.Create()
+	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to create duplicated sysctl NAD %s", nadName))
+
+	assertSysctlNADConfigContainsDuplicatedKernelArg(nadName, sysctlConfig)
+	assertSysctlNADConfig(nadName, macVlanIf, true, sysctlConfig)
+
+	return sysctlKey
+}
+
+func assertSysctlNADConfigContainsDuplicatedKernelArg(nadName string, sysctlConfig map[string]string) {
+	By(fmt.Sprintf("Verifying NAD %s Spec.Config contains duplicated sysctl key in raw JSON", nadName))
+
+	sysctlKey, jsonFragment := prepDuplicatedSysctlConfig(sysctlConfig)
+
+	pulled, err := nad.Pull(APIClient, nadName, tsparams.TestNamespaceName)
+	Expect(err).ToNot(HaveOccurred(), "Failed to pull NAD %s", nadName)
+	Expect(pulled.Definition.Spec.Config).NotTo(BeEmpty(), "NAD %s has empty Spec.Config", nadName)
+
+	Expect(strings.Count(pulled.Definition.Spec.Config, jsonFragment)).To(Equal(2),
+		"NAD %s expected sysctl key %q duplicated in raw JSON", nadName, sysctlKey)
+}
+
+func prepDuplicatedSysctlConfig(sysctlConfig map[string]string) (sysctlKey, jsonFragment string) {
+	keys := make([]string, 0, len(sysctlConfig))
+	for key := range sysctlConfig {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	sysctlKey = keys[0]
+	jsonFragment = fmt.Sprintf("\"%s\":\"%s\"", sysctlKey, sysctlConfig[sysctlKey])
+
+	return sysctlKey, jsonFragment
+}
+
+func defineDualSysctlNetPodNetworks() []*types.NetworkSelectionElement {
+	podNetworks := pod.StaticIPAnnotationWithNamespace(
+		tsparams.FirstSysctlNetworkName,
+		tsparams.TestNamespaceName,
+		[]string{tsparams.FirstSysctlNetworkIPv4CIDR})
+
+	return append(podNetworks, pod.StaticIPAnnotationWithNamespace(
+		tsparams.SecondSysctlNetworkName,
+		tsparams.TestNamespaceName,
+		[]string{tsparams.SecondSysctlNetworkIPv4CIDR})...)
+}
+
 // assertSysctlNADConfig pulls the NAD and unmarshals Spec.Config to verify CNI finished writing
 // a valid JSON object with the expected macvlan (and optional tuning) plugins.
 func assertSysctlNADConfig(
@@ -315,6 +404,26 @@ func defineCreatePodWithNetworksAndWaitUntilPending(podNetworks []*types.Network
 
 	err = createdPod.WaitUntilInStatus(corev1.PodPending, tsparams.DefaultTimeout)
 	Expect(err).ToNot(HaveOccurred(), "Pod is not in Pending phase")
+}
+
+func defineCreatePodWithNetworksAndWaitUntilRunning(
+	podNetworks []*types.NetworkSelectionElement) *pod.Builder {
+	Expect(sysctlWorkerNodeName).NotTo(BeEmpty(), "sysctl worker node was not discovered")
+
+	createdPod, err := pod.NewBuilder(
+		APIClient, "sysctl-running", tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer).
+		DefineOnNode(sysctlWorkerNodeName).
+		WithSecondaryNetwork(podNetworks).
+		CreateAndWaitUntilRunning(tsparams.DefaultTimeout)
+	Expect(err).ToNot(HaveOccurred(), "Failed to create pod with secondary networks")
+
+	return createdPod
+}
+
+func assertSysctlConfiguredOnPodInterface(
+	runningPod *pod.Builder, sysctlConfig map[string]string, interfaceName string) {
+	Expect(cmd.VerifySysctlKernelParametersConfiguredOnPodInterface(runningPod, sysctlConfig, interfaceName)).
+		To(Succeed(), "sysctl kernel params are not in expected state on interface %s", interfaceName)
 }
 
 func waitUntilEventListContainsSysctlFailedCreatePodSandBoxMessage(sysctlFlag string) {
@@ -468,17 +577,17 @@ func pingIPViaInterface(clientPod *pod.Builder, interfaceName, destIPAddr string
 }
 
 func cleanSysctlTestNamespace() {
-	By("Clean pods from the namespace")
+	By("Clean pods, NADs, and events from the namespace")
 
-	err := namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
-		tsparams.DefaultTimeout, pod.GetGVR())
-	Expect(err).ToNot(HaveOccurred(), "Failed to remove pods from test namespace")
+	cniNs, err := namespace.Pull(APIClient, tsparams.TestNamespaceName)
+	Expect(err).ToNot(HaveOccurred(), "Failed to pull test namespace")
 
-	By("Clean NADs from the namespace")
-
-	err = namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
-		tsparams.DefaultTimeout, nad.GetGVR())
-	Expect(err).ToNot(HaveOccurred(), "Failed to clean NetworkAttachmentDefinitions")
+	err = cniNs.CleanObjects(
+		tsparams.DefaultTimeout,
+		pod.GetGVR(),
+		nad.GetGVR(),
+		corev1.SchemeGroupVersion.WithResource("events"))
+	Expect(err).ToNot(HaveOccurred(), "Failed to clean test namespace")
 }
 
 func setHostIPForwarding(nodeName, interfaceName string, enabled bool) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for duplicate and conflicting network interface sysctl flags.
  * Added validation for static interface flags applied through incorrect or duplicate network configurations.
  * Added scenarios using multiple tuning networks, static IP assignments, and global kernel flags.
  * Added verification that invalid configurations produce the expected failure events.
  * Improved test consistency through deterministic configuration handling and comprehensive test-environment cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->