### PR TITLE
ptp: Add dual T-BC time receiver ports (same NIC) holdover tests (CNF-23885)

### DIFF
--- a/tests/cnf/ran/ptp/internal/iface/helper.go
+++ b/tests/cnf/ran/ptp/internal/iface/helper.go
@@ -122,6 +122,20 @@ func SetInterfaceStatus(client *clients.Settings, nodeName string, iface Name, s
 	return nil
 }
 
+// SetInterfacesStatus sets each provided interface to the given state on nodeName.
+// Note: If setting an interface fails, the function returns an error immediately without rolling back
+// previously changed interfaces.
+func SetInterfacesStatus(client *clients.Settings, nodeName string, ifaces []Name, state InterfaceState) error {
+	for _, ifn := range ifaces {
+		err := SetInterfaceStatus(client, nodeName, ifn, state)
+		if err != nil {
+			return fmt.Errorf("failed to set interface %s to %s on node %s: %w", ifn, state, nodeName, err)
+		}
+	}
+
+	return nil
+}
+
 var phcCtlCmpRegex = regexp.MustCompile(`offset from CLOCK_REALTIME is ([-0-9]+)ns`)
 
 // GetPTPClockSystemTimeOffset compares a PTP clock with the system clock and returns the offset with nanosecond

--- a/tests/cnf/ran/ptp/internal/profiles/oc2port.go
+++ b/tests/cnf/ran/ptp/internal/profiles/oc2port.go
@@ -17,10 +17,10 @@ type Oc2PortInfo struct {
 	PassiveInterface iface.Name
 }
 
-// Oc2PortDetermineActivePassiveInterfaces queries Prometheus metrics to identify which interface
-// in an OC 2-port configuration is currently active (FOLLOWER/SLAVE) and which is passive
-// (LISTENING). It returns an error if roles cannot be determined or are unexpected.
-func Oc2PortDetermineActivePassiveInterfaces(
+// DetermineActivePassiveInterfaces queries Prometheus metrics to identify which interface
+// in a multi-port configuration (like OC 2-port or Dual T-BC) is currently active (FOLLOWER/SLAVE)
+// and which is passive (LISTENING/PASSIVE). It returns an error if roles cannot be determined or are unexpected.
+func DetermineActivePassiveInterfaces(
 	ctx context.Context,
 	prometheusAPI prometheusv1.API,
 	nodeName string,
@@ -67,13 +67,11 @@ func Oc2PortDetermineActivePassiveInterfaces(
 		//nolint:exhaustive // Only two roles are valid for this logic.
 		switch role {
 		case metrics.InterfaceRoleFollower:
-			// Follower = SLAVE = Active
 			activeIface = clientIface.Name
-		case metrics.InterfaceRoleListening:
-			// Listening = Passive
+		case metrics.InterfaceRoleListening, metrics.InterfaceRolePassive:
 			passiveIface = clientIface.Name
 		default:
-			return "", "", fmt.Errorf("unexpected role %d for interface %s in OC 2-port profile",
+			return "", "", fmt.Errorf("unexpected role %d for interface %s",
 				role, clientIface.Name)
 		}
 	}

--- a/tests/cnf/ran/ptp/internal/profiles/parser.go
+++ b/tests/cnf/ran/ptp/internal/profiles/parser.go
@@ -209,6 +209,10 @@ func determineProfileType(
 	// If the profile has one interface and one client interface, return ProfileTypeOC.
 	case numInterfaces == 1 && numClientInterfaces == 1:
 		return ProfileTypeOC, nil
+	// Dual T-BC must be classified before two-port OC: both have two client interfaces.
+	case numClientInterfaces == 2 && numServerInterfaces == 0 &&
+		isDualTBCReceiver(profile, controlledNames, profileName):
+		return ProfileTypeDualTBCReceiver, nil
 	// If the profile has two interfaces and two client interfaces, return ProfileTypeTwoPortOC.
 	case numInterfaces == 2 && numClientInterfaces == 2:
 		return ProfileTypeTwoPortOC, nil
@@ -222,6 +226,30 @@ func determineProfileType(
 	default:
 		return 0, fmt.Errorf("unable to determine PTP profile type based on defined rules")
 	}
+}
+
+// isDualTBCReceiver reports whether a multi-client profile is a dual time-receiver T-BC rather than a two-port OC.
+// Dual T-BC is identified by clockType T-BC, a controllingProfile reference, or a comma-separated upstreamPort
+// combined with telecom-slave (ts2phc/phc2sys) configuration.
+func isDualTBCReceiver(profile ptpv1.PtpProfile, controlledNames map[string]bool, profileName string) bool {
+	if profile.PtpSettings != nil && profile.PtpSettings["clockType"] == "T-BC" {
+		return true
+	}
+
+	if controlledNames[profileName] {
+		return true
+	}
+
+	return hasTelecomSlaveConfig(profile) && hasDualUpstreamPort(profile)
+}
+
+// hasDualUpstreamPort reports whether ptpSettings.upstreamPort lists more than one interface.
+func hasDualUpstreamPort(profile ptpv1.PtpProfile) bool {
+	if profile.PtpSettings == nil {
+		return false
+	}
+
+	return strings.Contains(profile.PtpSettings["upstreamPort"], ",")
 }
 
 // hasClientFlag checks if the ptp4lOpts string contains any client-only flags. Though the reference PTP profiles use

--- a/tests/cnf/ran/ptp/internal/profiles/parser_test.go
+++ b/tests/cnf/ran/ptp/internal/profiles/parser_test.go
@@ -1,0 +1,81 @@
+//go:build unit_test
+
+package profiles
+
+import (
+	"testing"
+
+	ptpv1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/ptp/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+)
+
+func TestParsePtpProfileDualTBC(t *testing.T) {
+	t.Parallel()
+
+	dualClientConf := `
+[ens7f1]
+masterOnly 0
+[ens7f3]
+masterOnly 0
+[global]
+slaveOnly 1
+`
+
+	tests := []struct {
+		name            string
+		profile         ptpv1.PtpProfile
+		controlledNames map[string]bool
+		want            PtpProfileType
+	}{
+		{
+			name: "WPC dual T-BC with clockType and controllingProfile",
+			profile: ptpv1.PtpProfile{
+				Name:      ptr.To("tbc-tr"),
+				Ptp4lConf: ptr.To(dualClientConf),
+				PtpSettings: map[string]string{
+					"clockType":    "T-BC",
+					"upstreamPort": "ens7f1,ens7f3",
+				},
+				Ts2PhcConf:  ptr.To("[ens7f0]\nts2phc.master 0\n"),
+				Phc2sysOpts: ptr.To("-s ens7f1"),
+			},
+			controlledNames: map[string]bool{"tbc-tr": true},
+			want:            ProfileTypeDualTBCReceiver,
+		},
+		{
+			name: "GNRD dual T-BC with clockType and no controllingProfile",
+			profile: ptpv1.PtpProfile{
+				Name:      ptr.To("01-bc-tr"),
+				Ptp4lConf: ptr.To(dualClientConf),
+				PtpSettings: map[string]string{
+					"clockType":    "T-BC",
+					"upstreamPort": "eno8503np2,eno8603np3",
+				},
+				Ts2PhcConf:  ptr.To("[eno8703np0]\nts2phc.master 0\n"),
+				Phc2sysOpts: ptr.To("-s eno8503np2"),
+			},
+			want: ProfileTypeDualTBCReceiver,
+		},
+		{
+			name: "two-port OC is not classified as dual T-BC",
+			profile: ptpv1.PtpProfile{
+				Name:      ptr.To("oc-2-port"),
+				Ptp4lConf: ptr.To(dualClientConf),
+			},
+			want: ProfileTypeTwoPortOC,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parsePtpProfile(testCase.profile, ProfileReference{ProfileName: *testCase.profile.Name},
+				testCase.controlledNames)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.want, got.ProfileType)
+		})
+	}
+}

--- a/tests/cnf/ran/ptp/internal/profiles/plugins.go
+++ b/tests/cnf/ran/ptp/internal/profiles/plugins.go
@@ -263,36 +263,80 @@ func HasPlugin(profile *ptpv1.PtpProfile, pluginType ptp.PluginType) bool {
 	return ok
 }
 
-// GetUpstreamPortForProfile returns the upstream (time-receiving) network port for the profile.
+// GetUpstreamPortsForProfile returns the upstream (time-receiving) network ports for the profile.
+// Dual T-BC configurations list both ports as a comma-separated upstreamPort value.
 //
 // PtpSettings["upstreamPort"] is checked first — it is the mandatory field set by the operator
 // for all GNRD T-BC profiles (E825 plugin path and HardwareConfig path alike). When not present,
 // the function falls back to the E810 plugin interconnections.
-func GetUpstreamPortForProfile(profile *ptpv1.PtpProfile) (iface.Name, error) {
-	if profile.PtpSettings != nil {
+func GetUpstreamPortsForProfile(profile *ptpv1.PtpProfile) ([]iface.Name, error) {
+	if profile != nil && profile.PtpSettings != nil {
 		if port, ok := profile.PtpSettings["upstreamPort"]; ok && port != "" {
-			return iface.Name(port), nil
+			ports := splitUpstreamPorts(port)
+			if len(ports) == 0 {
+				return nil, fmt.Errorf("upstreamPort is empty after parsing")
+			}
+
+			return ports, nil
 		}
 	}
 
-	return GetUpstreamPortFromE810Plugin(profile)
+	return GetUpstreamPortsFromE810Plugin(profile)
 }
 
-// GetUpstreamPortFromE810Plugin returns the upstream port from the E810 plugin's interconnections. Returns the first
-// interconnection entry that has an upstreamPort set.
-func GetUpstreamPortFromE810Plugin(profile *ptpv1.PtpProfile) (iface.Name, error) {
+// GetUpstreamPortForProfile returns the first upstream (time-receiving) network port for the profile.
+func GetUpstreamPortForProfile(profile *ptpv1.PtpProfile) (iface.Name, error) {
+	ports, err := GetUpstreamPortsForProfile(profile)
+	if err != nil {
+		return "", err
+	}
+
+	return ports[0], nil
+}
+
+// GetUpstreamPortsFromE810Plugin returns the upstream ports from the E810 plugin's interconnections.
+// Returns ports from the first interconnection entry that has an upstreamPort set. Comma-separated
+// values are split into individual interface names.
+func GetUpstreamPortsFromE810Plugin(profile *ptpv1.PtpProfile) ([]iface.Name, error) {
 	intelPlugin, err := getIntelPlugin(profile, ptp.PluginTypeE810)
 	if err != nil {
-		return "", fmt.Errorf("failed to get Intel plugin for upstream port: %w", err)
+		return nil, fmt.Errorf("failed to get Intel plugin for upstream port: %w", err)
 	}
 
 	for _, interconnection := range intelPlugin.InputDelays {
 		if interconnection.UpstreamPort != "" {
-			return iface.Name(interconnection.UpstreamPort), nil
+			ports := splitUpstreamPorts(interconnection.UpstreamPort)
+			if len(ports) > 0 {
+				return ports, nil
+			}
 		}
 	}
 
-	return "", fmt.Errorf("no upstream port found in E810 plugin interconnections")
+	return nil, fmt.Errorf("no upstream port found in E810 plugin interconnections")
+}
+
+// GetUpstreamPortFromE810Plugin returns the first upstream port from the E810 plugin's interconnections.
+func GetUpstreamPortFromE810Plugin(profile *ptpv1.PtpProfile) (iface.Name, error) {
+	ports, err := GetUpstreamPortsFromE810Plugin(profile)
+	if err != nil {
+		return "", err
+	}
+
+	return ports[0], nil
+}
+
+// splitUpstreamPorts splits a comma-separated upstreamPort value into interface names.
+func splitUpstreamPorts(port string) []iface.Name {
+	var ports []iface.Name
+
+	for _, part := range strings.Split(port, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			ports = append(ports, iface.Name(part))
+		}
+	}
+
+	return ports
 }
 
 // GetRxInterfaces returns the interfaces configured as RX (pin state 1) in the E810 plugin.

--- a/tests/cnf/ran/ptp/internal/profiles/plugins_test.go
+++ b/tests/cnf/ran/ptp/internal/profiles/plugins_test.go
@@ -92,3 +92,57 @@ func TestGetRxInterfaces(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []iface.Name{"ens2f0"}, got)
 }
+
+func TestGetUpstreamPortsForProfile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		profile *ptpv1.PtpProfile
+		want    []iface.Name
+		wantErr bool
+	}{
+		{
+			name: "single upstreamPort",
+			profile: &ptpv1.PtpProfile{
+				PtpSettings: map[string]string{"upstreamPort": "ens7f1"},
+			},
+			want: []iface.Name{"ens7f1"},
+		},
+		{
+			name: "dual comma-separated upstreamPort",
+			profile: &ptpv1.PtpProfile{
+				PtpSettings: map[string]string{"upstreamPort": "ens7f1,ens7f3"},
+			},
+			want: []iface.Name{"ens7f1", "ens7f3"},
+		},
+		{
+			name: "dual upstreamPort with spaces",
+			profile: &ptpv1.PtpProfile{
+				PtpSettings: map[string]string{"upstreamPort": "eno8503np2, eno8603np3"},
+			},
+			want: []iface.Name{"eno8503np2", "eno8603np3"},
+		},
+		{
+			name:    "missing upstreamPort and plugin",
+			profile: &ptpv1.PtpProfile{},
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := GetUpstreamPortsForProfile(testCase.profile)
+			if testCase.wantErr {
+				assert.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.want, got)
+		})
+	}
+}

