### PR TITLE
hw-accel: Add Neuron DRA RBAC, ResourceSlice, and cleanup tests

### DIFF
--- a/tests/hw-accel/neuron/dra/tests/dra-cleanup-test.go
+++ b/tests/hw-accel/neuron/dra/tests/dra-cleanup-test.go
@@ -1,0 +1,118 @@
+package tests
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/neuron"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/dra/internal/tsparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/neuronconfig"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/params"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+var _ = Describe("Neuron DRA Cleanup Tests", Ordered,
+	Label(params.Label, params.DRALabel, "dra-cleanup"), func() {
+		Context("DeviceConfig deletion cleanup", Label(tsparams.LabelSuite), func() {
+			neuronCfg := neuronconfig.NewNeuronConfig()
+
+			BeforeAll(func() {
+				if !neuronCfg.IsDRAConfigured() {
+					Skip("DRA not configured - ECO_HWACCEL_NEURON_DRA_DRIVER_IMAGE not set")
+				}
+
+				By("Verifying DRA DeviceConfig exists before cleanup")
+
+				dcBuilder, err := neuron.Pull(
+					APIClient, params.DefaultDeviceConfigName, params.NeuronNamespace)
+				Expect(err).ToNot(HaveOccurred(), "DRA DeviceConfig must exist")
+				Expect(dcBuilder.Definition.Spec.DRADriverImage).ToNot(BeEmpty(),
+					"DeviceConfig must be in DRA mode")
+
+				By("Deleting DeviceConfig")
+
+				_, err = dcBuilder.Delete()
+				Expect(err).ToNot(HaveOccurred(), "Failed to delete DeviceConfig")
+
+				By("Waiting for DeviceConfig to be fully deleted")
+
+				Eventually(func() bool {
+					_, pullErr := neuron.Pull(
+						APIClient, params.DefaultDeviceConfigName, params.NeuronNamespace)
+
+					return pullErr != nil
+				}, 5*time.Minute, 5*time.Second).Should(BeTrue(),
+					"DeviceConfig should be deleted")
+
+				klog.V(params.NeuronLogLevel).Info("DeviceConfig deleted, verifying cleanup")
+			})
+
+			It("should remove DRA DaemonSet after DeviceConfig deletion",
+				reportxml.ID("90480"), func() {
+					By("Waiting for DRA DaemonSets to be removed")
+
+					Eventually(func() int {
+						dsList, err := APIClient.K8sClient.AppsV1().DaemonSets(
+							params.NeuronNamespace).List(
+							context.TODO(), metav1.ListOptions{
+								LabelSelector: params.DRADaemonSetLabelKey + "=" + params.DRADaemonSetLabelValue,
+							})
+						if err != nil {
+							return -1
+						}
+
+						return len(dsList.Items)
+					}, 3*time.Minute, 5*time.Second).Should(Equal(0),
+						"All DRA DaemonSets should be removed")
+
+					klog.V(params.NeuronLogLevel).Info("DRA DaemonSets removed")
+				})
+
+			It("should remove ResourceSlices after DRA DaemonSet deletion",
+				reportxml.ID("90481"), func() {
+					By("Waiting for ResourceSlices to be cleaned up")
+
+					Eventually(func() int {
+						sliceList, err := APIClient.K8sClient.ResourceV1().ResourceSlices().List(
+							context.TODO(), metav1.ListOptions{})
+						if err != nil {
+							return -1
+						}
+
+						count := 0
+
+						for idx := range sliceList.Items {
+							if sliceList.Items[idx].Spec.Driver == params.DRADriverName {
+								count++
+							}
+						}
+
+						return count
+					}, 3*time.Minute, 5*time.Second).Should(Equal(0),
+						"All ResourceSlices for %s should be removed", params.DRADriverName)
+
+					klog.V(params.NeuronLogLevel).Info("ResourceSlices cleaned up")
+				})
+
+			It("should remove DeviceClass after DeviceConfig deletion",
+				reportxml.ID("90482"), func() {
+					By("Waiting for DeviceClass to be removed")
+
+					Eventually(func() bool {
+						_, err := APIClient.K8sClient.ResourceV1().DeviceClasses().Get(
+							context.TODO(), params.DRADefaultDeviceClassName, metav1.GetOptions{})
+
+						return err != nil
+					}, 3*time.Minute, 5*time.Second).Should(BeTrue(),
+						"DeviceClass %s should be removed", params.DRADefaultDeviceClassName)
+
+					klog.V(params.NeuronLogLevel).Infof(
+						"DeviceClass %s removed", params.DRADefaultDeviceClassName)
+				})
+		})
+	})

