### PR TITLE
hw-accel: Add Neuron DRA allocation and DaemonSet inspection tests

### DIFF
--- a/tests/hw-accel/neuron/dra/tests/dra-allocation-test.go
+++ b/tests/hw-accel/neuron/dra/tests/dra-allocation-test.go
@@ -1,0 +1,160 @@
+package tests
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/neuron"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/resource"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/dra/internal/tsparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/await"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/check"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/do"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/neuronconfig"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/params"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	draAllocTestNS   = "neuron-dra-alloc-test"
+	draClaimTemplate = "neuron-claim"
+	draAllocTimeout  = 5 * time.Minute
+)
+
+var _ = Describe("Neuron DRA Allocation Tests", Ordered,
+	Label(params.Label, params.DRALabel), func() {
+		Context("DRA device allocation", Label(tsparams.LabelSuite), func() {
+			neuronCfg := neuronconfig.NewNeuronConfig()
+
+			BeforeAll(func() {
+				if !neuronCfg.IsDRAConfigured() {
+					Skip("DRA not configured - ECO_HWACCEL_NEURON_DRA_DRIVER_IMAGE not set")
+				}
+
+				By("Verifying DRA DeviceConfig exists")
+
+				dcBuilder, err := neuron.Pull(
+					APIClient, params.DefaultDeviceConfigName, params.NeuronNamespace)
+				Expect(err).ToNot(HaveOccurred(), "DRA DeviceConfig must exist")
+				Expect(dcBuilder.Definition.Spec.DRADriverImage).ToNot(BeEmpty(),
+					"DeviceConfig must be in DRA mode")
+
+				By("Verifying Neuron nodes exist")
+
+				exists, err := check.NeuronNodesExist(APIClient)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(exists).To(BeTrue(), "At least one Neuron node must exist")
+
+				By("Creating test namespace and ResourceClaimTemplate")
+
+				nsBuilder := namespace.NewBuilder(APIClient, draAllocTestNS)
+				if !nsBuilder.Exists() {
+					_, err = nsBuilder.Create()
+					Expect(err).ToNot(HaveOccurred())
+				}
+
+				rctBuilder := resource.NewResourceClaimTemplateBuilder(
+					APIClient, draClaimTemplate, draAllocTestNS).
+					WithDeviceRequest("neuron-device", params.DRADefaultDeviceClassName, 1)
+				Expect(rctBuilder).ToNot(BeNil())
+
+				if !rctBuilder.Exists() {
+					_, err = rctBuilder.Create()
+					Expect(err).ToNot(HaveOccurred(), "Failed to create ResourceClaimTemplate")
+				}
+			})
+
+			AfterAll(func() {
+				By("Cleaning up test namespace")
+
+				nsBuilder := namespace.NewBuilder(APIClient, draAllocTestNS)
+				if nsBuilder.Exists() {
+					err := nsBuilder.DeleteAndWait(5 * time.Minute)
+					Expect(err).ToNot(HaveOccurred())
+				}
+			})
+
+			It("should allocate a Neuron device to a pod via ResourceClaim",
+				reportxml.ID("90398"), func() {
+					By("Creating DRA consumer pod and waiting for Running")
+
+					err := do.CreateDRAConsumerPodAndWait(
+						APIClient, "dra-consumer", draAllocTestNS, draClaimTemplate, draAllocTimeout)
+					Expect(err).ToNot(HaveOccurred(), "DRA consumer pod should be Running")
+				})
+
+			It("should have /dev/neuron device visible in the allocated pod",
+				reportxml.ID("90399"), func() {
+					By("Verifying Neuron devices inside the container")
+
+					hasDevices, err := check.PodHasNeuronDevices(APIClient, "dra-consumer", draAllocTestNS)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(hasDevices).To(BeTrue(), "Pod should have /dev/neuron* device visible")
+				})
+
+			It("should NOT expose Neuron devices to a pod without ResourceClaim",
+				reportxml.ID("90400"), func() {
+					By("Creating a sleep pod without ResourceClaim on a Neuron node")
+
+					sleepPod := do.NewSleepPod(APIClient, "no-claim-pod", draAllocTestNS).
+						WithNodeSelector(map[string]string{
+							params.NeuronNFDLabelKey: params.NeuronNFDLabelValue,
+						})
+					_, err := sleepPod.Create()
+					Expect(err).ToNot(HaveOccurred())
+
+					err = await.PodRunning(APIClient, "no-claim-pod", draAllocTestNS, draAllocTimeout)
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Verifying no Neuron devices are visible")
+
+					hasDevices, err := check.PodHasNeuronDevices(APIClient, "no-claim-pod", draAllocTestNS)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(hasDevices).To(BeFalse(),
+						"Pod without ResourceClaim should NOT have Neuron devices")
+				})
+
+			It("should keep pod Pending when all Neuron devices are allocated",
+				reportxml.ID("90401"), func() {
+					By("Cleaning up pods from previous tests")
+
+					err := do.DeletePodsIfExist(APIClient, draAllocTestNS,
+						[]string{"dra-consumer", "no-claim-pod"})
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Exhausting all devices on the smallest node")
+
+					targetNode, deviceCount, err := check.SmallestDRANode(APIClient)
+					Expect(err).ToNot(HaveOccurred())
+
+					err = do.ExhaustDRADevicesOnNode(
+						APIClient, draAllocTestNS, draClaimTemplate,
+						targetNode, deviceCount, draAllocTimeout)
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Creating one more pod and verifying it stays Pending")
+
+					pendingPod := do.NewDRAConsumerPod(
+						APIClient, "dra-pending", draAllocTestNS, draClaimTemplate).
+						WithNodeSelector(map[string]string{"kubernetes.io/hostname": targetNode})
+					_, err = pendingPod.Create()
+					Expect(err).ToNot(HaveOccurred())
+
+					Consistently(func(g Gomega) corev1.PodPhase {
+						refreshed, pullErr := pod.Pull(APIClient, "dra-pending", draAllocTestNS)
+						g.Expect(pullErr).ToNot(HaveOccurred(), "Failed to pull pending pod")
+
+						return refreshed.Object.Status.Phase
+					}, 30*time.Second, 5*time.Second).Should(Equal(corev1.PodPending),
+						"Pod should stay Pending when all devices are allocated")
+
+					klog.V(params.NeuronLogLevel).Info("Confirmed: pod stays Pending with no available devices")
+				})
+		})
+	})