--- a/tests/cnf/ran/ptp/internal/profiles/profiles.go
+++ b/tests/cnf/ran/ptp/internal/profiles/profiles.go
@@ -53,6 +53,10 @@ const (
 	// ProfileTypeTTSC refers to a Telecom Time Slave Clock (ITU-T G.8275.1). It has ts2phc and phc2sys
 	// configurations for hardware timestamping and holdover, but is not part of a T-BC pair.
 	ProfileTypeTTSC
+	// ProfileTypeDualTBCReceiver refers to a T-BC receiver with two time-receiver ports on the same NIC
+	// (same PHC). One port is active (SLAVE/FOLLOWER) and the other is backup (LISTENING); loss of the
+	// active port failovers to the backup, and loss of both ports enters holdover.
+	ProfileTypeDualTBCReceiver
 )
 
 // PtpClockType enumerates the roles of each interface. It is different from the roles in metrics, which include extra

--- a/tests/cnf/ran/ptp/internal/profiles/tbc.go
+++ b/tests/cnf/ran/ptp/internal/profiles/tbc.go
@@ -1,0 +1,49 @@
+package profiles
+
+import (
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/iface"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/metrics"
+)
+
+// HoldoverTestData groups the per-node test context that is discovered once in BeforeEach and shared
+// by all test cases within a Context block.
+type HoldoverTestData struct {
+	PrometheusAPI  prometheusv1.API
+	NodeName       string
+	ProfileInfo    *ProfileInfo
+	UpstreamIfaces []iface.Name
+}
+
+// HoldoverExpectedClockClasses groups the expected clock class values for each holdover state.
+type HoldoverExpectedClockClasses struct {
+	Locked            metrics.PtpClockClass
+	HoldoverInSpec    metrics.PtpClockClass
+	HoldoverOutOfSpec metrics.PtpClockClass
+	Freerun           metrics.PtpClockClass
+}
+
+var (
+	// HoldoverPluginSettingsNoOutOfSpec are the holdover settings without out-of-spec.
+	HoldoverPluginSettingsNoOutOfSpec = HoldoverPluginSettings{
+		LocalHoldoverTimeout:   360,
+		MaxInSpecOffset:        14401,
+		LocalMaxHoldoverOffSet: 14400,
+	}
+	// HoldoverPluginSettingsWithOutOfSpec are the holdover settings with out-of-spec.
+	HoldoverPluginSettingsWithOutOfSpec = HoldoverPluginSettings{
+		LocalHoldoverTimeout:   360,
+		MaxInSpecOffset:        1800,
+		LocalMaxHoldoverOffSet: 14400,
+	}
+)
+
+// TBCClockClasses returns the standard clock class values for T-BC tests.
+func TBCClockClasses() HoldoverExpectedClockClasses {
+	return HoldoverExpectedClockClasses{
+		Locked:            metrics.ClockClass6,
+		HoldoverInSpec:    metrics.ClockClass135,
+		HoldoverOutOfSpec: metrics.ClockClass165,
+		Freerun:           metrics.ClockClass248,
+	}
+}