--- a/tests/hw-accel/neuron/dra/tests/dra-crd-validation-test.go
+++ b/tests/hw-accel/neuron/dra/tests/dra-crd-validation-test.go
@@ -1,52 +1,18 @@
 package tests
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	neuronscheme "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/neuron/v1beta1"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/dra/internal/tsparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/do"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/params"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 )
 
-var deviceConfigGVR = schema.GroupVersionResource{
-	Group:    "k8s.aws",
-	Version:  "v1beta1",
-	Resource: "deviceconfigs",
-}
-
-func createDeviceConfigUnstructured(spec map[string]interface{}) error {
-	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "k8s.aws/v1beta1",
-			"kind":       "DeviceConfig",
-			"metadata": map[string]interface{}{
-				"name":      "validation-test",
-				"namespace": params.NeuronNamespace,
-			},
-			"spec": spec,
-		},
-	}
-
-	_, err := APIClient.Resource(deviceConfigGVR).
-		Namespace(params.NeuronNamespace).
-		Create(context.TODO(), obj, metav1.CreateOptions{})
-
-	return err
-}
-
-func deleteDeviceConfigIfExists() {
-	_ = APIClient.Resource(deviceConfigGVR).
-		Namespace(params.NeuronNamespace).
-		Delete(context.TODO(), "validation-test", metav1.DeleteOptions{})
-}
+const validationTestDCName = "validation-test"
 
 var _ = Describe("Neuron DRA CRD Validation Tests", Ordered,
 	Label(params.Label, params.DRALabel, tsparams.LabelValidation), func() {
@@ -55,17 +21,17 @@ var _ = Describe("Neuron DRA CRD Validation Tests", Ordered,
 		})
 
 		BeforeEach(func() {
-			deleteDeviceConfigIfExists()
+			do.DeleteDeviceConfigIfExists(APIClient, validationTestDCName)
 		})
 
 		AfterAll(func() {
-			deleteDeviceConfigIfExists()
+			do.DeleteDeviceConfigIfExists(APIClient, validationTestDCName)
 		})
 
 		Context("Mutual exclusivity — CEL rule 1", Label(tsparams.LabelSuite), func() {
 			It("should reject DeviceConfig with draDriverImage AND devicePluginImage",
 				reportxml.ID("90380"), func() {
-					err := createDeviceConfigUnstructured(map[string]interface{}{
+					err := do.CreateDeviceConfigUnstructured(APIClient, validationTestDCName, map[string]interface{}{
 						"draDriverImage":    "registry.example.com/dra-driver:latest",
 						"devicePluginImage": "registry.example.com/device-plugin:latest",
 						"nodeMetricsImage":  "registry.example.com/metrics:latest",
@@ -78,7 +44,7 @@ var _ = Describe("Neuron DRA CRD Validation Tests", Ordered,
 
 			It("should reject DeviceConfig with draDriverImage AND customSchedulerImage",
 				reportxml.ID("90381"), func() {
-					err := createDeviceConfigUnstructured(map[string]interface{}{
+					err := do.CreateDeviceConfigUnstructured(APIClient, validationTestDCName, map[string]interface{}{
 						"draDriverImage":       "registry.example.com/dra-driver:latest",
 						"customSchedulerImage": "registry.example.com/scheduler:latest",
 						"nodeMetricsImage":     "registry.example.com/metrics:latest",
@@ -91,7 +57,7 @@ var _ = Describe("Neuron DRA CRD Validation Tests", Ordered,
 
 			It("should reject DeviceConfig with draDriverImage AND schedulerExtensionImage",
 				reportxml.ID("90382"), func() {
-					err := createDeviceConfigUnstructured(map[string]interface{}{
+					err := do.CreateDeviceConfigUnstructured(APIClient, validationTestDCName, map[string]interface{}{
 						"draDriverImage":          "registry.example.com/dra-driver:latest",
 						"schedulerExtensionImage": "registry.example.com/scheduler-ext:latest",
 						"nodeMetricsImage":        "registry.example.com/metrics:latest",
@@ -104,7 +70,7 @@ var _ = Describe("Neuron DRA CRD Validation Tests", Ordered,
 
 			It("should reject DeviceConfig with draDriverImage AND all three device-plugin fields",
 				reportxml.ID("90383"), func() {
-					err := createDeviceConfigUnstructured(map[string]interface{}{
+					err := do.CreateDeviceConfigUnstructured(APIClient, validationTestDCName, map[string]interface{}{
 						"draDriverImage":          "registry.example.com/dra-driver:latest",
 						"devicePluginImage":       "registry.example.com/device-plugin:latest",
 						"customSchedulerImage":    "registry.example.com/scheduler:latest",
@@ -121,7 +87,7 @@ var _ = Describe("Neuron DRA CRD Validation Tests", Ordered,
 		Context("Triad completeness — CEL rule 2", Label(tsparams.LabelSuite), func() {
 			It("should reject DeviceConfig with devicePluginImage but missing schedulerExtensionImage",
 				reportxml.ID("90384"), func() {
-					err := createDeviceConfigUnstructured(map[string]interface{}{
+					err := do.CreateDeviceConfigUnstructured(APIClient, validationTestDCName, map[string]interface{}{
 						"devicePluginImage":    "registry.example.com/device-plugin:latest",
 						"customSchedulerImage": "registry.example.com/scheduler:latest",
 						"nodeMetricsImage":     "registry.example.com/metrics:latest",
@@ -134,7 +100,7 @@ var _ = Describe("Neuron DRA CRD Validation Tests", Ordered,
 
 			It("should reject DeviceConfig with devicePluginImage but missing customSchedulerImage",
 				reportxml.ID("90385"), func() {
-					err := createDeviceConfigUnstructured(map[string]interface{}{
+					err := do.CreateDeviceConfigUnstructured(APIClient, validationTestDCName, map[string]interface{}{
 						"devicePluginImage":       "registry.example.com/device-plugin:latest",
 						"schedulerExtensionImage": "registry.example.com/scheduler-ext:latest",
 						"nodeMetricsImage":        "registry.example.com/metrics:latest",
@@ -149,7 +115,7 @@ var _ = Describe("Neuron DRA CRD Validation Tests", Ordered,
 		Context("Valid configurations — happy paths", Label(tsparams.LabelSuite), func() {
 			It("should accept DeviceConfig with only draDriverImage",
 				reportxml.ID("90386"), func() {
-					err := createDeviceConfigUnstructured(map[string]interface{}{
+					err := do.CreateDeviceConfigUnstructured(APIClient, validationTestDCName, map[string]interface{}{
 						"draDriverImage":   "registry.example.com/dra-driver:latest",
 						"nodeMetricsImage": "registry.example.com/metrics:latest",
 					})
@@ -160,7 +126,7 @@ var _ = Describe("Neuron DRA CRD Validation Tests", Ordered,
 
 			It("should accept DeviceConfig with full device-plugin triad",
 				reportxml.ID("90387"), func() {
-					err := createDeviceConfigUnstructured(map[string]interface{}{
+					err := do.CreateDeviceConfigUnstructured(APIClient, validationTestDCName, map[string]interface{}{
 						"devicePluginImage":       "registry.example.com/device-plugin:latest",
 						"customSchedulerImage":    "registry.example.com/scheduler:latest",
 						"schedulerExtensionImage": "registry.example.com/scheduler-ext:latest",
@@ -175,7 +141,7 @@ var _ = Describe("Neuron DRA CRD Validation Tests", Ordered,
 		Context("DeviceClasses validation", Label(tsparams.LabelSuite), func() {
 			It("should accept DRA DeviceConfig with valid deviceClasses",
 				reportxml.ID("90388"), func() {
-					err := createDeviceConfigUnstructured(map[string]interface{}{
+					err := do.CreateDeviceConfigUnstructured(APIClient, validationTestDCName, map[string]interface{}{
 						"draDriverImage":   "registry.example.com/dra-driver:latest",
 						"nodeMetricsImage": "registry.example.com/metrics:latest",
 						"deviceClasses": []interface{}{
@@ -199,7 +165,7 @@ var _ = Describe("Neuron DRA CRD Validation Tests", Ordered,
 
 			It("should reject DeviceConfig with invalid deviceClass name pattern",
 				reportxml.ID("90389"), func() {
-					err := createDeviceConfigUnstructured(map[string]interface{}{
+					err := do.CreateDeviceConfigUnstructured(APIClient, validationTestDCName, map[string]interface{}{
 						"draDriverImage":   "registry.example.com/dra-driver:latest",
 						"nodeMetricsImage": "registry.example.com/metrics:latest",
 						"deviceClasses": []interface{}{

--- a/tests/hw-accel/neuron/dra/tests/dra-rbac-test.go
+++ b/tests/hw-accel/neuron/dra/tests/dra-rbac-test.go
@@ -1,0 +1,139 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/dra/internal/tsparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/check"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/params"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	draClusterRoleName = "awslabs-gpu-operator-dra-driver"
+	draServiceAccount  = "awslabs-gpu-operator-dra-driver"
+)
+
+var _ = Describe("Neuron DRA RBAC Tests", Ordered,
+	Label(params.Label, params.DRALabel, tsparams.LabelValidation), func() {
+		Context("DRA driver RBAC", Label(tsparams.LabelSuite), func() {
+			It("should have DRA driver ServiceAccount",
+				reportxml.ID("90474"), func() {
+					By("Checking ServiceAccount exists")
+
+					serviceAccount, err := APIClient.K8sClient.CoreV1().ServiceAccounts(
+						params.NeuronNamespace).Get(
+						context.TODO(), draServiceAccount, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred(),
+						"ServiceAccount %s should exist in namespace %s",
+						draServiceAccount, params.NeuronNamespace)
+
+					By("Verifying ClusterRoleBinding connects SA to ClusterRole")
+
+					crb, err := APIClient.K8sClient.RbacV1().ClusterRoleBindings().Get(
+						context.TODO(), draClusterRoleName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred(),
+						"ClusterRoleBinding %s should exist", draClusterRoleName)
+					Expect(crb.RoleRef.Name).To(Equal(draClusterRoleName),
+						"ClusterRoleBinding should reference ClusterRole %s", draClusterRoleName)
+
+					foundSubject := false
+
+					for _, subject := range crb.Subjects {
+						if subject.Kind == "ServiceAccount" &&
+							subject.Name == serviceAccount.Name &&
+							subject.Namespace == params.NeuronNamespace {
+							foundSubject = true
+
+							break
+						}
+					}
+
+					Expect(foundSubject).To(BeTrue(),
+						"ClusterRoleBinding should have SA %s/%s as subject",
+						params.NeuronNamespace, draServiceAccount)
+
+					klog.V(params.NeuronLogLevel).Infof(
+						"ServiceAccount %s bound to ClusterRole %s", serviceAccount.Name, draClusterRoleName)
+				})
+
+			It("should have ResourceSlices CRUD permissions",
+				reportxml.ID("90475"), func() {
+					By("Getting DRA ClusterRole")
+
+					clusterRole, err := check.GetClusterRole(APIClient, draClusterRoleName)
+					Expect(err).ToNot(HaveOccurred(),
+						"ClusterRole %s should exist", draClusterRoleName)
+
+					By("Verifying resourceslices CRUD")
+
+					expectedVerbs := []string{"get", "list", "watch", "create", "update", "patch", "delete"}
+					Expect(check.HasPolicyRule(clusterRole.Rules, "resource.k8s.io", "resourceslices", expectedVerbs)).To(BeTrue(),
+						"ClusterRole should grant %v on resourceslices", expectedVerbs)
+
+					klog.V(params.NeuronLogLevel).Info("ResourceSlices CRUD permissions verified")
+				})
+
+			It("should have ResourceClaims read permissions",
+				reportxml.ID("90476"), func() {
+					clusterRole, err := check.GetClusterRole(APIClient, draClusterRoleName)
+					Expect(err).ToNot(HaveOccurred())
+
+					expectedVerbs := []string{"get", "list", "watch"}
+					Expect(check.HasPolicyRule(clusterRole.Rules, "resource.k8s.io", "resourceclaims", expectedVerbs)).To(BeTrue(),
+						"ClusterRole should grant %v on resourceclaims", expectedVerbs)
+
+					klog.V(params.NeuronLogLevel).Info("ResourceClaims read permissions verified")
+				})
+
+			It("should have DeviceClasses read permissions",
+				reportxml.ID("90477"), func() {
+					clusterRole, err := check.GetClusterRole(APIClient, draClusterRoleName)
+					Expect(err).ToNot(HaveOccurred())
+
+					expectedVerbs := []string{"get", "list", "watch"}
+					Expect(check.HasPolicyRule(clusterRole.Rules, "resource.k8s.io", "deviceclasses", expectedVerbs)).To(BeTrue(),
+						"ClusterRole should grant %v on deviceclasses", expectedVerbs)
+
+					klog.V(params.NeuronLogLevel).Info("DeviceClasses read permissions verified")
+				})
+
+			It("should have nodes read and status patch permissions",
+				reportxml.ID("90478"), func() {
+					clusterRole, err := check.GetClusterRole(APIClient, draClusterRoleName)
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Verifying nodes read + patch + update")
+
+					nodeVerbs := []string{"get", "list", "watch", "patch", "update"}
+					Expect(check.HasPolicyRule(clusterRole.Rules, "", "nodes", nodeVerbs)).To(BeTrue(),
+						"ClusterRole should grant %v on nodes", nodeVerbs)
+
+					By("Verifying nodes/status patch")
+
+					statusVerbs := []string{"patch"}
+					Expect(check.HasPolicyRule(clusterRole.Rules, "", "nodes/status", statusVerbs)).To(BeTrue(),
+						"ClusterRole should grant %v on nodes/status", statusVerbs)
+
+					klog.V(params.NeuronLogLevel).Info("Nodes read and status patch permissions verified")
+				})
+
+			It("should have privileged SCC use permission",
+				reportxml.ID("90479"), func() {
+					clusterRole, err := check.GetClusterRole(APIClient, draClusterRoleName)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(check.HasSCCRule(clusterRole.Rules, "privileged")).To(BeTrue(),
+						fmt.Sprintf("ClusterRole %s should grant 'use' on privileged SCC",
+							draClusterRoleName))
+
+					klog.V(params.NeuronLogLevel).Info("Privileged SCC use permission verified")
+				})
+		})
+	})

--- a/tests/hw-accel/neuron/dra/tests/dra-resourceslice-test.go
+++ b/tests/hw-accel/neuron/dra/tests/dra-resourceslice-test.go
@@ -1,0 +1,137 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/dra/internal/tsparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/check"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/neuronconfig"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/params"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+var _ = Describe("Neuron DRA ResourceSlice Tests", Ordered,
+	Label(params.Label, params.DRALabel), func() {
+		Context("ResourceSlice verification", Label(tsparams.LabelSuite), func() {
+			neuronCfg := neuronconfig.NewNeuronConfig()
+
+			BeforeAll(func() {
+				if !neuronCfg.IsDRAConfigured() {
+					Skip("DRA not configured - ECO_HWACCEL_NEURON_DRA_DRIVER_IMAGE not set")
+				}
+			})
+
+			It("should have one ResourceSlice per Neuron node",
+				reportxml.ID("90483"), func() {
+					By("Counting ResourceSlices for neuron.aws.com")
+
+					sliceList, err := APIClient.K8sClient.ResourceV1().ResourceSlices().List(
+						context.TODO(), metav1.ListOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					neuronSlices := 0
+
+					for idx := range sliceList.Items {
+						if sliceList.Items[idx].Spec.Driver == params.DRADriverName {
+							neuronSlices++
+						}
+					}
+
+					By("Counting Neuron nodes")
+
+					neuronNodes, err := check.GetNeuronNodes(APIClient)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(neuronNodes).ToNot(BeEmpty(), "At least one Neuron node must exist")
+
+					Expect(neuronSlices).To(Equal(len(neuronNodes)),
+						"ResourceSlice count should match Neuron node count")
+
+					klog.V(params.NeuronLogLevel).Infof(
+						"%d ResourceSlices for %d Neuron nodes", neuronSlices, len(neuronNodes))
+				})
+
+			It("should have ResourceSlice nodeName matching DRA driver pod node",
+				reportxml.ID("90484"), func() {
+					By("Collecting ResourceSlice nodeNames")
+
+					sliceList, err := APIClient.K8sClient.ResourceV1().ResourceSlices().List(
+						context.TODO(), metav1.ListOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					sliceNodes := map[string]bool{}
+
+					for idx := range sliceList.Items {
+						if sliceList.Items[idx].Spec.Driver == params.DRADriverName {
+							Expect(sliceList.Items[idx].Spec.NodeName).ToNot(BeNil(),
+								"ResourceSlice should have a nodeName")
+
+							sliceNodes[*sliceList.Items[idx].Spec.NodeName] = true
+						}
+					}
+
+					Expect(sliceNodes).ToNot(BeEmpty(), "Should have at least one neuron ResourceSlice")
+
+					By("Collecting DRA driver pod nodeNames")
+
+					podList, err := APIClient.K8sClient.CoreV1().Pods(params.NeuronNamespace).List(
+						context.TODO(), metav1.ListOptions{
+							LabelSelector: fmt.Sprintf("%s=%s",
+								params.DRADaemonSetLabelKey, params.DRADaemonSetLabelValue),
+						})
+					Expect(err).ToNot(HaveOccurred())
+
+					podNodes := map[string]bool{}
+					for idx := range podList.Items {
+						podNodes[podList.Items[idx].Spec.NodeName] = true
+					}
+
+					By("Verifying 1:1 mapping")
+
+					for nodeName := range sliceNodes {
+						Expect(podNodes).To(HaveKey(nodeName),
+							"ResourceSlice node %s should have a DRA driver pod", nodeName)
+					}
+
+					klog.V(params.NeuronLogLevel).Infof(
+						"All %d ResourceSlice nodes match DRA pod nodes", len(sliceNodes))
+				})
+
+			It("should report at least one device per ResourceSlice",
+				reportxml.ID("90485"), func() {
+					sliceList, err := APIClient.K8sClient.ResourceV1().ResourceSlices().List(
+						context.TODO(), metav1.ListOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					neuronSliceCount := 0
+
+					for idx := range sliceList.Items {
+						slice := &sliceList.Items[idx]
+						if slice.Spec.Driver != params.DRADriverName {
+							continue
+						}
+
+						neuronSliceCount++
+
+						nodeName := ""
+						if slice.Spec.NodeName != nil {
+							nodeName = *slice.Spec.NodeName
+						}
+
+						Expect(slice.Spec.Devices).ToNot(BeEmpty(),
+							"ResourceSlice on node %s should have at least one device", nodeName)
+
+						klog.V(params.NeuronLogLevel).Infof(
+							"Node %s: %d devices", nodeName, len(slice.Spec.Devices))
+					}
+
+					Expect(neuronSliceCount).To(BeNumerically(">", 0),
+						"Should have at least one neuron ResourceSlice")
+				})
+		})
+	})

--- a/tests/hw-accel/neuron/internal/check/rbac.go
+++ b/tests/hw-accel/neuron/internal/check/rbac.go
@@ -1,0 +1,60 @@
+package check
+
+import (
+	"context"
+	"slices"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/params"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+// GetClusterRole retrieves a ClusterRole by name.
+func GetClusterRole(apiClient *clients.Settings, name string) (*rbacv1.ClusterRole, error) {
+	klog.V(params.NeuronLogLevel).Infof("Getting ClusterRole %s", name)
+
+	return apiClient.K8sClient.RbacV1().ClusterRoles().Get(
+		context.TODO(), name, metav1.GetOptions{})
+}
+
+// HasPolicyRule checks if a set of PolicyRules grants all specified verbs
+// for a given API group and resource within a single rule.
+func HasPolicyRule(rules []rbacv1.PolicyRule, apiGroup, resource string, verbs []string) bool {
+	for _, rule := range rules {
+		if !slices.Contains(rule.APIGroups, apiGroup) || !slices.Contains(rule.Resources, resource) {
+			continue
+		}
+
+		allFound := true
+
+		for _, verb := range verbs {
+			if !slices.Contains(rule.Verbs, verb) {
+				allFound = false
+
+				break
+			}
+		}
+
+		if allFound {
+			return true
+		}
+	}
+
+	return false
+}
+
+// HasSCCRule checks if a set of PolicyRules grants 'use' on a named SecurityContextConstraint.
+func HasSCCRule(rules []rbacv1.PolicyRule, sccName string) bool {
+	for _, rule := range rules {
+		if slices.Contains(rule.APIGroups, "security.openshift.io") &&
+			slices.Contains(rule.Resources, "securitycontextconstraints") &&
+			slices.Contains(rule.Verbs, "use") &&
+			slices.Contains(rule.ResourceNames, sccName) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/tests/hw-accel/neuron/internal/do/deviceconfig.go
+++ b/tests/hw-accel/neuron/internal/do/deviceconfig.go
@@ -1,0 +1,52 @@
+package do
+
+import (
+	"context"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/params"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+)
+
+var deviceConfigGVR = schema.GroupVersionResource{
+	Group:    "k8s.aws",
+	Version:  "v1beta1",
+	Resource: "deviceconfigs",
+}
+
+// CreateDeviceConfigUnstructured creates a DeviceConfig with the given spec using the dynamic client.
+// This bypasses eco-goinfra builder validation, useful for testing CRD-level CEL validation.
+func CreateDeviceConfigUnstructured(
+	apiClient *clients.Settings, name string, spec map[string]interface{}) error {
+	klog.V(params.NeuronLogLevel).Infof("Creating unstructured DeviceConfig %s", name)
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "k8s.aws/v1beta1",
+			"kind":       "DeviceConfig",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": params.NeuronNamespace,
+			},
+			"spec": spec,
+		},
+	}
+
+	_, err := apiClient.Resource(deviceConfigGVR).
+		Namespace(params.NeuronNamespace).
+		Create(context.TODO(), obj, metav1.CreateOptions{})
+
+	return err
+}
+
+// DeleteDeviceConfigIfExists deletes a DeviceConfig by name, ignoring not-found errors.
+func DeleteDeviceConfigIfExists(apiClient *clients.Settings, name string) {
+	klog.V(params.NeuronLogLevel).Infof("Deleting DeviceConfig %s if it exists", name)
+
+	_ = apiClient.Resource(deviceConfigGVR).
+		Namespace(params.NeuronNamespace).
+		Delete(context.TODO(), name, metav1.DeleteOptions{})
+}


### PR DESCRIPTION
## Summary
- Add 6 RBAC tests (OCP-90474 to OCP-90479): verify DRA driver ServiceAccount, ClusterRole permissions
- Add 3 ResourceSlice tests (OCP-90483 to OCP-90485): slice count, nodeName mapping, device count
- Add 3 Cleanup tests (OCP-90480 to OCP-90482): DeviceConfig deletion removes DaemonSet, ResourceSlices, DeviceClass
