### PR TITLE
system-tests: set txq_mem_algn=0 for rootless DPDK server. (#1493) (#1503) (#1506) (#1510) (#1603)

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/sriov-rootless-dpdk.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/sriov-rootless-dpdk.go
@@ -555,17 +555,42 @@ func getNumberOfPackets(line, firstFieldSubstr string) int {
 }
 
 func defineTestServerPmdCmd(ethPeer, pciAddress, txIPs string) []string {
-	baseCmd := fmt.Sprintf("dpdk-testpmd -R -a %s -- "+
-		"--mbuf-size=%d "+
-		"--forward-mode txonly --eth-peer=0,%s --max-pkt-len=%d",
-		pciAddress, mbufSize, ethPeer, maxPktLen)
+	// Build a bash script that detects NIC vendor and applies correct device arguments.
+	// Mellanox NICs (15b3) require txq_mem_algn=0 to disable contiguous UMEM layout.
+	// Intel NICs (8086) don't need this parameter.
+	script := fmt.Sprintf(`# Detect if the allocated SR-IOV device belongs to Mellanox (15b3) or Intel (8086)
+PCI_ADDR=%s
+VENDOR_ID=$(lspci -n -s ${PCI_ADDR} | cut -d' ' -f3 | cut -d':' -f1)
+
+if [ -z "$VENDOR_ID" ]; then
+    echo "ERROR: Failed to detect vendor ID for PCI device ${PCI_ADDR}"
+    exit 1
+fi
+
+DEV_ARGS=""
+if [ "$VENDOR_ID" == "15b3" ]; then
+    echo "Mellanox NIC detected (vendor ID: ${VENDOR_ID}). Applying txq_mem_algn workaround."
+    DEV_ARGS=",txq_mem_algn=0"
+elif [ "$VENDOR_ID" == "8086" ]; then
+    echo "Intel NIC detected (vendor ID: ${VENDOR_ID}). No extra devargs needed."
+else
+    echo "ERROR: Unsupported NIC vendor ID: ${VENDOR_ID} for PCI device ${PCI_ADDR}"
+    exit 1
+fi
+
+dpdk-testpmd -R -a ${PCI_ADDR}${DEV_ARGS} -- \
+  --mbuf-size=%d \
+  --forward-mode txonly \
+  --eth-peer=0,%s \
+  --max-pkt-len=%d`, pciAddress, mbufSize, ethPeer, maxPktLen)
+
 	if txIPs != "" {
-		baseCmd += fmt.Sprintf(" --tx-ip=%s", txIPs)
+		script += fmt.Sprintf(" \\\n  --tx-ip=%s", txIPs)
 	}
 
-	baseCmd += " --stats-period 5"
+	script += " \\\n  --stats-period 5"
 
-	return []string{"/bin/bash", "-c", baseCmd}
+	return []string{"/bin/bash", "-c", script}
 }
 
 func defineTestPmdCmd(interfaceName string, pciAddress string) string {


### PR DESCRIPTION
The Problem: By default, the mlx5 driver tries to aggregate all memory regions for your Transmit Queues sequentially into a singular, unique UMEM block to squeeze out maximum PCIe efficiency. The ConnectX-6 Dx Virtual Function firmware on your new cluster rejects this multi-queue contiguous arrangement.

The Fix: Setting txq_mem_algn=0 tells the driver to completely disable this layout alignment feature. Instead of trying to register one unique contiguous UMEM layout for all SQs combined, it falls back to requesting completely separated standalone allocations per queue, satisfying the strict isolation rules of the ConnectX-6 Dx hardware.

(cherry picked from commit 578d2ca4be6dc8feb0a1f9eb6cff6fbcf2ad9093)

(cherry picked from commit f6d7c3512b5f2b91781eacd2f4be9560b4df9347)

(cherry picked from commit 447dc599f5d2e105228670bba4f4e0e5ec09c419)

(cherry picked from commit a42173662c95472d8959c983f9423e74a8452bf4)


(cherry picked from commit df4cf233bb79a539c34c0bbcafb3aa6c2dbdd882)