### PR TITLE
hw-accel: Add hub-spoke DRA validation test (OCP-89711)

### DIFF
--- a/tests/hw-accel/kmm/internal/define/mcm.go
+++ b/tests/hw-accel/kmm/internal/define/mcm.go
@@ -1,0 +1,89 @@
+package define
+
+import (
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/kmm"
+	moduleV1Beta1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/kmm/v1beta1"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/kmmparams"
+)
+
+// DRAModuleSpec builds a ModuleSpec with DRA configuration using the builder pattern.
+func DRAModuleSpec(apiClient *clients.Settings, name, namespace, image,
+	kmodName, serviceAccountName string, nodeSelector map[string]string,
+	deviceClassNames []string) (moduleV1Beta1.ModuleSpec, error) {
+	kernelMapping, err := kmm.NewRegExKernelMappingBuilder("^.+$").
+		WithContainerImage(image).
+		BuildKernelMappingConfig()
+	if err != nil {
+		return moduleV1Beta1.ModuleSpec{}, err
+	}
+
+	moduleLoaderCfg, err := kmm.NewModLoaderContainerBuilder(kmodName).
+		WithKernelMapping(kernelMapping).
+		BuildModuleLoaderContainerCfg()
+	if err != nil {
+		return moduleV1Beta1.ModuleSpec{}, err
+	}
+
+	draCfg, err := kmm.NewDRAContainerBuilder(kmmparams.DRADriverImage).
+		WithCommand([]string{"dra-example-kubeletplugin"}).
+		GetDRAContainerConfig()
+	if err != nil {
+		return moduleV1Beta1.ModuleSpec{}, err
+	}
+
+	builder := kmm.NewModuleBuilder(apiClient, name, namespace).
+		WithNodeSelector(nodeSelector).
+		WithModuleLoaderContainer(moduleLoaderCfg).
+		WithDRAContainer(draCfg).
+		WithDRADriverName(kmmparams.DRADriverName).
+		WithDRAServiceAccount(serviceAccountName)
+
+	for _, dc := range deviceClassNames {
+		builder = builder.WithDRADeviceClass(moduleV1Beta1.DeviceClassSpec{Name: dc})
+	}
+
+	return builder.BuildModuleSpec()
+}
+
+// DRAAndDevicePluginModuleSpec builds a ModuleSpec with both DRA and DevicePlugin
+// configured, which should be rejected by the webhook.
+func DRAAndDevicePluginModuleSpec(apiClient *clients.Settings, name, namespace, image,
+	kmodName, serviceAccountName, devicePluginImage string,
+	nodeSelector map[string]string) (moduleV1Beta1.ModuleSpec, error) {
+	kernelMapping, err := kmm.NewRegExKernelMappingBuilder("^.+$").
+		WithContainerImage(image).
+		BuildKernelMappingConfig()
+	if err != nil {
+		return moduleV1Beta1.ModuleSpec{}, err
+	}
+
+	moduleLoaderCfg, err := kmm.NewModLoaderContainerBuilder(kmodName).
+		WithKernelMapping(kernelMapping).
+		BuildModuleLoaderContainerCfg()
+	if err != nil {
+		return moduleV1Beta1.ModuleSpec{}, err
+	}
+
+	draCfg, err := kmm.NewDRAContainerBuilder(kmmparams.DRADriverImage).
+		WithCommand([]string{"dra-example-kubeletplugin"}).
+		GetDRAContainerConfig()
+	if err != nil {
+		return moduleV1Beta1.ModuleSpec{}, err
+	}
+
+	dpCfg, err := kmm.NewDevicePluginContainerBuilder(devicePluginImage).
+		GetDevicePluginContainerConfig()
+	if err != nil {
+		return moduleV1Beta1.ModuleSpec{}, err
+	}
+
+	return kmm.NewModuleBuilder(apiClient, name, namespace).
+		WithNodeSelector(nodeSelector).
+		WithModuleLoaderContainer(moduleLoaderCfg).
+		WithDRAContainer(draCfg).
+		WithDRADriverName(kmmparams.DRADriverName).
+		WithDRAServiceAccount(serviceAccountName).
+		WithDevicePluginContainer(dpCfg).
+		BuildModuleSpec()
+}

