### PR TITLE
cnf ran: power off original node in IBBF e2e before reinstall

### DIFF
--- a/tests/cnf/ran/gitopsztp/tests/IBBF-e2e-test.go
+++ b/tests/cnf/ran/gitopsztp/tests/IBBF-e2e-test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/siteconfig"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/gitopsztp/internal/gitdetails"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/gitopsztp/internal/tsparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/rancluster"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/ranparam"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +29,13 @@ var _ = Describe(
 		var (
 			spokeNamespace = RANConfig.Spoke1Name
 		)
+
+		BeforeAll(func() {
+			By("Checking BMC configuration is provided for original-node power-off")
+
+			Expect(BMCClient).ToNot(BeNil(),
+				"IBBF requires BMC configuration (ECO_CNF_RAN_BMC_HOSTS/USERNAME/PASSWORD) to power off the original node")
+		})
 
 		BeforeEach(func() {
 			By("checking if the git path exists")
@@ -93,6 +101,16 @@ var _ = Describe(
 			clusterInstance, err := siteconfig.PullClusterInstance(
 				HubAPIClient, RANConfig.Spoke1Name, spokeNamespace)
 			Expect(err).ToNot(HaveOccurred(), "error pulling clusterinstance")
+
+			By("Powering off the original node before IBBF reinstall")
+
+			powerState, err := BMCClient.SystemPowerState()
+			Expect(err).ToNot(HaveOccurred(), "Failed to get original node power state before IBBF")
+
+			if powerState != "Off" {
+				err = rancluster.PowerOffWithRetries(BMCClient, 3)
+				Expect(err).ToNot(HaveOccurred(), "Failed to power off original node before IBBF")
+			}
 
 			By("Changing clusters app to point to IBBF test target directory")
 

--- a/tests/lca/seedgeneration/internal/tsparams/consts.go
+++ b/tests/lca/seedgeneration/internal/tsparams/consts.go
@@ -13,6 +13,9 @@ const (
 
 	// LCANamespace is the namespace used by the lifecycle-agent.
 	LCANamespace = "openshift-lifecycle-agent"
+
+	// OADPNamespace is the namespace used by the OADP operator.
+	OADPNamespace = "openshift-adp"
 )
 
 var (

--- a/tests/lca/seedgeneration/tests/seedgeneration-test.go
+++ b/tests/lca/seedgeneration/tests/seedgeneration-test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/lca"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/oadp"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/secret"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/cluster"
@@ -15,6 +16,8 @@ import (
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/lca/seedgeneration/internal/seedgenerationinittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/seedgeneration/internal/tsparams"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/klog/v2"
 )
 
@@ -35,6 +38,37 @@ var _ = Describe(
 
 			// Verify we have the required API client
 			Expect(TargetSNOAPIClient).NotTo(BeNil(), "TargetSNOAPIClient is not initialized")
+
+			By("removing DataProtectionApplication if present", func() {
+				// ListDataProtectionApplication requires nsname but does not apply it
+				// unless ListOptions.Namespace is set; omitting ListOptions lists all namespaces.
+				dpaList, err := oadp.ListDataProtectionApplication(
+					TargetSNOAPIClient, tsparams.OADPNamespace)
+				if apimeta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
+					klog.V(lcaparams.LCALogLevel).Info(
+						"DataProtectionApplication CRD is not installed, skipping deletion")
+
+					return
+				}
+
+				Expect(err).NotTo(HaveOccurred(),
+					fmt.Sprintf("Failed to list DataProtectionApplication CRs: %v", err))
+
+				for _, dpa := range dpaList {
+					dpaNS, dpaName := dpa.Definition.Namespace, dpa.Definition.Name
+
+					klog.V(lcaparams.LCALogLevel).Infof(
+						"Deleting DataProtectionApplication %s/%s", dpaNS, dpaName)
+
+					err = dpa.Delete()
+					Expect(err).NotTo(HaveOccurred(),
+						fmt.Sprintf("Failed to delete DataProtectionApplication %s/%s: %v",
+							dpaNS, dpaName, err))
+
+					Eventually(dpa.Exists, 2*time.Minute, 5*time.Second).Should(BeFalse(),
+						fmt.Sprintf("DataProtectionApplication %s/%s was not deleted", dpaNS, dpaName))
+				}
+			})
 
 			By("checking for existing SeedGenerator and deleting if present", func() {
 				seedGenerator, err := lca.PullSeedGenerator(TargetSNOAPIClient, "seedimage")


### PR DESCRIPTION
IBBF requires the failed node off before SiteConfig reinstall; handle this in the test via Redfish instead of relying on external CI steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enhanced IBBF end-to-end coverage by validating required BMC configuration before execution.
  - Ensured the original node is powered off before starting the IBBF reinstall process, with power-state checks and retry handling.
  - Added test setup cleanup to remove existing data protection applications before seed generation tests.
  - Improved test compatibility when data protection resources or their definitions are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->