--- a/tests/hw-accel/neuron/dra/tests/dra-daemonset-test.go
+++ b/tests/hw-accel/neuron/dra/tests/dra-daemonset-test.go
@@ -1,0 +1,159 @@
+package tests
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/dra/internal/tsparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/check"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/neuronconfig"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/params"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
+	"k8s.io/klog/v2"
+)
+
+var _ = Describe("Neuron DRA DaemonSet Inspection Tests", Ordered,
+	Label(params.Label, params.DRALabel), func() {
+		Context("DRA DaemonSet spec verification", Label(tsparams.LabelSuite), func() {
+			neuronCfg := neuronconfig.NewNeuronConfig()
+
+			BeforeAll(func() {
+				if !neuronCfg.IsDRAConfigured() {
+					Skip("DRA not configured - ECO_HWACCEL_NEURON_DRA_DRIVER_IMAGE not set")
+				}
+			})
+
+			It("should have correct container spec, env vars, and resource limits",
+				reportxml.ID("90486"), func() {
+					draDS, err := check.DRADaemonSet(APIClient)
+					Expect(err).ToNot(HaveOccurred())
+
+					containers := draDS.Spec.Template.Spec.Containers
+					Expect(containers).ToNot(BeEmpty(), "DaemonSet should have at least one container")
+
+					container := containers[0]
+
+					By("Verifying container command")
+
+					Expect(container.Command).To(ContainElement("k8s-neuron-dra-driver"),
+						"Container should run k8s-neuron-dra-driver")
+
+					By("Verifying container image")
+
+					Expect(container.Image).To(Equal(neuronCfg.DRADriverImage),
+						"Container image should match DRA driver image")
+
+					By("Verifying env vars")
+
+					envMap := map[string]string{}
+
+					for _, env := range container.Env {
+						if env.Value != "" {
+							envMap[env.Name] = env.Value
+						} else if env.ValueFrom != nil && env.ValueFrom.FieldRef != nil {
+							envMap[env.Name] = env.ValueFrom.FieldRef.FieldPath
+						}
+					}
+
+					Expect(envMap).To(HaveKeyWithValue("NODE_NAME", "spec.nodeName"))
+					Expect(envMap).To(HaveKeyWithValue("POD_UID", "metadata.uid"))
+					Expect(envMap).To(HaveKeyWithValue("CDI_ROOT", "/var/run/cdi"))
+					Expect(envMap).To(HaveKeyWithValue("HEALTHCHECK_PORT", "51515"))
+
+					By("Verifying resource limits")
+
+					limits := container.Resources.Limits
+					Expect(limits.Cpu().String()).To(Equal("20m"),
+						"CPU limit should be 20m")
+					Expect(limits.Memory().String()).To(Equal("256Mi"),
+						"Memory limit should be 256Mi")
+
+					klog.V(params.NeuronLogLevel).Info("Container spec, env vars, and resource limits verified")
+				})
+
+			It("should have correct volumes, hostNetwork, liveness probe, and privileged context",
+				reportxml.ID("90487"), func() {
+					draDS, err := check.DRADaemonSet(APIClient)
+					Expect(err).ToNot(HaveOccurred())
+
+					podSpec := draDS.Spec.Template.Spec
+
+					By("Verifying hostNetwork")
+
+					Expect(podSpec.HostNetwork).To(BeTrue(), "DRA DaemonSet should use hostNetwork")
+
+					By("Verifying volumes")
+
+					volumeNames := []string{}
+
+					for _, vol := range podSpec.Volumes {
+						volumeNames = append(volumeNames, vol.Name)
+					}
+
+					Expect(volumeNames).To(ContainElement("kubelet-plugins"))
+					Expect(volumeNames).To(ContainElement("kubelet-plugins-registry"))
+					Expect(volumeNames).To(ContainElement("cdi"))
+
+					By("Verifying liveness probe")
+
+					Expect(podSpec.Containers).ToNot(BeEmpty(), "DaemonSet should have at least one container")
+
+					container := podSpec.Containers[0]
+					Expect(container.LivenessProbe).ToNot(BeNil(), "Should have a liveness probe")
+					Expect(container.LivenessProbe.GRPC).ToNot(BeNil(), "Liveness probe should be gRPC")
+					Expect(container.LivenessProbe.GRPC.Port).To(Equal(int32(51515)),
+						"gRPC probe port should be 51515")
+					Expect(container.LivenessProbe.InitialDelaySeconds).To(Equal(int32(30)))
+					Expect(container.LivenessProbe.PeriodSeconds).To(Equal(int32(10)))
+
+					By("Verifying privileged security context")
+
+					Expect(container.SecurityContext).ToNot(BeNil())
+					Expect(container.SecurityContext.Privileged).ToNot(BeNil())
+					Expect(*container.SecurityContext.Privileged).To(BeTrue(),
+						"Container should run privileged")
+
+					klog.V(params.NeuronLogLevel).Info("Volumes, hostNetwork, probe, and security context verified")
+				})
+
+			It("should have correct serviceAccount, priorityClass, and tolerations",
+				reportxml.ID("90488"), func() {
+					draDS, err := check.DRADaemonSet(APIClient)
+					Expect(err).ToNot(HaveOccurred())
+
+					podSpec := draDS.Spec.Template.Spec
+
+					By("Verifying serviceAccountName")
+
+					Expect(podSpec.ServiceAccountName).To(Equal("awslabs-gpu-operator-dra-driver"),
+						"Should use DRA driver service account")
+
+					By("Verifying priorityClassName")
+
+					Expect(podSpec.PriorityClassName).To(Equal("system-node-critical"),
+						"Should use system-node-critical priority")
+
+					By("Verifying tolerations")
+
+					foundUpgradeToleration := false
+					foundUnschedulableToleration := false
+
+					for _, tol := range podSpec.Tolerations {
+						if tol.Key == "aws-neuron-driver-upgrade" && tol.Effect == "NoExecute" {
+							foundUpgradeToleration = true
+						}
+
+						if tol.Key == "node.kubernetes.io/unschedulable" && tol.Effect == "NoSchedule" {
+							foundUnschedulableToleration = true
+						}
+					}
+
+					Expect(foundUpgradeToleration).To(BeTrue(),
+						"Should tolerate aws-neuron-driver-upgrade:NoExecute")
+					Expect(foundUnschedulableToleration).To(BeTrue(),
+						"Should tolerate node.kubernetes.io/unschedulable:NoSchedule")
+
+					klog.V(params.NeuronLogLevel).Info("ServiceAccount, priorityClass, and tolerations verified")
+				})
+		})
+	})

