### PR TITLE
cnf network: fix unnumbered nmstate 4-22

### DIFF
--- a/tests/cnf/core/network/metallb/tests/bgp-unnumbered.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-unnumbered.go
@@ -110,17 +110,27 @@ var _ = Describe("BGP Unnumbered", Ordered, Label(tsparams.LabelBGPUnnumbered),
 			By("Remove custom MetalLB test label from nodes")
 			removeNodeLabel(workerNodeList, metalLbTestsLabel)
 
-			By(fmt.Sprintf("Resetting ethernet interface %s on worker node %s",
-				interfacesUnderTest[0], workerNodeList[0].Definition.Name))
-			ethIntWorker0Policy := nmstate.NewPolicyBuilder(APIClient, nodeNetConfigPolicyName, NetConfig.WorkerLabelMap).
-				WithEthernetDualStackInterface(interfacesUnderTest[0])
-			err := netnmstate.UpdatePolicyAndWaitUntilItsAvailable(netparam.DefaultTimeout, ethIntWorker0Policy)
-			Expect(err).ToNot(HaveOccurred(), "Failed to update NMState network policy")
+			// Leave the PF up on the setup node.
+			// Do not use absent — that leaves the PF down after NNCP deletion and breaks later suites.
+			// Capture the error so CleanAllNMStatePolicies still runs if restore fails.
+			var restoreErr error
+
+			if len(interfacesUnderTest) > 0 && len(workerNodeList) > 0 {
+				By(fmt.Sprintf("Restoring ethernet interface %s on worker node %s",
+					interfacesUnderTest[0], workerNodeList[0].Definition.Name))
+				ethIntWorker0Policy := nmstate.NewPolicyBuilder(APIClient, nodeNetConfigPolicyName,
+					map[string]string{corev1.LabelHostname: workerNodeList[0].Definition.Name}).
+					WithInterfaceUp(interfacesUnderTest[0])
+				restoreErr = netnmstate.UpdatePolicyAndWaitUntilItsAvailable(
+					netparam.DefaultTimeout, ethIntWorker0Policy)
+			}
 
 			By("Removing NMState policies")
 
-			err = nmstate.CleanAllNMStatePolicies(APIClient)
-			Expect(err).ToNot(HaveOccurred(), "Failed to remove all NMState policies")
+			cleanErr := nmstate.CleanAllNMStatePolicies(APIClient)
+
+			Expect(restoreErr).ToNot(HaveOccurred(), "Failed to restore ethernet interface via NMState policy")
+			Expect(cleanErr).ToNot(HaveOccurred(), "Failed to remove all NMState policies")
 
 			By("Clean MetalLB operator and test namespaces")
 			resetOperatorAndTestNS()


### PR DESCRIPTION
- BGP Unnumbered AfterAll was resetting the SR-IOV PF with `WithEthernetDualStackInterface` and the `workercnf` label, so the NNCP applied to every worker. That can leave the policy Degraded (`ipv4.enabled desire 'true', current 'false'`) and AfterAll hits `context deadline exceeded`.
- Restore the PF on the setup node only (hostname selector) and leave it up with `WithInterfaceUp`. Do not use `WithAbsentInterface` (that leaves the PF down after NNCP deletion and breaks later suites).
- Capture the restore error so `CleanAllNMStatePolicies` still runs if restore fails.
- Same cleanup as main #1538 / release-4.20 #1612.