### PR TITLE
Fix dra driver image version

### DIFF
--- a/tests/hw-accel/kmm/README.md
+++ b/tests/hw-accel/kmm/README.md
@@ -48,6 +48,7 @@ Notes:
 - `ECO_HWACCEL_KMM_PULL_SECRET`: External registry pull-secret 
 - `ECO_HWACCEL_KMM_REGISTRY`: External registry url (eg: quay.io/ocp-edge-qe )
 - `ECO_HWACCEL_KMM_DEVICE_PLUGIN_IMAGE`: Image used for the device-plugin test. If the image tag includes `%s` it will be replaced with the architecture ( amd64 / arm64 )
+- `ECO_HWACCEL_KMM_DRA_DRIVER_IMAGE_REPO`: DRA example driver image repository. The tag is resolved automatically from the cluster's Kubernetes version. DRA tests are skipped if not set.
 
 #### Upgrade related
 - `ECO_HWACCEL_KMM_SUBSCRIPTION_NAME`: Name of subscription used to deploy the KMM operator

--- a/tests/hw-accel/kmm/internal/kmmconfig/config.go
+++ b/tests/hw-accel/kmm/internal/kmmconfig/config.go
@@ -19,6 +19,7 @@ type ModulesConfig struct {
 	CatalogSourceName    string `envconfig:"ECO_HWACCEL_KMM_CATALOG_SOURCE_NAME"`
 	CatalogSourceChannel string `envconfig:"ECO_HWACCEL_KMM_CATALOG_SOURCE_CHANNEL"`
 	UpgradeTargetVersion string `envconfig:"ECO_HWACCEL_KMM_UPGRADE_TARGET_VERSION"`
+	DRADriverImageRepo   string `envconfig:"ECO_HWACCEL_KMM_DRA_DRIVER_IMAGE_REPO"`
 	SpokeKubeConfig      string `envconfig:"ECO_HWACCEL_KMM_SPOKE_KUBECONFIG"`
 	SpokeClusterName     string `envconfig:"ECO_HWACCEL_KMM_SPOKE_CLUSTER_NAME"`
 	SpokeAPIClient       *clients.Settings

--- a/tests/hw-accel/kmm/internal/kmmparams/const.go
+++ b/tests/hw-accel/kmm/internal/kmmparams/const.go
@@ -319,8 +319,8 @@ const (
 	DRADeviceClassTestNamespace = "89703-dc"
 	// DRAPresetEnvTestNamespace represents test case namespace for DRA preset env/probe tests.
 	DRAPresetEnvTestNamespace = "89705-env"
-	// DRADriverImage represents the DRA example driver image used in DRA tests.
-	DRADriverImage = "registry.k8s.io/dra-example-driver/dra-example-driver:v0.3.0"
+	// DRADriverImageRepo is the base repository for the DRA example driver.
+	DRADriverImageRepo = "quay.io/ocp-edge-qe/dra-example-driver"
 	// DRADriverName represents the DRA driver name used in tests.
 	DRADriverName = "gpu.example.com"
 	// DRADeviceClassName represents the default DeviceClass name used in DRA tests.

--- a/tests/hw-accel/kmm/internal/kmmparams/const.go
+++ b/tests/hw-accel/kmm/internal/kmmparams/const.go
@@ -319,8 +319,6 @@ const (
 	DRADeviceClassTestNamespace = "89703-dc"
 	// DRAPresetEnvTestNamespace represents test case namespace for DRA preset env/probe tests.
 	DRAPresetEnvTestNamespace = "89705-env"
-	// DRADriverImageRepo is the base repository for the DRA example driver.
-	DRADriverImageRepo = "quay.io/ocp-edge-qe/dra-example-driver"
 	// DRADriverName represents the DRA driver name used in tests.
 	DRADriverName = "gpu.example.com"
 	// DRADeviceClassName represents the default DeviceClass name used in DRA tests.

--- a/tests/hw-accel/kmm/internal/kmmparams/kmmvars.go
+++ b/tests/hw-accel/kmm/internal/kmmparams/kmmvars.go
@@ -2,6 +2,8 @@ package kmmparams
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/internal/hwaccelparams"
 	corev1 "k8s.io/api/core/v1"
@@ -106,4 +108,38 @@ var (
 		Operator: corev1.TolerationOpEqual,
 		Effect:   corev1.TaintEffectNoExecute,
 	}
+
+	// DRADriverImage is the DRA example driver image, resolved at runtime
+	// from the cluster's Kubernetes version. Call SetDRADriverImage before
+	// running DRA tests.
+	DRADriverImage = fmt.Sprintf("%s:v0.4.0", DRADriverImageRepo)
+
+	draDriverTags = map[int]string{
+		32: "v0.1.0",
+		33: "v0.2.0",
+		34: "v0.2.1",
+		35: "v0.2.1",
+		36: "v0.3.0",
+		37: "v0.4.0",
+	}
 )
+
+// SetDRADriverImage resolves the DRA example driver image tag from the
+// cluster's Kubernetes version (e.g. "v1.35.3") and stores it in
+// DRADriverImage. Unknown versions fall back to the latest tag.
+func SetDRADriverImage(serverVersion string) {
+	v := strings.TrimPrefix(serverVersion, "v")
+	parts := strings.SplitN(v, ".", 3)
+
+	if len(parts) >= 2 {
+		if minor, err := strconv.Atoi(parts[1]); err == nil {
+			if tag, ok := draDriverTags[minor]; ok {
+				DRADriverImage = fmt.Sprintf("%s:%s", DRADriverImageRepo, tag)
+
+				return
+			}
+		}
+	}
+
+	DRADriverImage = fmt.Sprintf("%s:v0.4.0", DRADriverImageRepo)
+}

--- a/tests/hw-accel/kmm/internal/kmmparams/kmmvars.go
+++ b/tests/hw-accel/kmm/internal/kmmparams/kmmvars.go
@@ -111,8 +111,8 @@ var (
 
 	// DRADriverImage is the DRA example driver image, resolved at runtime
 	// from the cluster's Kubernetes version. Call SetDRADriverImage before
-	// running DRA tests.
-	DRADriverImage = fmt.Sprintf("%s:v0.4.0", DRADriverImageRepo)
+	// running DRA tests. Empty until SetDRADriverImage is called.
+	DRADriverImage string
 
 	draDriverTags = map[int]string{
 		32: "v0.1.0",
@@ -126,20 +126,26 @@ var (
 
 // SetDRADriverImage resolves the DRA example driver image tag from the
 // cluster's Kubernetes version (e.g. "v1.35.3") and stores it in
-// DRADriverImage. Unknown versions fall back to the latest tag.
-func SetDRADriverImage(serverVersion string) {
+// DRADriverImage. repo is the image repository set via
+// ECO_HWACCEL_KMM_DRA_DRIVER_IMAGE_REPO. If repo is empty,
+// DRADriverImage remains empty and DRA tests should be skipped.
+func SetDRADriverImage(repo, serverVersion string) {
+	if repo == "" {
+		return
+	}
+
+	tag := "v0.4.0"
+
 	v := strings.TrimPrefix(serverVersion, "v")
 	parts := strings.SplitN(v, ".", 3)
 
 	if len(parts) >= 2 {
 		if minor, err := strconv.Atoi(parts[1]); err == nil {
-			if tag, ok := draDriverTags[minor]; ok {
-				DRADriverImage = fmt.Sprintf("%s:%s", DRADriverImageRepo, tag)
-
-				return
+			if t, ok := draDriverTags[minor]; ok {
+				tag = t
 			}
 		}
 	}
 
-	DRADriverImage = fmt.Sprintf("%s:v0.4.0", DRADriverImageRepo)
+	DRADriverImage = fmt.Sprintf("%s:%s", repo, tag)
 }

--- a/tests/hw-accel/kmm/modules/modules_suite_test.go
+++ b/tests/hw-accel/kmm/modules/modules_suite_test.go
@@ -46,6 +46,14 @@ func TestModules(t *testing.T) {
 var _ = BeforeSuite(func() {
 	By("Prepare environment for KMM tests execution")
 
+	By("Resolve DRA driver image for cluster k8s version")
+
+	serverVersion, err := APIClient.K8sClient.Discovery().ServerVersion()
+	Expect(err).ToNot(HaveOccurred(), "error getting server version")
+	kmmparams.SetDRADriverImage(serverVersion.GitVersion)
+	klog.V(kmmparams.KmmLogLevel).Infof("Resolved DRA driver image: %s (k8s %s)",
+		kmmparams.DRADriverImage, serverVersion.GitVersion)
+
 	By("Create helper ServiceAccount")
 
 	svcAccount, err := serviceaccount.

--- a/tests/hw-accel/kmm/modules/modules_suite_test.go
+++ b/tests/hw-accel/kmm/modules/modules_suite_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/serviceaccount"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/define"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/get"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/kmminittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/kmmparams"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/reporter"
@@ -50,7 +51,7 @@ var _ = BeforeSuite(func() {
 
 	serverVersion, err := APIClient.K8sClient.Discovery().ServerVersion()
 	Expect(err).ToNot(HaveOccurred(), "error getting server version")
-	kmmparams.SetDRADriverImage(serverVersion.GitVersion)
+	kmmparams.SetDRADriverImage(ModulesConfig.DRADriverImageRepo, serverVersion.GitVersion)
 	klog.V(kmmparams.KmmLogLevel).Infof("Resolved DRA driver image: %s (k8s %s)",
 		kmmparams.DRADriverImage, serverVersion.GitVersion)
 

--- a/tests/hw-accel/kmm/modules/tests/dra-advanced-test.go
+++ b/tests/hw-accel/kmm/modules/tests/dra-advanced-test.go
@@ -30,6 +30,12 @@ import (
 
 var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSanity), func() {
 	Context("DRA Advanced", Label("dra", "dra-advanced"), func() {
+		BeforeEach(func() {
+			if kmmparams.DRADriverImage == "" {
+				Skip("ECO_HWACCEL_KMM_DRA_DRIVER_IMAGE_REPO is not set")
+			}
+		})
+
 		Context("DeviceClass Lifecycle", Label("dra-deviceclass"), func() {
 			nSpace := kmmparams.DRADeviceClassTestNamespace
 			moduleName := "dc-lifecycle-test"

--- a/tests/hw-accel/kmm/modules/tests/dra-functional-test.go
+++ b/tests/hw-accel/kmm/modules/tests/dra-functional-test.go
@@ -25,6 +25,12 @@ import (
 
 var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSanity), func() {
 	Context("DRA Functional", Label("dra", "dra-functional"), func() {
+		BeforeEach(func() {
+			if kmmparams.DRADriverImage == "" {
+				Skip("ECO_HWACCEL_KMM_DRA_DRIVER_IMAGE_REPO is not set")
+			}
+		})
+
 		Context("Backward Compatibility", Label("dra-compat"), func() {
 			nSpace := kmmparams.DRABackwardCompatTestNamespace
 			moduleName := "compat-test-module"

--- a/tests/hw-accel/kmm/modules/tests/dra-lifecycle-test.go
+++ b/tests/hw-accel/kmm/modules/tests/dra-lifecycle-test.go
@@ -28,6 +28,12 @@ import (
 
 var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSanity), func() {
 	Context("DRA Lifecycle", Label("dra", "dra-lifecycle"), func() {
+		BeforeEach(func() {
+			if kmmparams.DRADriverImage == "" {
+				Skip("ECO_HWACCEL_KMM_DRA_DRIVER_IMAGE_REPO is not set")
+			}
+		})
+
 		Context("Happy Path", Label("dra-happy-path"), func() {
 			nSpace := kmmparams.DRAHappyPathTestNamespace
 			moduleName := "dra-test-module"

--- a/tests/hw-accel/kmm/modules/tests/dra-upgrade-test.go
+++ b/tests/hw-accel/kmm/modules/tests/dra-upgrade-test.go
@@ -33,6 +33,12 @@ import (
 
 var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSanity), func() {
 	Context("DRA Ordered Upgrade", Label("dra", "dra-upgrade"), func() {
+		BeforeEach(func() {
+			if kmmparams.DRADriverImage == "" {
+				Skip("ECO_HWACCEL_KMM_DRA_DRIVER_IMAGE_REPO is not set")
+			}
+		})
+
 		nSpace := kmmparams.DRAUpgradeTestNamespace
 		moduleName := "test-upgrade-dra"
 		tempModuleName := "test-upgrade-dra-v2"

--- a/tests/hw-accel/kmm/modules/tests/dra-validation-test.go
+++ b/tests/hw-accel/kmm/modules/tests/dra-validation-test.go
@@ -20,6 +20,12 @@ import (
 
 var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSanity), func() {
 	Context("DRA Validation", Label("dra", "dra-validation"), func() {
+		BeforeEach(func() {
+			if kmmparams.DRADriverImage == "" {
+				Skip("ECO_HWACCEL_KMM_DRA_DRIVER_IMAGE_REPO is not set")
+			}
+		})
+
 		nSpace := kmmparams.DRAValidationTestNamespace
 		image := fmt.Sprintf("%s/%s/%s:$KERNEL_FULL_VERSION",
 			tsparams.LocalImageRegistry, nSpace, "dra-kmod")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically selects a compatible DRA driver image based on the cluster’s Kubernetes version.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration for the DRA driver image repository through an environment variable.
  - Automatically selects a compatible driver image tag based on the cluster’s Kubernetes version.
  - DRA tests are skipped when no driver image repository is configured.

- **Documentation**
  - Updated the KMM test suite documentation with the new configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->