--- a/tests/hw-accel/neuron/internal/check/dra.go
+++ b/tests/hw-accel/neuron/internal/check/dra.go
@@ -1,0 +1,92 @@
+package check
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/resource"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/params"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+// DRADaemonSet returns the DRA driver DaemonSet from the operator namespace.
+func DRADaemonSet(apiClient *clients.Settings) (*appsv1.DaemonSet, error) {
+	klog.V(params.NeuronLogLevel).Info("Getting DRA DaemonSet")
+
+	dsList, err := apiClient.K8sClient.AppsV1().DaemonSets(params.NeuronNamespace).List(
+		context.TODO(), metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s",
+				params.DRADaemonSetLabelKey, params.DRADaemonSetLabelValue),
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(dsList.Items) == 0 {
+		return nil, fmt.Errorf("no DRA DaemonSet found in namespace %s", params.NeuronNamespace)
+	}
+
+	return &dsList.Items[0], nil
+}
+
+// SmallestDRANode returns the node name and device count of the Neuron node
+// with the fewest DRA devices, based on ResourceSlice data.
+func SmallestDRANode(apiClient *clients.Settings) (string, int, error) {
+	slices, err := resource.ListResourceSlicesByDriver(apiClient, params.DRADriverName)
+	if err != nil {
+		return "", 0, err
+	}
+
+	if len(slices) == 0 {
+		return "", 0, fmt.Errorf("no ResourceSlices found for driver %s", params.DRADriverName)
+	}
+
+	targetNode := ""
+	targetDeviceCount := 0
+
+	for _, slice := range slices {
+		if slice.Object.Spec.NodeName == nil {
+			continue
+		}
+
+		devCount := len(slice.Object.Spec.Devices)
+		if targetNode == "" || devCount < targetDeviceCount {
+			targetNode = *slice.Object.Spec.NodeName
+			targetDeviceCount = devCount
+		}
+	}
+
+	if targetNode == "" {
+		return "", 0, fmt.Errorf("no ResourceSlices with valid nodeName found")
+	}
+
+	klog.V(params.NeuronLogLevel).Infof("Smallest DRA node: %s with %d devices",
+		targetNode, targetDeviceCount)
+
+	return targetNode, targetDeviceCount, nil
+}
+
+// PodHasNeuronDevices checks if a running pod has /dev/neuron* devices visible.
+func PodHasNeuronDevices(apiClient *clients.Settings, name, namespace string) (bool, error) {
+	runningPod, err := pod.Pull(apiClient, name, namespace)
+	if err != nil {
+		return false, err
+	}
+
+	output, err := runningPod.ExecCommand(
+		[]string{"sh", "-c", "ls /dev/neuron* 2>/dev/null | head -1"})
+	if err != nil {
+		return false, err
+	}
+
+	found := strings.TrimSpace(output.String()) != ""
+
+	klog.V(params.NeuronLogLevel).Infof("Pod %s neuron devices found: %v", name, found)
+
+	return found, nil
+}

