### PR TITLE
ocp sriov: add externally managed sriov tests

### DIFF
--- a/tests/ocp/sriov/internal/sriovocpenv/host.go
+++ b/tests/ocp/sriov/internal/sriovocpenv/host.go
@@ -1,0 +1,61 @@
+package sriovocpenv
+
+import (
+	"fmt"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/sriov/internal/ocpsriovinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/sriov/internal/tsparams"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+func execOnSriovConfigDaemon(nodeName, command string) error {
+	klog.V(90).Infof("Running command %q on sriov-network-config-daemon on node %s", command, nodeName)
+
+	pods, err := pod.List(APIClient, SriovOcpConfig.OcpSriovOperatorNamespace, metav1.ListOptions{
+		LabelSelector: "app=sriov-network-config-daemon",
+		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list config daemon pods on node %s: %w", nodeName, err)
+	}
+
+	if len(pods) == 0 {
+		return fmt.Errorf("failed to find config daemon pod on node %s", nodeName)
+	}
+
+	output, err := pods[0].ExecCommand([]string{"bash", "-c", command})
+	if err != nil {
+		return fmt.Errorf("failed to execute command on node %s: %s %w",
+			nodeName, output.String(), err)
+	}
+
+	return nil
+}
+
+// RunCommandOnHostNetworkPod runs a command on a privileged host-network pod scheduled on the given node.
+func RunCommandOnHostNetworkPod(nodeName, nsName, command string) (string, error) {
+	klog.V(90).Infof("Running command %s on the host network pod on node %s",
+		command, nodeName)
+
+	testPod, err := pod.NewBuilder(APIClient, "hostnetworkpod", nsName, SriovOcpConfig.OcpSriovTestContainer).
+		DefineOnNode(nodeName).WithPrivilegedFlag().WithHostNetwork().CreateAndWaitUntilRunning(tsparams.DefaultTimeout)
+	if err != nil {
+		return "", err
+	}
+
+	defer func() {
+		_, deleteErr := testPod.DeleteAndWait(tsparams.DefaultTimeout)
+		if deleteErr != nil {
+			klog.V(90).Infof("failed to delete hostnetwork pod %s: %v", testPod.Definition.Name, deleteErr)
+		}
+	}()
+
+	output, err := testPod.ExecCommand([]string{"/bin/bash", "-c", command})
+	if err != nil {
+		return "", err
+	}
+
+	return output.String(), nil
+}

--- a/tests/ocp/sriov/internal/sriovocpenv/mlx.go
+++ b/tests/ocp/sriov/internal/sriovocpenv/mlx.go
@@ -1,0 +1,59 @@
+package sriovocpenv
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/sriov"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/cluster"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/sriov/internal/ocpsriovinittools"
+)
+
+// IsMellanoxDevice reports whether the given interface uses the mlx5_core driver.
+func IsMellanoxDevice(intName, nodeName string) (bool, error) {
+	sriovNetworkState := sriov.NewNetworkNodeStateBuilder(APIClient, nodeName,
+		SriovOcpConfig.OcpSriovOperatorNamespace)
+
+	driverName, err := sriovNetworkState.GetDriverName(intName)
+	if err != nil {
+		return false, fmt.Errorf("failed to get driver name for interface %s on node %s: %w", intName, nodeName, err)
+	}
+
+	return driverName == "mlx5_core", nil
+}
+
+// ConfigureSriovMlnxFirmwareOnWorkersAndWaitMCP configures Mellanox SR-IOV firmware and waits for MCP stability.
+func ConfigureSriovMlnxFirmwareOnWorkersAndWaitMCP(
+	mcpTimeout time.Duration,
+	stableDuration time.Duration,
+	workerNodes []*nodes.Builder,
+	sriovInterfaceName string,
+	enableSriov bool,
+	numVfs int,
+) error {
+	for _, workerNode := range workerNodes {
+		sriovNetworkState := sriov.NewNetworkNodeStateBuilder(
+			APIClient, workerNode.Object.Name, SriovOcpConfig.OcpSriovOperatorNamespace)
+
+		pciAddress, err := sriovNetworkState.GetPciAddress(sriovInterfaceName)
+		if err != nil {
+			return fmt.Errorf("failed to get PCI address: %w", err)
+		}
+
+		mstconfigCmd := fmt.Sprintf("mstconfig -y -d %s set SRIOV_EN=%t NUM_OF_VFS=%d",
+			pciAddress, enableSriov, numVfs)
+
+		err = execOnSriovConfigDaemon(workerNode.Object.Name, mstconfigCmd)
+		if err != nil {
+			return fmt.Errorf("failed to configure Mellanox firmware on node %s: %w",
+				workerNode.Object.Name, err)
+		}
+
+		_ = execOnSriovConfigDaemon(workerNode.Object.Name, "chroot /host reboot")
+	}
+
+	time.Sleep(10 * time.Second)
+
+	return cluster.WaitForMcpStable(APIClient, mcpTimeout, stableDuration, SriovOcpConfig.MCPLabel)
+}