--- a/tests/cnf/ran/ptp/internal/tsparams/consts.go
+++ b/tests/cnf/ran/ptp/internal/tsparams/consts.go
@@ -27,6 +27,8 @@ const (
 	LabelLogReduction = "log-reduction"
 	// LabelTBCTSCHoldover is the label for T-BC and T-TSC upstream clock loss holdover tests.
 	LabelTBCTSCHoldover = "tbc-tsc-holdover"
+	// LabelDualTBC is the label for dual time-receiver T-BC tests (same NIC).
+	LabelDualTBC = "dual-tbc"
 	// LabelGNSSLoss is the label for all tests in the PTP T-GM GNSS loss suite.
 	LabelGNSSLoss = "gnss-loss"
 	// LabelSMADisconnect is the label for all tests in the PTP T-GM SMA disconnect suite.

--- a/tests/cnf/ran/ptp/tests/ptp-dual-tbc.go
+++ b/tests/cnf/ran/ptp/tests/ptp-dual-tbc.go
@@ -1,0 +1,189 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/querier"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/ranparam"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/version"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/iface"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/metrics"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/profiles"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/tsparams"
+	"k8s.io/klog/v2"
+)
+
+var _ = Describe("PTP Dual T-BC", Label(tsparams.LabelDualTBC), func() {
+	var prometheusAPI prometheusv1.API
+
+	BeforeEach(func() {
+		var err error
+
+		By("creating a Prometheus API client")
+
+		prometheusAPI, err = querier.CreatePrometheusAPIForCluster(RANConfig.Spoke1APIClient)
+		Expect(err).ToNot(HaveOccurred(), "Failed to create Prometheus API client")
+
+		By("checking if PTP operator version supports dual T-BC tests")
+
+		inRange, err := version.IsVersionStringInRange(
+			RANConfig.Spoke1OperatorVersions[ranparam.PTP], "5.0.0-0", "")
+		Expect(err).ToNot(HaveOccurred(), "Failed to parse PTP operator version")
+
+		if !inRange {
+			Skip("Test is valid from version 5.0")
+		}
+	})
+
+	Context("dual t-bc dual time receiver ports on the same NIC", func() {
+		var testData profiles.HoldoverTestData
+
+		timeout := holdoverTestTimeout
+
+		BeforeEach(func() {
+			By("getting node info map")
+
+			discovered := discoverHoldoverTestData(prometheusAPI, profiles.ProfileTypeDualTBCReceiver)
+			if discovered == nil || len(discovered.UpstreamIfaces) < 2 {
+				Skip("No dual T-BC configuration found for dual time receiver tests")
+			}
+
+			testData = *discovered
+
+			klog.V(tsparams.LogLevel).Infof(
+				"Dual T-BC test on node %s, upstream interfaces %v", testData.NodeName, testData.UpstreamIfaces)
+		})
+
+		// 89744 - validates dual t-bc holdover to locked after switching to second upstream port
+		// when the active port is disconnected. OCP-89745 is the BC (non T-BC) counterpart
+		// and is not automated here.
+		It("validates dual t-bc holdover to locked after switching to second upstream port",
+			reportxml.ID("89744"), func() {
+				assertDualTBCFailoverToBackup(testData, timeout)
+			})
+
+		// 89746 - validates dual t-bc holdover and freerun after both ports are disconnected
+		It("validates dual t-bc holdover and freerun after both ports are disconnected",
+			reportxml.ID("89746"), func() {
+				assertDualTBCHoldoverInSpecToFreerun(testData, profiles.HoldoverPluginSettingsNoOutOfSpec,
+					timeout, profiles.TBCClockClasses())
+			})
+	})
+})
+
+// assertDualTBCFailoverToBackup brings the active (SLAVE) time-receiver port down, waits for HOLDOVER
+// (clock class 135), then LOCKED (clock class 6) once the backup port takes over. The original port
+// stays down for the duration of the assertions and is restored in cleanup.
+func assertDualTBCFailoverToBackup(testData profiles.HoldoverTestData, timeout time.Duration) {
+	GinkgoHelper()
+
+	activeIface, backupIface := dualTBCActiveBackupInterfaces(testData)
+
+	By(fmt.Sprintf("setting active upstream interface %s down to trigger failover to %s",
+		activeIface, backupIface))
+
+	ifaceDownTime := time.Now()
+
+	DeferCleanup(func() {
+		restoreInterfacesAndWaitForRelock(testData.PrometheusAPI, testData.NodeName, testData.UpstreamIfaces)
+	})
+
+	err := iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, testData.NodeName,
+		activeIface, iface.InterfaceStateDown)
+	Expect(err).ToNot(HaveOccurred(),
+		"Failed to set active upstream interface %s down on node %s", activeIface, testData.NodeName)
+
+	assertHoldoverState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
+		profiles.TBCClockClasses().HoldoverInSpec, true, timeout, false)
+
+	assertLockedState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
+		profiles.TBCClockClasses().Locked, true, timeout)
+
+	By("validating interface roles after failover")
+
+	err = metrics.AssertQuery(context.TODO(), testData.PrometheusAPI, metrics.InterfaceRoleQuery{
+		Interface: metrics.Equals(activeIface),
+		Node:      metrics.Equals(testData.NodeName),
+		Process:   metrics.Equals(metrics.ProcessPTP4L),
+	}, metrics.InterfaceRoleFaulty, metrics.AssertWithTimeout(1*time.Minute))
+	Expect(err).ToNot(HaveOccurred(),
+		"expected interface %s to be FAULTY on node %s", activeIface, testData.NodeName)
+
+	err = metrics.AssertQuery(context.TODO(), testData.PrometheusAPI, metrics.InterfaceRoleQuery{
+		Interface: metrics.Equals(backupIface),
+		Node:      metrics.Equals(testData.NodeName),
+		Process:   metrics.Equals(metrics.ProcessPTP4L),
+	}, metrics.InterfaceRoleFollower, metrics.AssertWithTimeout(1*time.Minute))
+	Expect(err).ToNot(HaveOccurred(),
+		"expected interface %s to be FOLLOWER on node %s", backupIface, testData.NodeName)
+}
+
+// assertDualTBCHoldoverInSpecToFreerun brings both time-receiver ports down, waits for HOLDOVER then FREERUN,
+// and asserts both ports are FAULTY. Cleanup restores ports via DeferCleanup.
+func assertDualTBCHoldoverInSpecToFreerun(
+	testData profiles.HoldoverTestData,
+	pluginSettings profiles.HoldoverPluginSettings,
+	timeout time.Duration,
+	expected profiles.HoldoverExpectedClockClasses,
+) {
+	GinkgoHelper()
+
+	changeHoldoverSettings(testData, pluginSettings, expected.Locked, true, timeout)
+
+	By("setting both upstream clock interfaces down to enter holdover-in-spec")
+
+	ifaceDownTime := time.Now()
+
+	DeferCleanup(func() {
+		restoreInterfacesAndWaitForRelock(testData.PrometheusAPI, testData.NodeName, testData.UpstreamIfaces)
+	})
+
+	err := iface.SetInterfacesStatus(RANConfig.Spoke1APIClient,
+		testData.NodeName, testData.UpstreamIfaces, iface.InterfaceStateDown)
+	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces down")
+
+	assertHoldoverState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
+		expected.HoldoverInSpec, true, timeout, true)
+
+	assertFreerunState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
+		expected.Freerun, true, timeout)
+
+	By("validating both upstream interfaces are FAULTY")
+
+	for _, ifn := range testData.UpstreamIfaces {
+		err := metrics.AssertQuery(context.TODO(), testData.PrometheusAPI, metrics.InterfaceRoleQuery{
+			Interface: metrics.Equals(ifn),
+			Node:      metrics.Equals(testData.NodeName),
+			Process:   metrics.Equals(metrics.ProcessPTP4L),
+		}, metrics.InterfaceRoleFaulty, metrics.AssertWithTimeout(1*time.Minute))
+		Expect(err).ToNot(HaveOccurred(),
+			"expected interface %s to be FAULTY on node %s", ifn, testData.NodeName)
+	}
+}
+
+// dualTBCActiveBackupInterfaces returns the currently active (FOLLOWER/SLAVE) and backup (LISTENING)
+// time-receiver interfaces for the dual T-BC profile.
+func dualTBCActiveBackupInterfaces(testData profiles.HoldoverTestData) (iface.Name, iface.Name) {
+	GinkgoHelper()
+
+	clientIfaces := testData.ProfileInfo.GetInterfacesByClockType(profiles.ClockTypeClient)
+	Expect(len(clientIfaces)).To(Equal(2),
+		"Expected exactly 2 client interfaces for dual T-BC profile %s on node %s",
+		testData.ProfileInfo.Reference.ProfileName, testData.NodeName)
+
+	activeIface, backupIface, err := profiles.DetermineActivePassiveInterfaces(
+		context.TODO(), testData.PrometheusAPI, testData.NodeName, clientIfaces)
+	Expect(err).ToNot(HaveOccurred(),
+		"Failed to determine active/backup interfaces for dual T-BC on node %s", testData.NodeName)
+
+	By(fmt.Sprintf("identified active interface: %s, backup interface: %s", activeIface, backupIface))
+
+	return activeIface, backupIface
+}