--- a/tests/hw-accel/neuron/internal/do/dra.go
+++ b/tests/hw-accel/neuron/internal/do/dra.go
@@ -1,0 +1,103 @@
+package do
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/await"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/params"
+	"k8s.io/klog/v2"
+)
+
+const defaultTestImage = "registry.access.redhat.com/ubi9/ubi-minimal:latest"
+
+// NewDRAConsumerPod creates a pod builder configured with a ResourceClaim
+// referencing the given ResourceClaimTemplate name.
+func NewDRAConsumerPod(
+	apiClient *clients.Settings, name, namespace, claimTemplateName string) *pod.Builder {
+	return pod.NewBuilder(apiClient, name, namespace, defaultTestImage).
+		WithCommand([]string{"sleep", "infinity"}).
+		WithResourceClaim("neuron-device", claimTemplateName)
+}
+
+// NewSleepPod creates a simple pod builder with a sleep infinity command.
+func NewSleepPod(apiClient *clients.Settings, name, namespace string) *pod.Builder {
+	return pod.NewBuilder(apiClient, name, namespace, defaultTestImage).
+		WithCommand([]string{"sleep", "infinity"})
+}
+
+// CreateDRAConsumerPodAndWait creates a DRA consumer pod and waits for it to reach Running.
+func CreateDRAConsumerPodAndWait(
+	apiClient *clients.Settings, name, namespace, claimTemplateName string,
+	timeout time.Duration) error {
+	consumerPod := NewDRAConsumerPod(apiClient, name, namespace, claimTemplateName)
+
+	_, err := consumerPod.Create()
+	if err != nil {
+		return fmt.Errorf("failed to create DRA consumer pod %s: %w", name, err)
+	}
+
+	return await.PodRunning(apiClient, name, namespace, timeout)
+}
+
+// DeletePodsIfExist deletes the named pods from a namespace, ignoring not-found errors.
+func DeletePodsIfExist(apiClient *clients.Settings, namespace string, podNames []string) error {
+	for _, podName := range podNames {
+		existingPod, pullErr := pod.Pull(apiClient, podName, namespace)
+		if pullErr != nil {
+			if strings.Contains(pullErr.Error(), "does not exist") {
+				continue
+			}
+
+			return fmt.Errorf("failed to look up pod %s: %w", podName, pullErr)
+		}
+
+		_, delErr := existingPod.DeleteAndWait(2 * time.Minute)
+		if delErr != nil {
+			return fmt.Errorf("failed to delete pod %s: %w", podName, delErr)
+		}
+
+		klog.V(params.NeuronLogLevel).Infof("Deleted pod %s", podName)
+	}
+
+	return nil
+}
+
+// ExhaustDRADevicesOnNode creates DRA consumer pods on a specific node to exhaust
+// all available devices, then waits for all pods to reach Running state.
+func ExhaustDRADevicesOnNode(
+	apiClient *clients.Settings, namespace, claimTemplateName, targetNode string,
+	deviceCount int, timeout time.Duration) error {
+	nodeSelector := map[string]string{"kubernetes.io/hostname": targetNode}
+
+	klog.V(params.NeuronLogLevel).Infof(
+		"Creating %d exhaust pods on node %s", deviceCount, targetNode)
+
+	for i := 0; i < deviceCount; i++ {
+		name := fmt.Sprintf("exhaust-pod-%d", i)
+
+		exhaustPod := NewDRAConsumerPod(apiClient, name, namespace, claimTemplateName).
+			WithNodeSelector(nodeSelector)
+
+		_, err := exhaustPod.Create()
+		if err != nil {
+			return fmt.Errorf("failed to create exhaust pod %s: %w", name, err)
+		}
+	}
+
+	for i := 0; i < deviceCount; i++ {
+		name := fmt.Sprintf("exhaust-pod-%d", i)
+
+		err := await.PodRunning(apiClient, name, namespace, timeout)
+		if err != nil {
+			return fmt.Errorf("exhaust pod %s not running: %w", name, err)
+		}
+	}
+
+	klog.V(params.NeuronLogLevel).Infof("All %d exhaust pods running on %s", deviceCount, targetNode)
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add 4 DRA allocation e2e tests (OCP-90398 to OCP-90401): pod allocation, /dev/neuron visibility, no devices without claim, resource exhaustion
- Add 3 DaemonSet inspection tests (OCP-90486 to OCP-90488): container spec/env/limits, volumes/network/probe/security, SA/priority/tolerations
- Add `check.GetDRADaemonSet` shared helper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for Neuron Dynamic Resource Allocation device allocation.
  * Verified device visibility for workloads with resource claims and absence without claims.
  * Added checks for pending workloads when node devices are exhausted.
  * Added validation of the Neuron DRA DaemonSet configuration, including probes, resources, security settings, networking, and scheduling.
  * Added handling for environments where DRA is not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->