--- a/tests/ocp/sriov/internal/sriovocpenv/nmstate.go
+++ b/tests/ocp/sriov/internal/sriovocpenv/nmstate.go
@@ -1,0 +1,183 @@
+package sriovocpenv
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	nmstateShared "github.com/nmstate/kubernetes-nmstate/api/shared"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/daemonset"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nmstate"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/sriov"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/sriov/internal/ocpsriovinittools"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// NmstateName is the default NMState instance name.
+	NmstateName = "nmstate"
+	// NmstateHandlerDsName is the NMState handler daemonset name.
+	NmstateHandlerDsName = "nmstate-handler"
+	// NmstateWebhookDeploymentName is the NMState webhook deployment name.
+	NmstateWebhookDeploymentName = "nmstate-webhook"
+	// NmstateOperatorNamespace is the openshift-nmstate operator namespace.
+	NmstateOperatorNamespace = "openshift-nmstate"
+)
+
+// IsNMStateOperatorInstalled reports whether the NMState operator namespace exists.
+func IsNMStateOperatorInstalled() bool {
+	_, err := namespace.Pull(APIClient, NmstateOperatorNamespace)
+
+	return err == nil
+}
+
+// CreateNewNMStateAndWaitUntilItsRunning creates a new NMState instance and waits until it is ready.
+func CreateNewNMStateAndWaitUntilItsRunning(timeout time.Duration) error {
+	nmstateInstance, err := nmstate.PullNMstate(APIClient, NmstateName)
+	if err == nil {
+		_, err = nmstateInstance.Delete()
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err = nmstate.NewBuilder(APIClient, NmstateName).Create()
+	if err != nil {
+		return err
+	}
+
+	return isNMStateDeployedAndReady(timeout)
+}
+
+func isNMStateDeployedAndReady(timeout time.Duration) error {
+	var (
+		nmstateHandlerDs         *daemonset.Builder
+		nmstateWebhookDeployment *deployment.Builder
+		err                      error
+	)
+
+	err = wait.PollUntilContextTimeout(
+		context.TODO(), 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+			nmstateHandlerDs, err = daemonset.Pull(
+				APIClient, NmstateHandlerDsName, NmstateOperatorNamespace)
+			if err != nil {
+				return false, nil
+			}
+
+			nmstateWebhookDeployment, err = deployment.Pull(
+				APIClient, NmstateWebhookDeploymentName, NmstateOperatorNamespace)
+			if err != nil {
+				return false, nil
+			}
+
+			return true, nil
+		})
+	if err != nil {
+		return err
+	}
+
+	time.Sleep(10 * time.Second)
+
+	if !nmstateHandlerDs.IsReady(timeout) {
+		return fmt.Errorf("nmstate handler daemonset is not ready")
+	}
+
+	if !nmstateWebhookDeployment.IsReady(timeout) {
+		return fmt.Errorf("nmstate webhook deployment is not ready")
+	}
+
+	return nil
+}
+
+// ConfigureVFsAndWaitUntilItsConfigured creates an NMState policy with VF configuration and waits until applied.
+func ConfigureVFsAndWaitUntilItsConfigured(
+	policyName string,
+	sriovInterfaceName string,
+	nodeLabel map[string]string,
+	numberOfVFs uint8,
+	timeout time.Duration) error {
+	nmstatePolicy := nmstate.NewPolicyBuilder(
+		APIClient, policyName, nodeLabel).WithInterfaceAndVFs(sriovInterfaceName, numberOfVFs)
+
+	nmstatePolicy, err := nmstatePolicy.Create()
+	if err != nil {
+		return err
+	}
+
+	return nmstatePolicy.WaitUntilCondition(nmstateShared.NodeNetworkConfigurationPolicyConditionAvailable, timeout)
+}
+
+// UpdatePolicyAndWaitUntilItsAvailable updates an NMState policy and waits until it is available.
+func UpdatePolicyAndWaitUntilItsAvailable(timeout time.Duration, nmstatePolicy *nmstate.PolicyBuilder) error {
+	nmstatePolicy, err := nmstatePolicy.Update(true)
+	if err != nil {
+		return err
+	}
+
+	err = nmstatePolicy.WaitUntilCondition(nmstateShared.NodeNetworkConfigurationPolicyConditionProgressing, timeout)
+	if err != nil {
+		return err
+	}
+
+	return nmstatePolicy.WaitUntilCondition(nmstateShared.NodeNetworkConfigurationPolicyConditionAvailable, timeout)
+}
+
+// AreVFsCreated verifies that the specified number of VFs has been created under the given interface.
+func AreVFsCreated(nodeName, sriovInterfaceName string, numberVFs int) error {
+	klog.V(90).Infof("Verifying that node %s has %d VFs under interface %s",
+		nodeName, numberVFs, sriovInterfaceName)
+
+	sriovNetworkState := sriov.NewNetworkNodeStateBuilder(
+		APIClient, nodeName, SriovOcpConfig.OcpSriovOperatorNamespace)
+
+	if err := sriovNetworkState.Discover(); err != nil {
+		return err
+	}
+
+	numVFs, err := sriovNetworkState.GetNumVFs(sriovInterfaceName)
+	if err != nil {
+		return err
+	}
+
+	if numVFs != numberVFs {
+		return fmt.Errorf("not all VFs are configured, expected number: %d; actual number: %d", numberVFs, numVFs)
+	}
+
+	return nil
+}
+
+// WaitUntilVfsCreated waits until the expected number of VFs exist on all given nodes.
+func WaitUntilVfsCreated(
+	nodeList []*nodes.Builder,
+	sriovInterfaceName string,
+	numberOfVfs int,
+	timeout time.Duration,
+) error {
+	for _, node := range nodeList {
+		err := wait.PollUntilContextTimeout(
+			context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+				sriovNetworkState := sriov.NewNetworkNodeStateBuilder(
+					APIClient, node.Object.Name, SriovOcpConfig.OcpSriovOperatorNamespace)
+
+				if discoverErr := sriovNetworkState.Discover(); discoverErr != nil {
+					return false, nil
+				}
+
+				sriovNumVfs, numErr := sriovNetworkState.GetNumVFs(sriovInterfaceName)
+				if numErr != nil {
+					return false, nil
+				}
+
+				return sriovNumVfs == numberOfVfs, nil
+			})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/tests/ocp/sriov/internal/tsparams/consts.go
+++ b/tests/ocp/sriov/internal/tsparams/consts.go
@@ -32,6 +32,10 @@ const (
 	LabelParallelDrainingTestCases = "paralleldraining"
 	// LabelQinQTestCases represents QinQ label that can be used for test cases selection.
 	LabelQinQTestCases = "qinq"
+	// LabelExternallyManagedTestCases represents ExternallyManaged label that can be used for test cases selection.
+	LabelExternallyManagedTestCases = "externallymanaged"
+	// SriovResourceNameExManagedTrue is the SR-IOV policy and network name for ExternallyManaged tests.
+	SriovResourceNameExManagedTrue = "extmanaged"
 
 	// MCOWaitTimeout represent timeout for mco operations.
 	MCOWaitTimeout = 35 * time.Minute

--- a/tests/ocp/sriov/tests/externallymanaged.go
+++ b/tests/ocp/sriov/tests/externallymanaged.go
@@ -1,0 +1,461 @@
+package tests
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/sriov"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/sriovoperator"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/sriov/internal/ocpsriovinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/sriov/internal/sriovenv"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/sriov/internal/sriovocpenv"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/sriov/internal/tsparams"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+var (
+	vfZeroLineRegexp = regexp.MustCompile(`(?m)^\s*vf 0\b.*$`)
+	vlanRegexp       = regexp.MustCompile(`\bvlan (\d+)`)
+	maxTxRateRegexp  = regexp.MustCompile(`\bmax_tx_rate (\d+)`)
+)
+
+const (
+	ipv4Family   = "IPv4"
+	ipv6Family   = "IPv6"
+	dualIPFamily = "dual"
+)
+
+var _ = Describe("ExternallyManaged", Ordered, Label(tsparams.LabelExternallyManagedTestCases),
+	ContinueOnFailure, func() {
+		Context("General", Label("generalexcreated"), func() {
+			var (
+				sriovInterfacesUnderTest []string
+				workerNodeList           []*nodes.Builder
+				vfNum                    int
+			)
+
+			BeforeAll(func() {
+				By("Verifying if SR-IOV tests can be executed on given cluster")
+
+				err := sriovocpenv.DoesClusterHaveEnoughNodes(1, 1)
+				if err != nil {
+					Skip(fmt.Sprintf(
+						"given cluster is not suitable for SR-IOV tests because it doesn't have enough nodes: %s", err.Error()))
+				}
+
+				vfNum, err = SriovOcpConfig.GetVFNum()
+				Expect(err).ToNot(HaveOccurred(), "Failed to get VF number")
+
+				By("Validating SR-IOV interfaces")
+
+				workerNodeList, err = nodes.List(APIClient,
+					metav1.ListOptions{LabelSelector: labels.Set(SriovOcpConfig.WorkerLabelMap).String()})
+				Expect(err).ToNot(HaveOccurred(), "Failed to discover worker nodes")
+
+				Expect(sriovocpenv.ValidateSriovInterfaces(workerNodeList, 1)).ToNot(HaveOccurred(),
+					"Failed to get required SR-IOV interfaces")
+
+				sriovInterfacesUnderTest, err = SriovOcpConfig.GetSriovInterfaces(1)
+				Expect(err).ToNot(HaveOccurred(), "Failed to retrieve SR-IOV interfaces for testing")
+
+				isMellanox, err := sriovocpenv.IsMellanoxDevice(
+					sriovInterfacesUnderTest[0], workerNodeList[0].Object.Name,
+				)
+				Expect(err).ToNot(HaveOccurred(), "Failed to check if interface is a Mellanox device")
+
+				if isMellanox {
+					err = sriovocpenv.ConfigureSriovMlnxFirmwareOnWorkersAndWaitMCP(
+						tsparams.MCOWaitTimeout,
+						time.Minute,
+						workerNodeList,
+						sriovInterfacesUnderTest[0],
+						true,
+						vfNum,
+					)
+					Expect(err).ToNot(HaveOccurred(), "Failed to configure Mellanox firmware")
+				}
+
+				By("Creating SR-IOV VFs on workers")
+
+				err = configureVFsOnWorkersAndWait(
+					workerNodeList,
+					sriovInterfacesUnderTest[0],
+					vfNum)
+				Expect(err).ToNot(HaveOccurred(), "Failed to create VFs on workers")
+
+				By("Configure SR-IOV with flag ExternallyManaged true")
+				createExternallyManagedSriovConfiguration(
+					tsparams.SriovResourceNameExManagedTrue, sriovInterfacesUnderTest[0], vfNum)
+			})
+
+			AfterAll(func() {
+				if len(workerNodeList) == 0 || len(sriovInterfacesUnderTest) == 0 {
+					return
+				}
+
+				By("Removing SR-IOV configuration")
+
+				err := sriovoperator.RemoveSriovConfigurationAndWaitForSriovAndMCPStable(
+					APIClient,
+					SriovOcpConfig.WorkerLabelEnvVar,
+					SriovOcpConfig.OcpSriovOperatorNamespace,
+					tsparams.MCOWaitTimeout,
+					tsparams.DefaultTimeout)
+				Expect(err).ToNot(HaveOccurred(), "Failed to remove SR-IOV configuration")
+
+				By("Verifying that VFs still exist")
+
+				err = sriovocpenv.WaitUntilVfsCreated(
+					workerNodeList,
+					sriovInterfacesUnderTest[0], vfNum, tsparams.DefaultTimeout,
+				)
+				Expect(err).ToNot(HaveOccurred(), "Unexpected amount of VF")
+
+				err = sriovocpenv.AreVFsCreated(workerNodeList[0].Object.Name, sriovInterfacesUnderTest[0], vfNum)
+				Expect(err).ToNot(HaveOccurred(), "VFs were removed during the test")
+
+				By("Removing SR-IOV VFs on workers")
+
+				err = configureVFsOnWorkersAndWait(
+					workerNodeList,
+					sriovInterfacesUnderTest[0],
+					0)
+				Expect(err).ToNot(HaveOccurred(), "Failed to remove VFs on workers")
+			})
+
+			AfterEach(func() {
+				By("Cleaning test namespace")
+
+				err := namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
+					tsparams.DefaultTimeout, pod.GetGVR())
+
+				Expect(err).ToNot(HaveOccurred(), "Failed to clean test namespace")
+			})
+
+			DescribeTable("Verifying connectivity with different IP protocols", reportxml.ID("63527"),
+				func(ipStack string) {
+					By("Verifying cluster has enough workers")
+
+					err := sriovocpenv.DoesClusterHaveEnoughNodes(1, 2)
+					if err != nil {
+						Skip(fmt.Sprintf("Skipping test - cluster doesn't have enough workers: %v", err))
+					}
+
+					By("Validating SR-IOV interfaces on 2 workers")
+					Expect(sriovocpenv.ValidateSriovInterfaces(workerNodeList, 2)).ToNot(HaveOccurred(),
+						"Failed to get required SR-IOV interfaces on 2 workers")
+
+					_, err = SriovOcpConfig.GetSriovInterfaces(2)
+					Expect(err).ToNot(HaveOccurred(), "Failed to retrieve SR-IOV interfaces for testing")
+
+					By("Defining test parameters")
+
+					clientIPs, serverIPs, err := defineExternallyManagedIterationParams(ipStack)
+					Expect(err).ToNot(HaveOccurred(), "Failed to define test parameters")
+
+					By("Creating test pods and checking connectivity")
+
+					err = sriovocpenv.CreatePodsAndRunTraffic(workerNodeList[0].Object.Name, workerNodeList[1].Object.Name,
+						tsparams.SriovResourceNameExManagedTrue, tsparams.SriovResourceNameExManagedTrue, "", "",
+						clientIPs, serverIPs)
+					Expect(err).ToNot(HaveOccurred(), "Failed to test connectivity between test pods")
+				},
+
+				Entry("", ipv4Family, reportxml.SetProperty("IPStack", ipv4Family)),
+				Entry("", ipv6Family, reportxml.SetProperty("IPStack", ipv6Family)),
+				Entry("", dualIPFamily, reportxml.SetProperty("IPStack", dualIPFamily)),
+			)
+
+			It("Recreate VFs when SR-IOV policy is applied", reportxml.ID("63533"), func() {
+				By("Creating test pods and checking connectivity")
+
+				err := sriovocpenv.CreatePodsAndRunTraffic(workerNodeList[0].Object.Name, workerNodeList[0].Object.Name,
+					tsparams.SriovResourceNameExManagedTrue, tsparams.SriovResourceNameExManagedTrue,
+					tsparams.ClientMacAddress, tsparams.ServerMacAddress,
+					[]string{tsparams.ClientIPv4IPAddress}, []string{tsparams.ServerIPv4IPAddress})
+				Expect(err).ToNot(HaveOccurred(), "Failed to test connectivity between test pods")
+
+				By("Removing created SR-IOV VFs on workers")
+
+				err = configureVFsOnWorkersAndWait(
+					workerNodeList,
+					sriovInterfacesUnderTest[0],
+					0)
+				Expect(err).ToNot(HaveOccurred(), "Failed to remove VFs on workers")
+
+				By("Removing all test pods")
+
+				err = namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
+					tsparams.DefaultTimeout, pod.GetGVR())
+				Expect(err).ToNot(HaveOccurred(), "Failed to clean all test pods")
+
+				By("Creating SR-IOV VFs again on workers")
+
+				err = configureVFsOnWorkersAndWait(
+					workerNodeList,
+					sriovInterfacesUnderTest[0],
+					vfNum)
+				Expect(err).ToNot(HaveOccurred(), "Failed to recreate VFs on workers")
+
+				By("Re-create test pods and verify connectivity after recreating the VFs")
+
+				err = sriovocpenv.CreatePodsAndRunTraffic(workerNodeList[0].Object.Name, workerNodeList[0].Object.Name,
+					tsparams.SriovResourceNameExManagedTrue, tsparams.SriovResourceNameExManagedTrue,
+					tsparams.ClientMacAddress, tsparams.ServerMacAddress,
+					[]string{tsparams.ClientIPv4IPAddress}, []string{tsparams.ServerIPv4IPAddress})
+				Expect(err).ToNot(HaveOccurred(), "Failed to test connectivity between test pods")
+			})
+
+			It("SR-IOV network with options", reportxml.ID("63534"), func() {
+				By("Collecting default MaxTxRate and Vlan values")
+
+				defaultMaxTxRate, defaultVlanID := getVlanIDAndMaxTxRateForVf(workerNodeList[0].Object.Name,
+					sriovInterfacesUnderTest[0])
+
+				By("Updating Vlan and MaxTxRate configurations in the SriovNetwork")
+
+				newMaxTxRate := defaultMaxTxRate + 1
+				newVlanID := defaultVlanID + 1
+				sriovNetwork, err := sriov.PullNetwork(APIClient, tsparams.SriovResourceNameExManagedTrue,
+					SriovOcpConfig.OcpSriovOperatorNamespace)
+				Expect(err).ToNot(HaveOccurred(), "Failed to pull SR-IOV network object")
+				_, err = sriovNetwork.WithMaxTxRate(uint16(newMaxTxRate)).WithVLAN(uint16(newVlanID)).Update(false)
+				Expect(err).ToNot(HaveOccurred(), "Failed to update SR-IOV network with new configuration")
+
+				By("Creating test pods and checking connectivity")
+
+				err = sriovocpenv.CreatePodsAndRunTraffic(workerNodeList[0].Object.Name, workerNodeList[0].Object.Name,
+					tsparams.SriovResourceNameExManagedTrue, tsparams.SriovResourceNameExManagedTrue,
+					tsparams.ClientMacAddress, tsparams.ServerMacAddress,
+					[]string{tsparams.ClientIPv4IPAddress}, []string{tsparams.ServerIPv4IPAddress})
+				Expect(err).ToNot(HaveOccurred(), "Failed to test connectivity between test pods")
+
+				By("Checking that VF configured with new VLAN and MaxTxRate values")
+				Eventually(func() []int {
+					currentmaxTxRate, currentVlanID := getVlanIDAndMaxTxRateForVf(workerNodeList[0].Object.Name,
+						sriovInterfacesUnderTest[0])
+
+					return []int{currentmaxTxRate, currentVlanID}
+				}, time.Minute, tsparams.RetryInterval).Should(Equal([]int{newMaxTxRate, newVlanID}),
+					"MaxTxRate and VlanId have been not configured properly")
+
+				By("Removing all test pods")
+
+				err = namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
+					tsparams.DefaultTimeout, pod.GetGVR())
+				Expect(err).ToNot(HaveOccurred(), "Failed to clean all test pods")
+
+				By("Checking that VF has initial configuration")
+
+				Eventually(func() []int {
+					currentmaxTxRate, currentVlanID := getVlanIDAndMaxTxRateForVf(workerNodeList[0].Object.Name,
+						sriovInterfacesUnderTest[0])
+
+					return []int{currentmaxTxRate, currentVlanID}
+				}, tsparams.DefaultTimeout, tsparams.RetryInterval).
+					Should(Equal([]int{defaultMaxTxRate, defaultVlanID}),
+						"MaxTxRate and VlanId configuration have not been reverted to the initial one")
+
+				By("Removing SR-IOV configuration")
+
+				err = sriovoperator.RemoveSriovConfigurationAndWaitForSriovAndMCPStable(
+					APIClient,
+					SriovOcpConfig.WorkerLabelEnvVar,
+					SriovOcpConfig.OcpSriovOperatorNamespace,
+					tsparams.MCOWaitTimeout,
+					tsparams.DefaultTimeout)
+				Expect(err).ToNot(HaveOccurred(), "Failed to remove SR-IOV configuration")
+
+				By("Checking that VF has initial configuration")
+				Eventually(func() []int {
+					currentmaxTxRate, currentVlanID := getVlanIDAndMaxTxRateForVf(workerNodeList[0].Object.Name,
+						sriovInterfacesUnderTest[0])
+
+					return []int{currentmaxTxRate, currentVlanID}
+				}, time.Minute, tsparams.RetryInterval).Should(Equal([]int{defaultMaxTxRate, defaultVlanID}),
+					"MaxTxRate and VlanId configurations have not been reverted to the initial one")
+
+				By("Configure SR-IOV with flag ExternallyManaged true")
+				createExternallyManagedSriovConfiguration(
+					tsparams.SriovResourceNameExManagedTrue, sriovInterfacesUnderTest[0], vfNum)
+			})
+
+			It("SR-IOV operator removal", reportxml.ID("63537"), func() {
+				By("Creating test pods and checking connectivity")
+
+				err := sriovocpenv.CreatePodsAndRunTraffic(workerNodeList[0].Object.Name, workerNodeList[0].Object.Name,
+					tsparams.SriovResourceNameExManagedTrue, tsparams.SriovResourceNameExManagedTrue, "", "",
+					[]string{tsparams.ClientIPv4IPAddress}, []string{tsparams.ServerIPv4IPAddress})
+				Expect(err).ToNot(HaveOccurred(), "Failed to test connectivity between test pods")
+
+				By("Collecting info about installed SR-IOV operator")
+
+				sriovNamespace, sriovOperatorgroup, sriovSubscription := collectingInfoSriovOperator()
+
+				By("Removing SR-IOV operator")
+				removeSriovOperator(sriovNamespace)
+				Expect(
+					sriovoperator.IsSriovDeployed(APIClient, SriovOcpConfig.OcpSriovOperatorNamespace)).To(HaveOccurred(),
+					"SR-IOV operator is not removed")
+
+				By("Installing SR-IOV operator")
+				installSriovOperator(sriovNamespace, sriovOperatorgroup, sriovSubscription)
+				Eventually(func() error {
+					return sriovoperator.IsSriovDeployed(APIClient, SriovOcpConfig.OcpSriovOperatorNamespace)
+				}, time.Minute, tsparams.RetryInterval).
+					ShouldNot(HaveOccurred(), "SR-IOV operator is not installed")
+
+				By("Verifying that VFs still exist after SR-IOV operator reinstallation")
+
+				err = sriovocpenv.AreVFsCreated(workerNodeList[0].Object.Name, sriovInterfacesUnderTest[0], vfNum)
+				Expect(err).ToNot(HaveOccurred(), "VFs were removed after SR-IOV operator reinstallation")
+
+				By("Configure SR-IOV with flag ExternallyManaged true")
+				createExternallyManagedSriovConfiguration(
+					tsparams.SriovResourceNameExManagedTrue, sriovInterfacesUnderTest[0], vfNum)
+
+				By("Recreating test pods and checking connectivity")
+
+				err = namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
+					tsparams.DefaultTimeout, pod.GetGVR())
+				Expect(err).ToNot(HaveOccurred(), "Failed to remove test pods")
+
+				err = sriovocpenv.CreatePodsAndRunTraffic(workerNodeList[0].Object.Name, workerNodeList[0].Object.Name,
+					tsparams.SriovResourceNameExManagedTrue, tsparams.SriovResourceNameExManagedTrue, "", "",
+					[]string{tsparams.ClientIPv4IPAddress}, []string{tsparams.ServerIPv4IPAddress})
+				Expect(err).ToNot(HaveOccurred(), "Failed to test connectivity between test pods")
+			})
+		})
+	})
+
+func createExternallyManagedSriovConfiguration(sriovAndResName, sriovInterfaceName string, numVfs int) {
+	By("Creating SR-IOV policy with flag ExternallyManaged true")
+
+	err := createSriovPolicyWithExternallyManaged(sriovAndResName, numVfs, []string{sriovInterfaceName + "#0-1"})
+	Expect(err).ToNot(HaveOccurred(), "Failed to create sriov policy")
+
+	err = sriovenv.CreateSriovNetwork(sriovAndResName, sriovAndResName, tsparams.TestNamespaceName)
+	Expect(err).ToNot(HaveOccurred(), "Failed to create sriov network")
+}
+
+func createSriovPolicyWithExternallyManaged(sriovAndResName string, numVfs int, pfDevices []string) error {
+	sriovPolicy := sriov.NewPolicyBuilder(APIClient, sriovAndResName, SriovOcpConfig.OcpSriovOperatorNamespace,
+		sriovAndResName,
+		numVfs, pfDevices, SriovOcpConfig.WorkerLabelMap).WithExternallyManaged(true)
+
+	err := sriovoperator.CreateSriovPolicyAndWaitUntilItsApplied(
+		APIClient,
+		SriovOcpConfig.WorkerLabelEnvVar,
+		SriovOcpConfig.OcpSriovOperatorNamespace,
+		sriovPolicy,
+		tsparams.MCOWaitTimeout,
+		tsparams.DefaultStableDuration)
+	if err != nil {
+		return fmt.Errorf("failed to create sriov policy: %w", err)
+	}
+
+	return nil
+}
+
+func configureVFsOnWorkersAndWait(
+	workerNodes []*nodes.Builder,
+	sriovInterfaceName string,
+	numVfs int,
+) error {
+	err := setSriovNumVfsOnWorkers(workerNodes, sriovInterfaceName, numVfs)
+	if err != nil {
+		return err
+	}
+
+	return sriovocpenv.WaitUntilVfsCreated(workerNodes, sriovInterfaceName, numVfs, tsparams.DefaultTimeout)
+}
+
+func setSriovNumVfsOnWorkers(workerNodes []*nodes.Builder, sriovInterfaceName string, numVfs int) error {
+	for _, workerNode := range workerNodes {
+		cmd := fmt.Sprintf("echo %d > /host/sys/class/net/%s/device/sriov_numvfs",
+			numVfs, sriovInterfaceName)
+		if numVfs > 0 {
+			cmd = fmt.Sprintf(
+				"echo 0 > /host/sys/class/net/%s/device/sriov_numvfs; echo %d > /host/sys/class/net/%s/device/sriov_numvfs",
+				sriovInterfaceName, numVfs, sriovInterfaceName)
+		}
+
+		if _, err := execOnSriovConfigDaemon(workerNode.Object.Name, cmd); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func execOnSriovConfigDaemon(nodeName, command string) (string, error) {
+	pods, err := pod.List(APIClient, SriovOcpConfig.OcpSriovOperatorNamespace, metav1.ListOptions{
+		LabelSelector: "app=sriov-network-config-daemon",
+		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to list config daemon pods on node %s: %w", nodeName, err)
+	}
+
+	if len(pods) == 0 {
+		return "", fmt.Errorf("failed to find config daemon pod on node %s", nodeName)
+	}
+
+	output, err := pods[0].ExecCommand([]string{"bash", "-c", command})
+	if err != nil {
+		return "", fmt.Errorf("failed to execute command on node %s: %s %w",
+			nodeName, output.String(), err)
+	}
+
+	return output.String(), nil
+}
+
+func getVlanIDAndMaxTxRateForVf(nodeName, sriovInterfaceName string) (maxTxRate, vlanID int) {
+	output, err := execOnSriovConfigDaemon(nodeName, fmt.Sprintf("ip link show %s", sriovInterfaceName))
+	Expect(err).ToNot(HaveOccurred(), "Failed to get VLAN and MaxTxRate for VF")
+
+	vfLine := vfZeroLineRegexp.FindString(output)
+	Expect(vfLine).ToNot(BeEmpty(), "vf 0 not found on interface %s node %s", sriovInterfaceName, nodeName)
+
+	return parseIntFromRegexp(maxTxRateRegexp, vfLine), parseIntFromRegexp(vlanRegexp, vfLine)
+}
+
+func parseIntFromRegexp(re *regexp.Regexp, input string) int {
+	match := re.FindStringSubmatch(input)
+	if len(match) < 2 {
+		return 0
+	}
+
+	value, err := strconv.Atoi(strings.TrimSpace(match[1]))
+	if err != nil {
+		return 0
+	}
+
+	return value
+}
+
+func defineExternallyManagedIterationParams(ipFamily string) (clientIPs, serverIPs []string, err error) {
+	switch ipFamily {
+	case ipv4Family:
+		return []string{tsparams.ClientIPv4IPAddress}, []string{tsparams.ServerIPv4IPAddress}, nil
+	case ipv6Family:
+		return []string{tsparams.ClientIPv6IPAddress}, []string{tsparams.ServerIPv6IPAddress}, nil
+	case dualIPFamily:
+		return []string{tsparams.ClientIPv4IPAddress, tsparams.ClientIPv6IPAddress},
+			[]string{tsparams.ServerIPv4IPAddress, tsparams.ServerIPv6IPAddress}, nil
+	}
+
+	return nil, nil, fmt.Errorf(
+		"ipStack parameter %s is invalid; allowed values are %s, %s, %s ",
+		ipFamily, ipv4Family, ipv6Family, dualIPFamily)
+}

--- a/tests/ocp/sriov/tests/qinq.go
+++ b/tests/ocp/sriov/tests/qinq.go
@@ -8,10 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	nmstateShared "github.com/nmstate/kubernetes-nmstate/api/shared"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/configmap"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/daemonset"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nad"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nmstate"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
@@ -37,9 +34,8 @@ import (
 )
 
 const (
-	sriovAndResourceNameExManagedTrue = "extmanaged"
-	logLevelDebug                     = "debug"
-	mlxVendorID                       = "15b3"
+	logLevelDebug = "debug"
+	mlxVendorID   = "15b3"
 )
 
 var _ = Describe(
@@ -657,25 +653,24 @@ var _ = Describe(
 
 				By("Checking if NMState operator is installed")
 
-				_, err = namespace.Pull(APIClient, nmstateOperatorNamespace)
-				if err != nil {
+				if !sriovocpenv.IsNMStateOperatorInstalled() {
 					Skip("NMState operator is not installed on this cluster")
 				}
 
 				By("Creating a new instance of NMstate instance")
 
-				err = createNewNMStateAndWaitUntilItsRunning(7 * time.Minute)
+				err = sriovocpenv.CreateNewNMStateAndWaitUntilItsRunning(7 * time.Minute)
 				Expect(err).ToNot(HaveOccurred(), "Failed to create NMState instance")
 
 				var isMellanox bool
 
-				isMellanox, err = isMellanoxDevice(
+				isMellanox, err = sriovocpenv.IsMellanoxDevice(
 					srIovInterfacesUnderTest[0], workerNodeList[0].Object.Name,
 				)
 				Expect(err).ToNot(HaveOccurred(), "Failed to check if interface is a Mellanox device")
 
 				if isMellanox {
-					err = configureSriovMlnxFirmwareOnWorkersAndWaitMCP(
+					err = sriovocpenv.ConfigureSriovMlnxFirmwareOnWorkersAndWaitMCP(
 						tsparams.MCOWaitTimeout,
 						time.Minute,
 						workerNodeList,
@@ -688,7 +683,7 @@ var _ = Describe(
 
 				By("Creating SR-IOV VFs via NMState")
 
-				err = configureVFsAndWaitUntilItsConfigured(
+				err = sriovocpenv.ConfigureVFsAndWaitUntilItsConfigured(
 					configureNMStatePolicyName,
 					srIovInterfacesUnderTest[0],
 					SriovOcpConfig.WorkerLabelMap,
@@ -696,7 +691,7 @@ var _ = Describe(
 					tsparams.DefaultTimeout)
 				Expect(err).ToNot(HaveOccurred(), "Failed to create VFs via NMState")
 
-				err = waitUntilVfsCreated(
+				err = sriovocpenv.WaitUntilVfsCreated(
 					workerNodeList,
 					srIovInterfacesUnderTest[0], 5, tsparams.DefaultTimeout,
 				)
@@ -704,7 +699,8 @@ var _ = Describe(
 
 				By("Configure SR-IOV with flag ExternallyManaged true")
 
-				err = createSriovPolicyWithExManaged(sriovAndResourceNameExManagedTrue, srIovInterfacesUnderTest[0])
+				err = createSriovPolicyWithExternallyManaged(
+					tsparams.SriovResourceNameExManagedTrue, 5, []string{srIovInterfacesUnderTest[0]})
 				Expect(err).ToNot(HaveOccurred(),
 					"Failed to create sriov configuration with flag ExternallyManaged true")
 
@@ -717,7 +713,7 @@ var _ = Describe(
 
 				By("Define and create sriov-networks")
 				defineAndCreateSriovNetworks(srIovNetworkPromiscuous, srIovNetworkDot1AD, srIovNetworkDot1Q,
-					sriovAndResourceNameExManagedTrue)
+					tsparams.SriovResourceNameExManagedTrue)
 
 				By("Enable VF promiscuous support on sriov interface under test")
 				setVFPromiscMode(workerNodeList[0].Definition.Name, srIovInterfacesUnderTest[0], sriovVendor, "on")
@@ -760,12 +756,12 @@ var _ = Describe(
 				nmstatePolicy := nmstate.NewPolicyBuilder(
 					APIClient, configureNMStatePolicyName, SriovOcpConfig.WorkerLabelMap).
 					WithInterfaceAndVFs(srIovInterfacesUnderTest[0], 0)
-				err = updatePolicyAndWaitUntilItsAvailable(tsparams.DefaultTimeout, nmstatePolicy)
+				err = sriovocpenv.UpdatePolicyAndWaitUntilItsAvailable(tsparams.DefaultTimeout, nmstatePolicy)
 				Expect(err).ToNot(HaveOccurred(), "Failed to update NMState network policy")
 
 				By("Verifying that VFs removed")
 
-				err = waitUntilVfsCreated(
+				err = sriovocpenv.WaitUntilVfsCreated(
 					workerNodeList,
 					srIovInterfacesUnderTest[0], 0, tsparams.DefaultTimeout,
 				)
@@ -1283,7 +1279,8 @@ func setVFPromiscMode(nodeName, srIovInterfacesUnderTest, sriovVendor, onOff str
 			srIovInterfacesUnderTest, onOff)
 	}
 
-	output, err := runCommandOnHostNetworkPod(nodeName, SriovOcpConfig.OcpSriovOperatorNamespace, promiscVFCommand)
+	output, err := sriovocpenv.RunCommandOnHostNetworkPod(
+		nodeName, SriovOcpConfig.OcpSriovOperatorNamespace, promiscVFCommand)
 	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to run command on node %s", output))
 }
 
@@ -1312,27 +1309,6 @@ func cleanTestEnvSRIOVConfiguration() {
 		APIClient, tsparams.MCOWaitTimeout, time.Minute,
 		SriovOcpConfig.MCPLabel, SriovOcpConfig.OcpSriovOperatorNamespace)
 	Expect(err).ToNot(HaveOccurred(), "Failed cluster is not stable")
-}
-
-func createSriovPolicyWithExManaged(sriovAndResName, sriovInterfaceName string) error {
-	klog.V(90).Infof("Creating SR-IOV policy with flag ExternallyManaged true")
-
-	sriovPolicy := sriov.NewPolicyBuilder(APIClient, sriovAndResName, SriovOcpConfig.OcpSriovOperatorNamespace,
-		sriovAndResName,
-		5, []string{sriovInterfaceName}, SriovOcpConfig.WorkerLabelMap).WithExternallyManaged(true)
-
-	err := sriovoperator.CreateSriovPolicyAndWaitUntilItsApplied(
-		APIClient,
-		SriovOcpConfig.WorkerLabelEnvVar,
-		SriovOcpConfig.OcpSriovOperatorNamespace,
-		sriovPolicy,
-		tsparams.MCOWaitTimeout,
-		tsparams.DefaultStableDuration)
-	if err != nil {
-		return fmt.Errorf("failed to sriov policy, %w", err)
-	}
-
-	return nil
 }
 
 func createSriovNetworkAndWaitForNAD(sNet *sriov.NetworkBuilder, timeout time.Duration) error {
@@ -1372,31 +1348,6 @@ func defineAndCreateSriovNetwork(networkName, resourceName string, withStaticIP,
 	return createSriovNetworkAndWaitForNAD(networkBuilder, tsparams.NADWaitTimeout)
 }
 
-func runCommandOnHostNetworkPod(nodeName, nsName, command string) (string, error) {
-	klog.V(90).Infof("Running command %s on the host network pod on node %s",
-		command, nodeName)
-
-	testPod, err := pod.NewBuilder(APIClient, "hostnetworkpod", nsName, SriovOcpConfig.OcpSriovTestContainer).
-		DefineOnNode(nodeName).WithPrivilegedFlag().WithHostNetwork().CreateAndWaitUntilRunning(tsparams.DefaultTimeout)
-	if err != nil {
-		return "", err
-	}
-
-	defer func() {
-		_, deleteErr := testPod.DeleteAndWait(tsparams.DefaultTimeout)
-		if deleteErr != nil {
-			klog.V(90).Infof("failed to delete hostnetwork pod %s: %v", testPod.Definition.Name, deleteErr)
-		}
-	}()
-
-	output, err := testPod.ExecCommand([]string{"/bin/bash", "-c", command})
-	if err != nil {
-		return "", err
-	}
-
-	return output.String(), nil
-}
-
 func rxTrafficOnClientPod(clientPod *pod.Builder, clientRxCmd string) error {
 	timeoutError := "command terminated with exit code 137"
 
@@ -1433,184 +1384,4 @@ func createTapNad(name string, nsname string, user int, group int,
 	}
 
 	return nad.NewBuilder(APIClient, name, nsname).WithPlugins(name, &plugins).Create()
-}
-
-func isMellanoxDevice(intName, nodeName string) (bool, error) {
-	sriovNetworkState := sriov.NewNetworkNodeStateBuilder(APIClient, nodeName,
-		SriovOcpConfig.OcpSriovOperatorNamespace)
-
-	driverName, err := sriovNetworkState.GetDriverName(intName)
-	if err != nil {
-		return false, fmt.Errorf("failed to get driver name for interface %s on node %s: %w", intName, nodeName, err)
-	}
-
-	return driverName == "mlx5_core", nil
-}
-
-func waitUntilVfsCreated(
-	nodeList []*nodes.Builder,
-	sriovInterfaceName string,
-	numberOfVfs int,
-	timeout time.Duration,
-) error {
-	for _, node := range nodeList {
-		err := wait.PollUntilContextTimeout(
-			context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-				sriovNetworkState := sriov.NewNetworkNodeStateBuilder(
-					APIClient, node.Object.Name, SriovOcpConfig.OcpSriovOperatorNamespace)
-
-				if discoverErr := sriovNetworkState.Discover(); discoverErr != nil {
-					return false, nil
-				}
-
-				sriovNumVfs, numErr := sriovNetworkState.GetNumVFs(sriovInterfaceName)
-				if numErr != nil {
-					return false, nil
-				}
-
-				return sriovNumVfs == numberOfVfs, nil
-			})
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func configureSriovMlnxFirmwareOnWorkersAndWaitMCP(
-	mcpTimeout time.Duration,
-	stableDuration time.Duration,
-	workerNodes []*nodes.Builder,
-	sriovInterfaceName string,
-	enableSriov bool,
-	numVfs int,
-) error {
-	for _, workerNode := range workerNodes {
-		sriovNetworkState := sriov.NewNetworkNodeStateBuilder(
-			APIClient, workerNode.Object.Name, SriovOcpConfig.OcpSriovOperatorNamespace)
-
-		pciAddress, err := sriovNetworkState.GetPciAddress(sriovInterfaceName)
-		if err != nil {
-			return fmt.Errorf("failed to get PCI address: %w", err)
-		}
-
-		mstconfigCmd := fmt.Sprintf("mstconfig -y -d %s set SRIOV_EN=%t NUM_OF_VFS=%d",
-			pciAddress, enableSriov, numVfs)
-
-		pods, err := pod.List(APIClient, SriovOcpConfig.OcpSriovOperatorNamespace, metav1.ListOptions{
-			LabelSelector: "app=sriov-network-config-daemon",
-			FieldSelector: fmt.Sprintf("spec.nodeName=%s", workerNode.Object.Name),
-		})
-		if err != nil || len(pods) == 0 {
-			return fmt.Errorf("failed to find config daemon pod on node %s", workerNode.Object.Name)
-		}
-
-		output, err := pods[0].ExecCommand([]string{"bash", "-c", mstconfigCmd})
-		if err != nil {
-			return fmt.Errorf("failed to configure Mellanox firmware on node %s: %s %w",
-				workerNode.Object.Name, output.String(), err)
-		}
-
-		_, _ = pods[0].ExecCommand([]string{"bash", "-c", "chroot /host reboot"})
-	}
-
-	time.Sleep(10 * time.Second)
-
-	return cluster.WaitForMcpStable(APIClient, mcpTimeout, stableDuration, SriovOcpConfig.MCPLabel)
-}
-
-const (
-	nmstateName                  = "nmstate"
-	nmstateHandlerDsName         = "nmstate-handler"
-	nmstateWebhookDeploymentName = "nmstate-webhook"
-	nmstateOperatorNamespace     = "openshift-nmstate"
-)
-
-func createNewNMStateAndWaitUntilItsRunning(timeout time.Duration) error {
-	nmstateInstance, err := nmstate.PullNMstate(APIClient, nmstateName)
-	if err == nil {
-		_, err = nmstateInstance.Delete()
-		if err != nil {
-			return err
-		}
-	}
-
-	_, err = nmstate.NewBuilder(APIClient, nmstateName).Create()
-	if err != nil {
-		return err
-	}
-
-	return isNMStateDeployedAndReady(timeout)
-}
-
-func isNMStateDeployedAndReady(timeout time.Duration) error {
-	var (
-		nmstateHandlerDs         *daemonset.Builder
-		nmstateWebhookDeployment *deployment.Builder
-		err                      error
-	)
-
-	err = wait.PollUntilContextTimeout(
-		context.TODO(), 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-			nmstateHandlerDs, err = daemonset.Pull(
-				APIClient, nmstateHandlerDsName, nmstateOperatorNamespace)
-			if err != nil {
-				return false, nil
-			}
-
-			nmstateWebhookDeployment, err = deployment.Pull(
-				APIClient, nmstateWebhookDeploymentName, nmstateOperatorNamespace)
-			if err != nil {
-				return false, nil
-			}
-
-			return true, nil
-		})
-	if err != nil {
-		return err
-	}
-
-	time.Sleep(10 * time.Second)
-
-	if !nmstateHandlerDs.IsReady(timeout) {
-		return fmt.Errorf("nmstate handler daemonset is not ready")
-	}
-
-	if !nmstateWebhookDeployment.IsReady(timeout) {
-		return fmt.Errorf("nmstate webhook deployment is not ready")
-	}
-
-	return nil
-}
-
-func configureVFsAndWaitUntilItsConfigured(
-	policyName string,
-	sriovInterfaceName string,
-	nodeLabel map[string]string,
-	numberOfVFs uint8,
-	timeout time.Duration) error {
-	nmstatePolicy := nmstate.NewPolicyBuilder(
-		APIClient, policyName, nodeLabel).WithInterfaceAndVFs(sriovInterfaceName, numberOfVFs)
-
-	nmstatePolicy, err := nmstatePolicy.Create()
-	if err != nil {
-		return err
-	}
-
-	return nmstatePolicy.WaitUntilCondition(nmstateShared.NodeNetworkConfigurationPolicyConditionAvailable, timeout)
-}
-
-func updatePolicyAndWaitUntilItsAvailable(timeout time.Duration, nmstatePolicy *nmstate.PolicyBuilder) error {
-	nmstatePolicy, err := nmstatePolicy.Update(true)
-	if err != nil {
-		return err
-	}
-
-	err = nmstatePolicy.WaitUntilCondition(nmstateShared.NodeNetworkConfigurationPolicyConditionProgressing, timeout)
-	if err != nil {
-		return err
-	}
-
-	return nmstatePolicy.WaitUntilCondition(nmstateShared.NodeNetworkConfigurationPolicyConditionAvailable, timeout)
 }


### PR DESCRIPTION
Migrate CNF ExternallyManaged coverage into the OCP suite and create VFs on workers via sysfs instead of NMState.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added externally managed SR-IOV test coverage for IPv4, IPv6, dual-stack connectivity, VLAN and rate settings, VF recreation, and operator lifecycle scenarios.
  - Added validation for NMState configuration, VF availability, Mellanox devices, firmware settings, and host-network operations.
  - Added test selection and resource identifiers for externally managed SR-IOV scenarios.

- **Refactor**
  - Consolidated SR-IOV and NMState environment support across existing QinQ tests, improving consistency and reducing duplicated test logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->