--- a/tests/hw-accel/kmm/mcm/mcm_suite_test.go
+++ b/tests/hw-accel/kmm/mcm/mcm_suite_test.go
@@ -60,6 +60,14 @@ var _ = BeforeSuite(func() {
 		Skip("Skipping test. No Spoke environment variables defined.")
 	}
 
+	By("Resolve DRA driver image for spoke k8s version")
+
+	serverVersion, err := ModulesConfig.SpokeAPIClient.K8sClient.Discovery().ServerVersion()
+	Expect(err).ToNot(HaveOccurred(), "error getting spoke server version")
+	kmmparams.SetDRADriverImage(ModulesConfig.DRADriverImageRepo, serverVersion.GitVersion)
+	klog.V(kmmparams.KmmLogLevel).Infof("Resolved DRA driver image: %s (spoke k8s %s)",
+		kmmparams.DRADriverImage, serverVersion.GitVersion)
+
 	By("Create helper ServiceAccount")
 
 	svcAccount, err := serviceaccount.

--- a/tests/hw-accel/kmm/mcm/tests/dra-hub-spoke-test.go
+++ b/tests/hw-accel/kmm/mcm/tests/dra-hub-spoke-test.go
@@ -1,0 +1,82 @@
+package tests
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/kmm"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/define"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/kmmparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/mcm/internal/tsparams"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
+)
+
+var _ = Describe("KMM-HUB", Ordered, Label(tsparams.LabelSuite), func() {
+	Context("DRA Hub-Spoke", Label("mcm-dra", "dra"), func() {
+		BeforeEach(func() {
+			if kmmparams.DRADriverImage == "" {
+				Skip("ECO_HWACCEL_KMM_DRA_DRIVER_IMAGE_REPO is not set")
+			}
+		})
+
+		It("should accept MCM with valid DRA config", reportxml.ID("89711"),
+			Label("89711", "test_id:89711"), func() {
+				mcmName := "test-hub-dra"
+				image := fmt.Sprintf("%s/%s/%s:$KERNEL_FULL_VERSION",
+					kmmparams.LocalImageRegistry, kmmparams.KmmHubOperatorNamespace, "dra-kmod")
+
+				By("Build Module spec with DRA")
+
+				moduleSpec, err := define.DRAModuleSpec(APIClient, mcmName, "default", image,
+					"dramod", "dra-manager", GeneralConfig.WorkerLabelMap,
+					[]string{kmmparams.DRADeviceClassName})
+				Expect(err).ToNot(HaveOccurred(), "error building DRA module spec")
+
+				By("Create ManagedClusterModule with DRA")
+
+				mcm, err := kmm.NewManagedClusterModuleBuilder(APIClient, mcmName,
+					kmmparams.KmmHubOperatorNamespace).
+					WithModuleSpec(moduleSpec).
+					WithSpokeNamespace(kmmparams.KmmOperatorNamespace).
+					WithSelector(map[string]string{"nonexistent": "spoke"}).Create()
+				Expect(err).ToNot(HaveOccurred(), "MCM with valid DRA should be accepted")
+
+				DeferCleanup(func() { _, _ = mcm.Delete() })
+
+				By("Verify MCM has DRA config")
+
+				Expect(mcm.Definition.Spec.ModuleSpec.DRA).ToNot(BeNil(), "DRA spec should be set")
+				Expect(mcm.Definition.Spec.ModuleSpec.DRA.DriverName).
+					To(Equal(kmmparams.DRADriverName), "DRA driverName should match")
+				Expect(mcm.Definition.Spec.ModuleSpec.DRA.DeviceClasses).
+					To(HaveLen(1), "should have one DeviceClass")
+			})
+
+		It("should reject MCM with both dra and devicePlugin", reportxml.ID("89711"),
+			Label("89711", "test_id:89711"), func() {
+				mcmName := "test-hub-dra-invalid"
+				image := fmt.Sprintf("%s/%s/%s:$KERNEL_FULL_VERSION",
+					kmmparams.LocalImageRegistry, kmmparams.KmmHubOperatorNamespace, "dra-kmod")
+
+				By("Build Module spec with both DRA and DevicePlugin")
+
+				moduleSpec, err := define.DRAAndDevicePluginModuleSpec(APIClient, mcmName, "default",
+					image, "dramod", "dra-manager", "some-device-plugin:latest",
+					GeneralConfig.WorkerLabelMap)
+				Expect(err).ToNot(HaveOccurred(), "error building module spec")
+
+				By("Create ManagedClusterModule -- should be rejected")
+
+				_, err = kmm.NewManagedClusterModuleBuilder(APIClient, mcmName,
+					kmmparams.KmmHubOperatorNamespace).
+					WithModuleSpec(moduleSpec).
+					WithSpokeNamespace(kmmparams.KmmOperatorNamespace).
+					WithSelector(map[string]string{"nonexistent": "spoke"}).Create()
+				Expect(err).To(HaveOccurred(), "MCM with both DRA and DevicePlugin should be rejected")
+				Expect(err.Error()).To(ContainSubstring("mutually exclusive"),
+					"error should mention mutual exclusivity")
+			})
+	})
+})


### PR DESCRIPTION
Verify ManagedClusterModule DRA support on hub:
- Valid MCM with spec.moduleSpec.dra accepted
- MCM with both dra and devicePlugin rejected by webhook

Test runs in the mcm suite (hub-spoke profiles only). Skipped when ECO_HWACCEL_KMM_DRA_DRIVER_IMAGE_REPO is not set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for hardware-acceleration device management across hub-and-spoke deployments.
  * Verified valid DRA configurations are accepted and conflicting DRA and device-plugin settings are rejected.
  * Improved test setup to detect the Kubernetes version and select the compatible driver image.
  * Added clear failure reporting when cluster version discovery fails and skips scenarios when no driver image is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->