### PR TITLE
cnf ran: replace SSH subprocess with Go SSH client and improve error …

### DIFF
--- a/tests/cnf/ran/ibipreinstall/internal/helpers/bmh_provisioning.go
+++ b/tests/cnf/ran/ibipreinstall/internal/helpers/bmh_provisioning.go
@@ -151,12 +151,12 @@ func WaitForPreinstallCompletion(
 			}
 
 			failDuration := now.Sub(*sshFailingSince)
-			klog.V(tsparams.LogLevel).Infof("SSH to %s unavailable for %v (timeout %v), waiting %v...",
-				host, failDuration.Round(time.Second), sshFailureTimeout, pollInterval)
+			klog.V(tsparams.LogLevel).Infof("SSH to %s unavailable for %v (timeout %v): %v, waiting %v...",
+				host, failDuration.Round(time.Second), sshFailureTimeout, sshErr, pollInterval)
 
 			if failDuration >= sshFailureTimeout {
-				return false, fmt.Errorf("SSH to %s unreachable for %v — node may have been powered off or deprovisioned",
-					host, failDuration.Round(time.Second))
+				return false, fmt.Errorf("SSH to %s unreachable for %v — node may have been powered off or deprovisioned: %w",
+					host, failDuration.Round(time.Second), sshErr)
 			}
 
 			return false, nil

--- a/tests/cnf/ran/ibipreinstall/internal/helpers/ssh_utils.go
+++ b/tests/cnf/ran/ibipreinstall/internal/helpers/ssh_utils.go
@@ -4,45 +4,113 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os/exec"
+	"net"
+	"os"
 	"time"
 
+	"golang.org/x/crypto/ssh"
 	"k8s.io/klog/v2"
 
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ibipreinstall/internal/tsparams"
 )
 
-const sshSubprocessTimeout = 3 * time.Minute
+const (
+	sshSubprocessTimeout = 3 * time.Minute
+	sshConnectTimeout    = 10 * time.Second
+	sshPort              = "22"
+)
 
-// SSHExec executes a command on a remote host via SSH.
+// SSHExec executes a command on a remote host via SSH using the Go SSH client.
+// An OpenSSH binary is not required in the test image.
 func SSHExec(parentCtx context.Context, host, user, sshKeyPath, command string) (string, error) {
 	klog.V(tsparams.LogLevel).Infof("Executing on %s@%s: %s", user, host, command)
-
-	args := []string{
-		"-o", "StrictHostKeyChecking=no",
-		"-o", "UserKnownHostsFile=/dev/null",
-		"-o", "LogLevel=ERROR",
-		"-o", "ConnectTimeout=10",
-		"-o", "BatchMode=yes",
-		"-i", sshKeyPath,
-		fmt.Sprintf("%s@%s", user, host),
-		command,
-	}
 
 	ctx, cancel := context.WithTimeout(parentCtx, sshSubprocessTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "ssh", args...)
-
-	output, err := cmd.CombinedOutput()
+	client, err := dialSSH(ctx, host, user, sshKeyPath)
 	if err != nil {
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return string(output), fmt.Errorf(
-				"ssh timed out after %v: %w, output: %s", sshSubprocessTimeout, err, string(output))
-		}
+		return "", wrapSSHError(ctx, err, "")
+	}
 
-		return string(output), fmt.Errorf("ssh failed: %w, output: %s", err, string(output))
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		return "", wrapSSHError(ctx, err, "")
+	}
+
+	defer session.Close()
+
+	output, err := session.CombinedOutput(command)
+	if err != nil {
+		return string(output), wrapSSHError(ctx, err, string(output))
 	}
 
 	return string(output), nil
+}
+
+// dialSSH establishes an SSH connection using the Go crypto/ssh client.
+// A background goroutine closes the underlying TCP connection when ctx is cancelled.
+func dialSSH(ctx context.Context, host, user, sshKeyPath string) (*ssh.Client, error) {
+	keyBuf, err := os.ReadFile(sshKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open private key %s: %w", sshKeyPath, err)
+	}
+
+	signer, err := ssh.ParsePrivateKey(keyBuf)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse private key %s: %w", sshKeyPath, err)
+	}
+
+	config := &ssh.ClientConfig{
+		User: user,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(signer),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         sshConnectTimeout,
+	}
+
+	addr := net.JoinHostPort(host, sshPort)
+	dialer := net.Dialer{Timeout: sshConnectTimeout}
+
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unblock handshake and command execution when the context is cancelled
+	// or the per-command timeout expires.
+	go func() {
+		<-ctx.Done()
+
+		_ = conn.Close()
+	}()
+
+	clientConn, chans, reqs, err := ssh.NewClientConn(conn, addr, config)
+	if err != nil {
+		conn.Close()
+
+		return nil, err
+	}
+
+	return ssh.NewClient(clientConn, chans, reqs), nil
+}
+
+// wrapSSHError annotates an SSH error with timeout and output context.
+func wrapSSHError(ctx context.Context, err error, output string) error {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		if output == "" {
+			return fmt.Errorf("ssh timed out after %v: %w", sshSubprocessTimeout, err)
+		}
+
+		return fmt.Errorf("ssh timed out after %v: %w, output: %s", sshSubprocessTimeout, err, output)
+	}
+
+	if output == "" {
+		return fmt.Errorf("ssh failed: %w", err)
+	}
+
+	return fmt.Errorf("ssh failed: %w, output: %s", err, output)
 }

--- a/tests/cnf/ran/ibipreinstall/tests/preinstall-e2e-test.go
+++ b/tests/cnf/ran/ibipreinstall/tests/preinstall-e2e-test.go
@@ -166,6 +166,7 @@ var _ = Describe(
 			}
 		})
 
+		// 89666 - Performs disconnected IBI cluster node preinstall end to end
 		It("performs disconnected IBI cluster node preinstall end to end", reportxml.ID("89666"), func() {
 			ibiCfg := RANConfig.IBIPreinstallConfig
 


### PR DESCRIPTION
Replace os/exec SSH subprocess with golang.org/x/crypto/ssh native client, eliminating the dependency on an OpenSSH binary in the test container image. Fix a resource leak by closing the TCP connection when NewClientConn fails. Include the SSH error in WaitForPreinstallCompletion log messages and error wrapping to aid debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH error reporting and preserved underlying errors for more useful timeout diagnostics.
  * Enhanced SSH command execution reliability and timeout handling.

* **Tests**
  * Added a reference linking the disconnected preinstall end-to-end test to its tracking issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->