--- a/tests/cnf/ran/ptp/tests/ptp-holdover.go
+++ b/tests/cnf/ran/ptp/tests/ptp-holdover.go
@@ -26,50 +26,10 @@ import (
 
 const holdoverTestTimeout = 7 * time.Minute
 
-var (
-	holdoverPluginSettingsNoOutOfSpec = profiles.HoldoverPluginSettings{
-		LocalHoldoverTimeout:   360,
-		MaxInSpecOffset:        14401,
-		LocalMaxHoldoverOffSet: 14400,
-	}
-	holdoverPluginSettingsWithOutOfSpec = profiles.HoldoverPluginSettings{
-		LocalHoldoverTimeout:   360,
-		MaxInSpecOffset:        1800,
-		LocalMaxHoldoverOffSet: 14400,
-	}
-)
-
-// holdoverTestData groups the per-node test context that is discovered once in BeforeEach and shared
-// by all test cases within a Context block.
-type holdoverTestData struct {
-	prometheusAPI prometheusv1.API
-	nodeName      string
-	profileInfo   *profiles.ProfileInfo
-	upstreamIface iface.Name
-}
-
-// holdoverExpectedClockClasses groups the expected clock class values for each holdover state.
-type holdoverExpectedClockClasses struct {
-	Locked            metrics.PtpClockClass
-	HoldoverInSpec    metrics.PtpClockClass
-	HoldoverOutOfSpec metrics.PtpClockClass
-	Freerun           metrics.PtpClockClass
-}
-
-// TBCClockClasses returns the standard clock class values for T-BC tests.
-func TBCClockClasses() holdoverExpectedClockClasses {
-	return holdoverExpectedClockClasses{
-		Locked:            metrics.ClockClass6,
-		HoldoverInSpec:    metrics.ClockClass135,
-		HoldoverOutOfSpec: metrics.ClockClass165,
-		Freerun:           metrics.ClockClass248,
-	}
-}
-
 // TTSCClockClasses returns clock class values for T-TSC tests on 4.21+. Clock class does not change and
 // remains 255 throughout all states.
-func TTSCClockClasses() holdoverExpectedClockClasses {
-	return holdoverExpectedClockClasses{
+func TTSCClockClasses() profiles.HoldoverExpectedClockClasses {
+	return profiles.HoldoverExpectedClockClasses{
 		Locked:            metrics.ClockClass255,
 		HoldoverInSpec:    metrics.ClockClass255,
 		HoldoverOutOfSpec: metrics.ClockClass255,
@@ -79,8 +39,8 @@ func TTSCClockClasses() holdoverExpectedClockClasses {
 
 // backCompatTTSCClockClasses returns clock class values for T-TSC tests on 4.20, where T-TSC clock class
 // values match T-BC (6, 135, 165, 248).
-func backCompatTTSCClockClasses() holdoverExpectedClockClasses {
-	return TBCClockClasses()
+func backCompatTTSCClockClasses() profiles.HoldoverExpectedClockClasses {
+	return profiles.TBCClockClasses()
 }
 
 var _ = Describe("PTP Holdover", Label(tsparams.LabelTBCTSCHoldover), func() {
@@ -106,7 +66,7 @@ var _ = Describe("PTP Holdover", Label(tsparams.LabelTBCTSCHoldover), func() {
 	})
 
 	Context("t-bc upstream clock loss & unassisted holdover", func() {
-		var testData holdoverTestData
+		var testData profiles.HoldoverTestData
 
 		timeout := holdoverTestTimeout
 
@@ -121,43 +81,43 @@ var _ = Describe("PTP Holdover", Label(tsparams.LabelTBCTSCHoldover), func() {
 			testData = *discovered
 
 			klog.V(tsparams.LogLevel).Infof(
-				"T-BC holdover test on node %s, upstream interface %s", testData.nodeName, testData.upstreamIface)
+				"T-BC holdover test on node %s, upstream interfaces %v", testData.NodeName, testData.UpstreamIfaces)
 		})
 
 		// 83297 - Verifies t-bc transition from holdover-in-spec to locked when upstream clock recovers
 		It("verifies t-bc transition from holdover-in-spec to locked when upstream clock recovers",
 			reportxml.ID("83297"), func() {
-				assertHoldoverInSpecToLocked(testData, holdoverPluginSettingsNoOutOfSpec,
-					timeout, TBCClockClasses(), true)
+				assertHoldoverInSpecToLocked(testData, profiles.HoldoverPluginSettingsNoOutOfSpec,
+					timeout, profiles.TBCClockClasses(), true)
 			})
 
 		// 83298 - Verifies t-bc transition from holdover-in-spec to freerun when localmaxholdoveroffset reached
 		It("verifies t-bc transition from holdover-in-spec to freerun when localmaxholdoveroffset reached",
 			reportxml.ID("83298"), func() {
-				assertHoldoverInSpecToFreerun(testData, holdoverPluginSettingsNoOutOfSpec,
-					timeout, TBCClockClasses(), true)
+				assertHoldoverInSpecToFreerun(testData, profiles.HoldoverPluginSettingsNoOutOfSpec,
+					timeout, profiles.TBCClockClasses(), true)
 			})
 
 		// 83299 - Verifies t-bc transition from holdover-in-spec to holdover-out-of-spec when maxinspecoffset reached
 		It("verifies t-bc transition from holdover-in-spec to holdover-out-of-spec when maxinspecoffset reached",
 			reportxml.ID("83299"), func() {
-				assertHoldoverInSpecToOutOfSpec(testData, holdoverPluginSettingsWithOutOfSpec,
-					timeout, TBCClockClasses(), true)
+				assertHoldoverInSpecToOutOfSpec(testData, profiles.HoldoverPluginSettingsWithOutOfSpec,
+					timeout, profiles.TBCClockClasses(), true)
 			})
 
 		// 83300 - Verifies t-bc transition from holdover-out-of-spec to freerun when localmaxholdoveroffset reached
 		It("verifies t-bc transition from holdover-out-of-spec to freerun when localmaxholdoveroffset reached",
 			reportxml.ID("83300"), func() {
-				assertHoldoverOutOfSpecToFreerun(testData, holdoverPluginSettingsWithOutOfSpec,
-					timeout, TBCClockClasses(), true)
+				assertHoldoverOutOfSpecToFreerun(testData, profiles.HoldoverPluginSettingsWithOutOfSpec,
+					timeout, profiles.TBCClockClasses(), true)
 			})
 	})
 
 	Context("t-tsc upstream clock loss & unassisted holdover", func() {
 		var (
-			testData             holdoverTestData
+			testData             profiles.HoldoverTestData
 			clockClassChanges    bool
-			expectedClockClasses holdoverExpectedClockClasses
+			expectedClockClasses profiles.HoldoverExpectedClockClasses
 		)
 
 		timeout := holdoverTestTimeout
@@ -185,34 +145,34 @@ var _ = Describe("PTP Holdover", Label(tsparams.LabelTBCTSCHoldover), func() {
 			testData = *discovered
 
 			klog.V(tsparams.LogLevel).Infof(
-				"T-TSC holdover test on node %s, upstream interface %s", testData.nodeName, testData.upstreamIface)
+				"T-TSC holdover test on node %s, upstream interfaces %v", testData.NodeName, testData.UpstreamIfaces)
 		})
 
 		// 88274 - Verifies t-tsc transition from holdover-in-spec to locked when upstream clock recovers
 		It("verifies t-tsc transition from holdover-in-spec to locked when upstream clock recovers",
 			reportxml.ID("88274"), func() {
-				assertHoldoverInSpecToLocked(testData, holdoverPluginSettingsNoOutOfSpec,
+				assertHoldoverInSpecToLocked(testData, profiles.HoldoverPluginSettingsNoOutOfSpec,
 					timeout, expectedClockClasses, clockClassChanges)
 			})
 
 		// 88275 - Verifies t-tsc transition from holdover-in-spec to freerun when localmaxholdoveroffset reached
 		It("verifies t-tsc transition from holdover-in-spec to freerun when localmaxholdoveroffset reached",
 			reportxml.ID("88275"), func() {
-				assertHoldoverInSpecToFreerun(testData, holdoverPluginSettingsNoOutOfSpec,
+				assertHoldoverInSpecToFreerun(testData, profiles.HoldoverPluginSettingsNoOutOfSpec,
 					timeout, expectedClockClasses, clockClassChanges)
 			})
 
 		// 88276 - Verifies t-tsc transition from holdover-in-spec to holdover-out-of-spec when maxinspecoffset reached
 		It("verifies t-tsc transition from holdover-in-spec to holdover-out-of-spec when maxinspecoffset reached",
 			reportxml.ID("88276"), func() {
-				assertHoldoverInSpecToOutOfSpec(testData, holdoverPluginSettingsWithOutOfSpec,
+				assertHoldoverInSpecToOutOfSpec(testData, profiles.HoldoverPluginSettingsWithOutOfSpec,
 					timeout, expectedClockClasses, clockClassChanges)
 			})
 
 		// 88277 - Verifies t-tsc transition from holdover-out-of-spec to freerun when localmaxholdoveroffset reached
 		It("verifies t-tsc transition from holdover-out-of-spec to freerun when localmaxholdoveroffset reached",
 			reportxml.ID("88277"), func() {
-				assertHoldoverOutOfSpecToFreerun(testData, holdoverPluginSettingsWithOutOfSpec,
+				assertHoldoverOutOfSpecToFreerun(testData, profiles.HoldoverPluginSettingsWithOutOfSpec,
 					timeout, expectedClockClasses, clockClassChanges)
 			})
 	})
@@ -221,85 +181,85 @@ var _ = Describe("PTP Holdover", Label(tsparams.LabelTBCTSCHoldover), func() {
 // assertHoldoverInSpecToLocked validates that after upstream clock loss the clock enters holdover-in-spec,
 // then recovers to locked when upstream is restored. No FREERUN events should be generated.
 func assertHoldoverInSpecToLocked(
-	testData holdoverTestData,
+	testData profiles.HoldoverTestData,
 	pluginSettings profiles.HoldoverPluginSettings,
 	timeout time.Duration,
-	expected holdoverExpectedClockClasses,
+	expected profiles.HoldoverExpectedClockClasses,
 	clockClassChanges bool,
 ) {
 	GinkgoHelper()
 
 	changeHoldoverSettings(testData, pluginSettings, expected.Locked, clockClassChanges, timeout)
 
-	By("setting upstream clock interface down to enter holdover-in-spec")
+	By("setting upstream clock interfaces down to enter holdover-in-spec")
 
 	ifaceDownTime := time.Now()
 
-	err := iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, testData.nodeName,
-		testData.upstreamIface, iface.InterfaceStateDown)
-	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interface down")
-
 	DeferCleanup(func() {
-		restoreInterfaceAndWaitForRelock(testData.prometheusAPI, testData.nodeName, testData.upstreamIface)
+		restoreInterfacesAndWaitForRelock(testData.PrometheusAPI, testData.NodeName, testData.UpstreamIfaces)
 	})
 
-	assertHoldoverState(testData.prometheusAPI, testData.nodeName, ifaceDownTime,
-		expected.HoldoverInSpec, clockClassChanges, timeout)
+	err := iface.SetInterfacesStatus(RANConfig.Spoke1APIClient,
+		testData.NodeName, testData.UpstreamIfaces, iface.InterfaceStateDown)
+	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces down")
 
-	By("setting upstream clock interface up to return to locked")
+	assertHoldoverState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
+		expected.HoldoverInSpec, clockClassChanges, timeout, true)
+
+	By("setting upstream clock interfaces up to return to locked")
 
 	ifaceUpTime := time.Now()
 
-	err = iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, testData.nodeName,
-		testData.upstreamIface, iface.InterfaceStateUp)
-	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interface up")
+	err = iface.SetInterfacesStatus(RANConfig.Spoke1APIClient,
+		testData.NodeName, testData.UpstreamIfaces, iface.InterfaceStateUp)
+	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces up")
 
-	assertLockedState(testData.prometheusAPI, testData.nodeName, ifaceUpTime,
+	assertLockedState(testData.PrometheusAPI, testData.NodeName, ifaceUpTime,
 		expected.Locked, clockClassChanges, timeout)
 
-	assertNoFreerunEvent(testData.nodeName, ifaceUpTime)
+	assertNoFreerunEvent(testData.NodeName, ifaceUpTime)
 }
 
 // assertHoldoverInSpecToFreerun validates that after upstream clock loss the clock enters holdover-in-spec,
 // transitions to freerun when LocalMaxHoldoverOffSet is reached, then recovers to locked when upstream is restored.
 func assertHoldoverInSpecToFreerun(
-	testData holdoverTestData,
+	testData profiles.HoldoverTestData,
 	pluginSettings profiles.HoldoverPluginSettings,
 	timeout time.Duration,
-	expected holdoverExpectedClockClasses,
+	expected profiles.HoldoverExpectedClockClasses,
 	clockClassChanges bool,
 ) {
 	GinkgoHelper()
 
 	changeHoldoverSettings(testData, pluginSettings, expected.Locked, clockClassChanges, timeout)
 
-	By("setting upstream clock interface down to enter holdover-in-spec")
+	By("setting upstream clock interfaces down to enter holdover-in-spec")
 
 	ifaceDownTime := time.Now()
 
-	err := iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, testData.nodeName,
-		testData.upstreamIface, iface.InterfaceStateDown)
-	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interface down")
-
 	DeferCleanup(func() {
-		restoreInterfaceAndWaitForRelock(testData.prometheusAPI, testData.nodeName, testData.upstreamIface)
+		restoreInterfacesAndWaitForRelock(testData.PrometheusAPI, testData.NodeName, testData.UpstreamIfaces)
 	})
 
-	assertHoldoverState(testData.prometheusAPI, testData.nodeName, ifaceDownTime,
-		expected.HoldoverInSpec, clockClassChanges, timeout)
+	err := iface.SetInterfacesStatus(RANConfig.Spoke1APIClient,
+		testData.NodeName, testData.UpstreamIfaces, iface.InterfaceStateDown)
+	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces down")
 
-	assertFreerunState(testData.prometheusAPI, testData.nodeName, ifaceDownTime,
+	assertHoldoverState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
+		expected.HoldoverInSpec, clockClassChanges, timeout, true)
+
+	assertFreerunState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
 		expected.Freerun, clockClassChanges, timeout)
 
-	By("setting upstream clock interface up to return to locked")
+	By("setting upstream clock interfaces up to return to locked")
 
 	ifaceUpTime := time.Now()
 
-	err = iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, testData.nodeName,
-		testData.upstreamIface, iface.InterfaceStateUp)
-	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interface up")
+	err = iface.SetInterfacesStatus(RANConfig.Spoke1APIClient,
+		testData.NodeName, testData.UpstreamIfaces, iface.InterfaceStateUp)
+	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces up")
 
-	assertLockedState(testData.prometheusAPI, testData.nodeName, ifaceUpTime,
+	assertLockedState(testData.PrometheusAPI, testData.NodeName, ifaceUpTime,
 		expected.Locked, clockClassChanges, timeout)
 }
 
@@ -307,124 +267,99 @@ func assertHoldoverInSpecToFreerun(
 // transitions to holdover-out-of-spec when MaxInSpecOffset is reached, then recovers to locked when upstream
 // is restored. No FREERUN events should be generated.
 func assertHoldoverInSpecToOutOfSpec(
-	testData holdoverTestData,
+	testData profiles.HoldoverTestData,
 	pluginSettings profiles.HoldoverPluginSettings,
 	timeout time.Duration,
-	expected holdoverExpectedClockClasses,
+	expected profiles.HoldoverExpectedClockClasses,
 	clockClassChanges bool,
 ) {
 	GinkgoHelper()
 
 	changeHoldoverSettings(testData, pluginSettings, expected.Locked, clockClassChanges, timeout)
 
-	By("setting upstream clock interface down to enter holdover-in-spec")
+	By("setting upstream clock interfaces down to enter holdover-in-spec")
 
 	ifaceDownTime := time.Now()
 
-	err := iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, testData.nodeName,
-		testData.upstreamIface, iface.InterfaceStateDown)
-	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interface down")
-
 	DeferCleanup(func() {
-		restoreInterfaceAndWaitForRelock(testData.prometheusAPI, testData.nodeName, testData.upstreamIface)
+		restoreInterfacesAndWaitForRelock(testData.PrometheusAPI, testData.NodeName, testData.UpstreamIfaces)
 	})
 
-	assertHoldoverState(testData.prometheusAPI, testData.nodeName, ifaceDownTime,
-		expected.HoldoverInSpec, clockClassChanges, timeout)
+	err := iface.SetInterfacesStatus(RANConfig.Spoke1APIClient,
+		testData.NodeName, testData.UpstreamIfaces, iface.InterfaceStateDown)
+	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces down")
 
-	assertHoldoverOutOfSpecClockClass(testData.prometheusAPI, testData.nodeName, ifaceDownTime,
+	assertHoldoverState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
+		expected.HoldoverInSpec, clockClassChanges, timeout, true)
+
+	assertHoldoverOutOfSpecClockClass(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
 		expected.HoldoverOutOfSpec, clockClassChanges, timeout)
 
-	By("setting upstream clock interface up to return to locked")
+	By("setting upstream clock interfaces up to return to locked")
 
 	ifaceUpTime := time.Now()
 
-	err = iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, testData.nodeName,
-		testData.upstreamIface, iface.InterfaceStateUp)
-	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interface up")
+	err = iface.SetInterfacesStatus(RANConfig.Spoke1APIClient,
+		testData.NodeName, testData.UpstreamIfaces, iface.InterfaceStateUp)
+	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces up")
 
-	assertLockedState(testData.prometheusAPI, testData.nodeName, ifaceUpTime,
+	assertLockedState(testData.PrometheusAPI, testData.NodeName, ifaceUpTime,
 		expected.Locked, clockClassChanges, timeout)
 
-	assertNoFreerunEvent(testData.nodeName, ifaceUpTime)
+	assertNoFreerunEvent(testData.NodeName, ifaceUpTime)
 }
 
 // assertHoldoverOutOfSpecToFreerun validates the full cascade: holdover-in-spec -> holdover-out-of-spec -> freerun,
 // then recovery to locked when upstream is restored.
 func assertHoldoverOutOfSpecToFreerun(
-	testData holdoverTestData,
+	testData profiles.HoldoverTestData,
 	pluginSettings profiles.HoldoverPluginSettings,
 	timeout time.Duration,
-	expected holdoverExpectedClockClasses,
+	expected profiles.HoldoverExpectedClockClasses,
 	clockClassChanges bool,
 ) {
 	GinkgoHelper()
 
 	changeHoldoverSettings(testData, pluginSettings, expected.Locked, clockClassChanges, timeout)
 
-	By("setting upstream clock interface down to enter holdover-in-spec")
+	By("setting upstream clock interfaces down to enter holdover-in-spec")
 
 	ifaceDownTime := time.Now()
 
-	err := iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, testData.nodeName,
-		testData.upstreamIface, iface.InterfaceStateDown)
-	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interface down")
-
 	DeferCleanup(func() {
-		restoreInterfaceAndWaitForRelock(testData.prometheusAPI, testData.nodeName, testData.upstreamIface)
+		restoreInterfacesAndWaitForRelock(testData.PrometheusAPI, testData.NodeName, testData.UpstreamIfaces)
 	})
 
-	assertHoldoverState(testData.prometheusAPI, testData.nodeName, ifaceDownTime,
-		expected.HoldoverInSpec, clockClassChanges, timeout)
+	err := iface.SetInterfacesStatus(RANConfig.Spoke1APIClient,
+		testData.NodeName, testData.UpstreamIfaces, iface.InterfaceStateDown)
+	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces down")
 
-	assertHoldoverOutOfSpecClockClass(testData.prometheusAPI, testData.nodeName, ifaceDownTime,
+	assertHoldoverState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
+		expected.HoldoverInSpec, clockClassChanges, timeout, true)
+
+	assertHoldoverOutOfSpecClockClass(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
 		expected.HoldoverOutOfSpec, clockClassChanges, timeout)
 
-	assertFreerunState(testData.prometheusAPI, testData.nodeName, ifaceDownTime,
+	assertFreerunState(testData.PrometheusAPI, testData.NodeName, ifaceDownTime,
 		expected.Freerun, clockClassChanges, timeout)
 
-	By("setting upstream clock interface up to return to locked")
+	By("setting upstream clock interfaces up to return to locked")
 
 	ifaceUpTime := time.Now()
 
-	err = iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, testData.nodeName,
-		testData.upstreamIface, iface.InterfaceStateUp)
-	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interface up")
+	err = iface.SetInterfacesStatus(RANConfig.Spoke1APIClient,
+		testData.NodeName, testData.UpstreamIfaces, iface.InterfaceStateUp)
+	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interfaces up")
 
-	assertLockedState(testData.prometheusAPI, testData.nodeName, ifaceUpTime,
+	assertLockedState(testData.PrometheusAPI, testData.NodeName, ifaceUpTime,
 		expected.Locked, clockClassChanges, timeout)
 }
 
-// restoreInterfaceAndWaitForRelock brings the upstream interface back up and waits for the T-BC clock to return
-// to LOCKED state with a 5-second stable duration, matching the OC 2-port restore pattern. The process label
-// is T-BC because the linuxptp-daemon uses the clockType from PtpSettings (set to "T-BC" for T-BC profiles)
-// as the process label for clock state metrics. T-TSC profiles use the same shared helpers and the same process
-// label because cnf-gotests uses ProcessTBC for both T-BC and T-TSC holdover metric assertions.
-func restoreInterfaceAndWaitForRelock(
-	prometheusAPI prometheusv1.API,
-	nodeName string,
-	upstreamIface iface.Name,
-) {
-	GinkgoHelper()
-
-	By("restoring upstream interface and waiting for relock")
-
-	err := iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, nodeName,
-		upstreamIface, iface.InterfaceStateUp)
-	Expect(err).ToNot(HaveOccurred(), "Failed to restore upstream clock interface")
-
-	clockStateQuery := metrics.ClockStateQuery{
-		Node:    metrics.Equals(nodeName),
-		Process: metrics.Equals(metrics.ProcessTBC),
-	}
-	err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockStateQuery, metrics.ClockStateLocked,
-		metrics.AssertWithStableDuration(5*time.Second),
-		metrics.AssertWithTimeout(3*time.Minute))
-	Expect(err).ToNot(HaveOccurred(), "Clock did not return to LOCKED after restoration")
-}
-
 // assertHoldoverState waits for the HOLDOVER event and optional clock class change event, then validates
-// the corresponding Prometheus metrics.
+// the corresponding Prometheus metrics when checkMetrics is true. When checkMetrics is false the function
+// returns after the event checks, skipping the Prometheus metric assertions. This is useful for scenarios
+// such as dual T-BC failover where the clock may re-lock from a backup upstream port before the metric
+// query runs.
 func assertHoldoverState(
 	prometheusAPI prometheusv1.API,
 	nodeName string,
@@ -432,6 +367,7 @@ func assertHoldoverState(
 	expectedClockClass metrics.PtpClockClass,
 	clockClassChanges bool,
 	timeout time.Duration,
+	checkMetrics bool,
 ) {
 	GinkgoHelper()
 
@@ -456,6 +392,10 @@ func assertHoldoverState(
 		)
 		err = events.WaitForEvent(eventPod, sinceTime, timeout, clockClassFilter)
 		Expect(err).ToNot(HaveOccurred(), "Failed to wait for clock class %d event", expectedClockClass)
+	}
+
+	if !checkMetrics {
+		return
 	}
 
 	By(fmt.Sprintf("validating metrics: clock class %d, clock state HOLDOVER", expectedClockClass))
@@ -661,7 +601,7 @@ func assertNoFreerunEvent(nodeName string, sinceTime time.Time) {
 // Routes through HardwareConfig CR on 4.22+/GNRD or PtpConfig plugin on pre-4.22.
 // No-op when desired already matches current; restores originals via DeferCleanup.
 func changeHoldoverSettings(
-	testData holdoverTestData,
+	testData profiles.HoldoverTestData,
 	desired profiles.HoldoverPluginSettings,
 	expectedLockedClass metrics.PtpClockClass,
 	clockClassChanges bool,
@@ -669,7 +609,7 @@ func changeHoldoverSettings(
 ) {
 	GinkgoHelper()
 
-	current, err := profiles.GetHoldoverSettings(RANConfig.Spoke1APIClient, testData.profileInfo)
+	current, err := profiles.GetHoldoverSettings(RANConfig.Spoke1APIClient, testData.ProfileInfo)
 	Expect(err).ToNot(HaveOccurred(), "Failed to get current holdover settings")
 
 	if desired == *current {
@@ -680,36 +620,36 @@ func changeHoldoverSettings(
 
 	By("setting test case holdover settings")
 
-	err = profiles.ApplyHoldoverSettings(RANConfig.Spoke1APIClient, testData.profileInfo, desired)
+	err = profiles.ApplyHoldoverSettings(RANConfig.Spoke1APIClient, testData.ProfileInfo, desired)
 	Expect(err).ToNot(HaveOccurred(), "Failed to apply holdover settings")
 
 	DeferCleanup(func() {
 		By("restoring original holdover settings")
 
-		restoreErr := profiles.ApplyHoldoverSettings(RANConfig.Spoke1APIClient, testData.profileInfo, original)
+		restoreErr := profiles.ApplyHoldoverSettings(RANConfig.Spoke1APIClient, testData.ProfileInfo, original)
 		Expect(restoreErr).ToNot(HaveOccurred(), "Failed to restore holdover settings")
 
 		restoreTime := time.Now()
 
 		restoreErr = profiles.WaitForHoldoverSettingsApplied(
-			RANConfig.Spoke1APIClient, testData.nodeName, testData.profileInfo, restoreTime, 5*time.Minute)
+			RANConfig.Spoke1APIClient, testData.NodeName, testData.ProfileInfo, restoreTime, 5*time.Minute)
 		Expect(restoreErr).ToNot(HaveOccurred(), "Daemon did not reload after restore")
 
 		restoreTime = time.Now()
 
-		assertLockedState(testData.prometheusAPI, testData.nodeName, restoreTime,
+		assertLockedState(testData.PrometheusAPI, testData.NodeName, restoreTime,
 			expectedLockedClass, clockClassChanges, timeout)
 	})
 
 	setTime := time.Now()
 
 	err = profiles.WaitForHoldoverSettingsApplied(
-		RANConfig.Spoke1APIClient, testData.nodeName, testData.profileInfo, setTime, 3*time.Minute)
+		RANConfig.Spoke1APIClient, testData.NodeName, testData.ProfileInfo, setTime, 3*time.Minute)
 	Expect(err).ToNot(HaveOccurred(), "Daemon did not reload after config change")
 
 	setTime = time.Now()
 
-	assertLockedState(testData.prometheusAPI, testData.nodeName, setTime,
+	assertLockedState(testData.PrometheusAPI, testData.NodeName, setTime,
 		expectedLockedClass, clockClassChanges, timeout)
 }
 
@@ -719,7 +659,7 @@ func changeHoldoverSettings(
 func discoverHoldoverTestData(
 	prometheusAPI prometheusv1.API,
 	profileType profiles.PtpProfileType,
-) *holdoverTestData {
+) *profiles.HoldoverTestData {
 	nodeInfoMap, err := profiles.GetNodeInfoMap(RANConfig.Spoke1APIClient)
 	Expect(err).ToNot(HaveOccurred(), "Failed to get node info map")
 
@@ -736,23 +676,50 @@ func discoverHoldoverTestData(
 				continue
 			}
 
-			port, portErr := profiles.GetUpstreamPortForProfile(ptpProfile)
+			ports, portErr := profiles.GetUpstreamPortsForProfile(ptpProfile)
 			if portErr != nil {
 				klog.V(tsparams.LogLevel).Infof(
-					"Skipping profile %s on node %s: cannot determine upstream port: %v",
+					"Skipping profile %s on node %s: cannot determine upstream ports: %v",
 					profileInfo.Reference.ProfileName, name, portErr)
 
 				continue
 			}
 
-			return &holdoverTestData{
-				prometheusAPI: prometheusAPI,
-				nodeName:      name,
-				profileInfo:   profileInfo,
-				upstreamIface: port,
+			return &profiles.HoldoverTestData{
+				PrometheusAPI:  prometheusAPI,
+				NodeName:       name,
+				ProfileInfo:    profileInfo,
+				UpstreamIfaces: ports,
 			}
 		}
 	}
 
 	return nil
+}
+
+// restoreInterfacesAndWaitForRelock brings the upstream interfaces back up and waits for the T-BC clock to return
+// to LOCKED state with a 5-second stable duration, matching the OC 2-port restore pattern. The process label
+// is T-BC because the linuxptp-daemon uses the clockType from PtpSettings (set to "T-BC" for T-BC profiles)
+// as the process label for clock state metrics. T-TSC profiles use the same shared helpers and the same process
+// label because cnf-gotests uses ProcessTBC for both T-BC and T-TSC holdover metric assertions.
+func restoreInterfacesAndWaitForRelock(
+	prometheusAPI prometheusv1.API,
+	nodeName string,
+	upstreamIfaces []iface.Name,
+) {
+	GinkgoHelper()
+
+	By("restoring upstream interfaces and waiting for relock")
+
+	err := iface.SetInterfacesStatus(RANConfig.Spoke1APIClient, nodeName, upstreamIfaces, iface.InterfaceStateUp)
+	Expect(err).ToNot(HaveOccurred(), "Failed to restore upstream clock interfaces")
+
+	clockStateQuery := metrics.ClockStateQuery{
+		Node:    metrics.Equals(nodeName),
+		Process: metrics.Equals(metrics.ProcessTBC),
+	}
+	err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockStateQuery, metrics.ClockStateLocked,
+		metrics.AssertWithStableDuration(5*time.Second),
+		metrics.AssertWithTimeout(3*time.Minute))
+	Expect(err).ToNot(HaveOccurred(), "Clock did not return to LOCKED after restoration")
 }

--- a/tests/cnf/ran/ptp/tests/ptp-oc-2-port.go
+++ b/tests/cnf/ran/ptp/tests/ptp-oc-2-port.go
@@ -383,7 +383,7 @@ func getOc2PortInfo(
 
 	var err error
 
-	activeInterface, passiveInterface, err := profiles.Oc2PortDetermineActivePassiveInterfaces(
+	activeInterface, passiveInterface, err := profiles.DetermineActivePassiveInterfaces(
 		context.TODO(), prometheusAPI, nodeName, oc2PortInterfaces)
 	Expect(err).ToNot(HaveOccurred(), "Failed to determine active/passive interfaces")
 
@@ -443,7 +443,7 @@ func waitForOc2PortActivePassive(
 	GinkgoHelper()
 
 	Eventually(func() error {
-		_, _, err := profiles.Oc2PortDetermineActivePassiveInterfaces(
+		_, _, err := profiles.DetermineActivePassiveInterfaces(
 			ctx, prometheusAPI, nodeName, oc2PortInterfaces)
 
 		return err


### PR DESCRIPTION
## Summary

Adds automated tests for the dual time receiver ports (same NIC) T-BC feature (CNF-22709).
When a T-BC profile has two upstream time receiver ports on the same NIC (same PHC), ptp4l
uses priority-based failover between them. These tests validate holdover behavior for that
configuration on both WPC (E810) and GNRD (E825) environments.

Jira: https://redhat.atlassian.net/browse/CNF-23885

### Changes

- **New profile type `ProfileTypeDualTBCReceiver`** — classified by `clockType: T-BC` with
  2+ client interfaces in ptp4lConf, distinguished from two-port OC before the existing
  `ProfileTypeTwoPortOC` match.
- **`GetUpstreamPortsForProfile`** — new helper that splits comma-separated `upstreamPort`
  values (e.g. `ens7f1,ens7f3`) into multiple `iface.Name` entries. Single-port callers
  use the existing `GetUpstreamPortForProfile` which now delegates to it.
- **Holdover helpers refactored** — `ptp-holdover.go` helpers (`setUpstreamInterfacesStatus`,
  `restoreInterfacesAndWaitForRelock`) now operate on `[]iface.Name` so they work for both
  single and dual upstream port configurations.
- **New test file `ptp-dual-tbc.go`** with label `dual-tbc`, gated from PTP operator 5.0:
  - **OCP-89744** — Active TR port down → HOLDOVER (clock class 135) → failover to backup
    port → LOCKED (clock class 6). Validates interface roles (FAULTY / FOLLOWER).
  - **OCP-89746** — Both TR ports down → HOLDOVER → FREERUN (clock class 248). Both
    interfaces FAULTY. Restore → LOCKED.
  - Holdover in-spec → locked (no out-of-spec, IDs TBD)
  - Holdover in-spec → out-of-spec (IDs TBD)
  - Holdover out-of-spec → freerun (IDs TBD)
- **Unit tests** for `isDualTBCReceiver` profile classification and `GetUpstreamPortsForProfile`
  comma splitting.

### Notes

- OCP-89745 (BC, non T-BC counterpart) is intentionally not included per test plan.
- The existing single T-BC holdover tests (83297–83300) and T-TSC tests (88274–88277) are
  unaffected — they look up `ProfileTypeTBCReceiver` / `ProfileTypeTTSC` and skip when only
  a dual T-BC config is present, and vice versa.

## Test plan

- [x] Run on a **WPC** environment with a dual T-BC PtpConfig
      (e.g. `PtpConfigTbcTimeReciverPortsSameNic.yaml` — E810, `upstreamPort: ens7f1,ens7f3`)
      Label filter: `--ginkgo.label-filter="dual-tbc"`
- [x] Run on a **GNRD** environment with a dual T-BC PtpConfig
      (e.g. `PtpConfigDualTBcTRGnrd.yaml` — E825, `upstreamPort: eno8503np2,eno8603np3`)
      Label filter: `--ginkgo.label-filter="dual-tbc"`
- [x] Verify single T-BC holdover tests (label `tbc-tsc-holdover`) still pass on a
      cluster with a classic single-port T-BC config (no regression)
- [x] Verify dual T-BC tests skip cleanly on a cluster with no dual T-BC config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Dual T-BC receiver profiles with active and backup upstream interfaces.
  * Added failover and holdover validation scenarios for Dual T-BC configurations.
  * Added support for discovering and managing multiple upstream interfaces.
  * Added bulk interface state changes with detailed failure reporting.

* **Bug Fixes**
  * Improved passive-interface detection for listening and passive roles.
  * Updated holdover validation to support multiple upstream interfaces and clock-class variations.

* **Tests**
  * Added coverage for Dual T-BC profile detection, upstream-port parsing, failover, and holdover behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->