### PR TITLE
hw-accel: Add Neuron DRA migration and rollback tests (DRA-8, DRA-10)

### DIFF
--- a/tests/hw-accel/neuron/dra/tests/dra-migration-test.go
+++ b/tests/hw-accel/neuron/dra/tests/dra-migration-test.go
@@ -210,35 +210,56 @@ var _ = Describe("Neuron DRA Migration Tests", Ordered,
 						"DRA DaemonSet should not exist in device-plugin mode")
 				})
 
-			It("should migrate to DRA mode by updating DeviceConfig",
+			It("should migrate to DRA mode by deleting and recreating DeviceConfig",
 				reportxml.ID("90501"), func() {
-					By("Pulling DeviceConfig and switching to DRA mode")
+					By("Deleting device-plugin mode DeviceConfig")
 
 					dcBuilder, err := neuron.Pull(
 						APIClient, params.DefaultDeviceConfigName, params.NeuronNamespace)
 					Expect(err).ToNot(HaveOccurred())
 
-					dcBuilder.Definition.Spec.DevicePluginImage = ""
-					dcBuilder.Definition.Spec.CustomSchedulerImage = ""
-					dcBuilder.Definition.Spec.SchedulerExtensionImage = ""
-					dcBuilder.Definition.Spec.DRADriverImage = neuronCfg.DRADriverImage
+					_, err = dcBuilder.Delete()
+					Expect(err).ToNot(HaveOccurred(), "Failed to delete device-plugin DeviceConfig")
 
-					_, err = dcBuilder.Update(false)
-					Expect(err).ToNot(HaveOccurred(), "Failed to update DeviceConfig to DRA mode")
+					By("Waiting for cascade cleanup")
 
-					By("Waiting for device-plugin DaemonSet to be removed")
+					Eventually(func() bool {
+						_, pullErr := neuron.Pull(
+							APIClient, params.DefaultDeviceConfigName, params.NeuronNamespace)
+
+						return pullErr != nil
+					}, migrationTimeout, 5*time.Second).Should(BeTrue(),
+						"DeviceConfig should be deleted")
 
 					err = await.DevicePluginDaemonSetGone(
 						APIClient, params.NeuronNamespace, migrationTimeout)
 					Expect(err).ToNot(HaveOccurred(),
-						"Device-plugin DaemonSet should be removed after migration")
-
-					By("Waiting for scheduler deployments to be removed")
+						"Device-plugin DaemonSet should be removed after deletion")
 
 					err = await.NoSchedulerDeployments(
 						APIClient, params.NeuronNamespace, migrationTimeout)
 					Expect(err).ToNot(HaveOccurred(),
-						"Scheduler deployments should be removed after migration")
+						"Scheduler deployments should be removed after deletion")
+
+					By("Creating DRA-mode DeviceConfig")
+
+					draBuilder := neuron.NewBuilderWithDRA(
+						APIClient,
+						params.DefaultDeviceConfigName,
+						params.NeuronNamespace,
+						neuronCfg.DriversImage,
+						neuronCfg.DriverVersion,
+						neuronCfg.DRADriverImage,
+					).WithSelector(map[string]string{
+						params.NeuronNFDLabelKey: params.NeuronNFDLabelValue,
+					}).WithNodeMetricsImage(neuronCfg.NodeMetricsImage)
+
+					if neuronCfg.ImageRepoSecretName != "" {
+						draBuilder = draBuilder.WithImageRepoSecret(neuronCfg.ImageRepoSecretName)
+					}
+
+					_, err = draBuilder.Create()
+					Expect(err).ToNot(HaveOccurred(), "Failed to create DRA-mode DeviceConfig")
 
 					By("Waiting for DRA DaemonSet to be ready")
 
@@ -355,45 +376,73 @@ var _ = Describe("Neuron DRA Migration Tests", Ordered,
 				Expect(err).ToNot(HaveOccurred(), "DRA DaemonSet must be ready before rollback")
 			})
 
-			It("should rollback to device-plugin mode by updating DeviceConfig",
+			It("should rollback to device-plugin mode by deleting and recreating DeviceConfig",
 				reportxml.ID("90505"), func() {
-					By("Pulling DeviceConfig and switching to device-plugin mode")
+					By("Deleting DRA-mode DeviceConfig")
 
 					dcBuilder, err := neuron.Pull(
 						APIClient, params.DefaultDeviceConfigName, params.NeuronNamespace)
 					Expect(err).ToNot(HaveOccurred())
 
-					dcBuilder.Definition.Spec.DRADriverImage = ""
-					dcBuilder.Definition.Spec.DevicePluginImage = neuronCfg.DevicePluginImage
-					dcBuilder.Definition.Spec.CustomSchedulerImage = neuronCfg.SchedulerImage
-					dcBuilder.Definition.Spec.SchedulerExtensionImage = neuronCfg.SchedulerExtensionImage
-
-					_, err = dcBuilder.Update(false)
+					_, err = dcBuilder.Delete()
 					Expect(err).ToNot(HaveOccurred(),
-						"Failed to update DeviceConfig to device-plugin mode")
+						"Failed to delete DRA DeviceConfig")
 
-					By("Waiting for DRA DaemonSet to be removed")
+					By("Waiting for cascade cleanup")
+
+					Eventually(func() bool {
+						_, pullErr := neuron.Pull(
+							APIClient, params.DefaultDeviceConfigName, params.NeuronNamespace)
+
+						return pullErr != nil
+					}, migrationTimeout, 5*time.Second).Should(BeTrue(),
+						"DeviceConfig should be deleted")
 
 					err = await.DRADaemonSetGone(
 						APIClient, params.NeuronNamespace, migrationTimeout)
 					Expect(err).ToNot(HaveOccurred(),
-						"DRA DaemonSet should be removed after rollback")
-
-					By("Waiting for DeviceClass to be removed")
+						"DRA DaemonSet should be removed after deletion")
 
 					err = await.DeviceClassGone(
 						APIClient, params.DRADefaultDeviceClassName, migrationTimeout)
 					Expect(err).ToNot(HaveOccurred(),
-						"DeviceClass should be removed after rollback")
-
-					By("Waiting for ResourceSlices to be cleaned up")
+						"DeviceClass should be removed after deletion")
 
 					err = await.ResourceSlicesGone(
 						APIClient, params.DRADriverName, migrationTimeout)
 					Expect(err).ToNot(HaveOccurred(),
-						"ResourceSlices should be removed after rollback")
+						"ResourceSlices should be removed after deletion")
 
-					klog.V(params.NeuronLogLevel).Info("DRA resources cleaned up after rollback")
+					By("Creating device-plugin mode DeviceConfig")
+
+					dpBuilder := neuron.NewBuilder(
+						APIClient,
+						params.DefaultDeviceConfigName,
+						params.NeuronNamespace,
+						neuronCfg.DriversImage,
+						neuronCfg.DriverVersion,
+						neuronCfg.DevicePluginImage,
+					).WithSelector(map[string]string{
+						params.NeuronNFDLabelKey: params.NeuronNFDLabelValue,
+					}).WithScheduler(
+						neuronCfg.SchedulerImage,
+						neuronCfg.SchedulerExtensionImage,
+					).WithNodeMetricsImage(neuronCfg.NodeMetricsImage)
+
+					if neuronCfg.ImageRepoSecretName != "" {
+						dpBuilder = dpBuilder.WithImageRepoSecret(neuronCfg.ImageRepoSecretName)
+					}
+
+					_, err = dpBuilder.Create()
+					Expect(err).ToNot(HaveOccurred(),
+						"Failed to create device-plugin mode DeviceConfig")
+
+					By("Waiting for device-plugin mode to be fully ready")
+
+					err = neuronhelpers.WaitForClusterStabilityAfterDeviceConfig(APIClient)
+					Expect(err).ToNot(HaveOccurred())
+
+					klog.V(params.NeuronLogLevel).Info("Rollback to device-plugin mode complete")
 				})
 
 			It("should have device-plugin DaemonSet running after rollback",

--- a/tests/hw-accel/neuron/dra/tests/dra-migration-test.go
+++ b/tests/hw-accel/neuron/dra/tests/dra-migration-test.go
@@ -229,14 +229,14 @@ var _ = Describe("Neuron DRA Migration Tests", Ordered,
 					By("Waiting for device-plugin DaemonSet to be removed")
 
 					err = await.DevicePluginDaemonSetGone(
-						APIClient, params.NeuronNamespace, migrationPollTimeout)
+						APIClient, params.NeuronNamespace, migrationTimeout)
 					Expect(err).ToNot(HaveOccurred(),
 						"Device-plugin DaemonSet should be removed after migration")
 
 					By("Waiting for scheduler deployments to be removed")
 
 					err = await.NoSchedulerDeployments(
-						APIClient, params.NeuronNamespace, migrationPollTimeout)
+						APIClient, params.NeuronNamespace, migrationTimeout)
 					Expect(err).ToNot(HaveOccurred(),
 						"Scheduler deployments should be removed after migration")
 
@@ -375,21 +375,21 @@ var _ = Describe("Neuron DRA Migration Tests", Ordered,
 					By("Waiting for DRA DaemonSet to be removed")
 
 					err = await.DRADaemonSetGone(
-						APIClient, params.NeuronNamespace, migrationPollTimeout)
+						APIClient, params.NeuronNamespace, migrationTimeout)
 					Expect(err).ToNot(HaveOccurred(),
 						"DRA DaemonSet should be removed after rollback")
 
 					By("Waiting for DeviceClass to be removed")
 
 					err = await.DeviceClassGone(
-						APIClient, params.DRADefaultDeviceClassName, tsparams.DeviceClassTimeout)
+						APIClient, params.DRADefaultDeviceClassName, migrationTimeout)
 					Expect(err).ToNot(HaveOccurred(),
 						"DeviceClass should be removed after rollback")
 
 					By("Waiting for ResourceSlices to be cleaned up")
 
 					err = await.ResourceSlicesGone(
-						APIClient, params.DRADriverName, migrationPollTimeout)
+						APIClient, params.DRADriverName, migrationTimeout)
 					Expect(err).ToNot(HaveOccurred(),
 						"ResourceSlices should be removed after rollback")
 

--- a/tests/hw-accel/neuron/dra/tests/dra-migration-test.go
+++ b/tests/hw-accel/neuron/dra/tests/dra-migration-test.go
@@ -34,10 +34,54 @@ const (
 
 var _ = Describe("Neuron DRA Migration Tests", Ordered,
 	Label(params.Label, params.DRALabel, params.DRAMigrationLabel), func() {
+		neuronCfg := neuronconfig.NewNeuronConfig()
+
+		AfterAll(func() {
+			if !neuronCfg.IsDRAMigrationConfigured() {
+				return
+			}
+
+			By("Restoring DRA-mode DeviceConfig after migration tests")
+
+			if existingDC, _ := neuron.Pull(
+				APIClient, params.DefaultDeviceConfigName, params.NeuronNamespace); existingDC != nil {
+				_, err := existingDC.Delete()
+				Expect(err).ToNot(HaveOccurred())
+
+				Eventually(func() bool {
+					_, pullErr := neuron.Pull(
+						APIClient, params.DefaultDeviceConfigName, params.NeuronNamespace)
+
+					return pullErr != nil
+				}, migrationPollTimeout, 5*time.Second).Should(BeTrue())
+			}
+
+			builder := neuron.NewBuilderWithDRA(
+				APIClient,
+				params.DefaultDeviceConfigName,
+				params.NeuronNamespace,
+				neuronCfg.DriversImage,
+				neuronCfg.DriverVersion,
+				neuronCfg.DRADriverImage,
+			).WithSelector(map[string]string{
+				params.NeuronNFDLabelKey: params.NeuronNFDLabelValue,
+			}).WithNodeMetricsImage(neuronCfg.NodeMetricsImage)
+
+			if neuronCfg.ImageRepoSecretName != "" {
+				builder = builder.WithImageRepoSecret(neuronCfg.ImageRepoSecretName)
+			}
+
+			_, err := builder.Create()
+			Expect(err).ToNot(HaveOccurred(), "Failed to restore DRA-mode DeviceConfig")
+
+			err = await.DRADaemonSet(APIClient, params.NeuronNamespace, migrationTimeout)
+			Expect(err).ToNot(HaveOccurred(), "DRA DaemonSet should be ready after restore")
+
+			klog.V(params.NeuronLogLevel).Info("DRA mode restored after migration tests")
+		})
+
 		// DRA-8: Device-Plugin to DRA Migration
 		Context("Device-plugin to DRA migration", Label(tsparams.LabelSuite), func() {
-			neuronCfg := neuronconfig.NewNeuronConfig()
-
 			BeforeAll(func() {
 				if !neuronCfg.IsDRAMigrationConfigured() {
 					Skip("DRA migration not configured - requires both device-plugin and DRA images")
@@ -109,23 +153,9 @@ var _ = Describe("Neuron DRA Migration Tests", Ordered,
 					APIClient, params.NeuronNamespace, migrationTimeout)
 				Expect(err).ToNot(HaveOccurred(), "Device-plugin DaemonSet should be ready")
 
-				Eventually(func(g Gomega) {
-					deployList, listErr := APIClient.K8sClient.AppsV1().Deployments(
-						params.NeuronNamespace).List(
-						context.TODO(), metav1.ListOptions{})
-					g.Expect(listErr).ToNot(HaveOccurred())
-
-					schedulerFound := false
-
-					for _, deploy := range deployList.Items {
-						if strings.Contains(deploy.Name, "scheduler") &&
-							deploy.Status.ReadyReplicas > 0 {
-							schedulerFound = true
-						}
-					}
-
-					g.Expect(schedulerFound).To(BeTrue(), "Custom scheduler should be ready")
-				}, migrationTimeout, 10*time.Second).Should(Succeed())
+				err = await.SchedulerDeploymentBySubstring(
+					APIClient, params.NeuronNamespace, migrationTimeout)
+				Expect(err).ToNot(HaveOccurred(), "Custom scheduler should be ready")
 			})
 
 			It("should have device-plugin and scheduler running before migration",
@@ -139,11 +169,11 @@ var _ = Describe("Neuron DRA Migration Tests", Ordered,
 
 					dpFound := false
 
-					for _, ds := range dsList.Items {
-						if strings.HasPrefix(ds.Name, params.DevicePluginDaemonSetPrefix) {
+					for _, daemonSet := range dsList.Items {
+						if strings.HasPrefix(daemonSet.Name, params.DevicePluginDaemonSetPrefix) {
 							dpFound = true
 
-							Expect(int(ds.Status.NumberReady)).To(BeNumerically(">", 0),
+							Expect(int(daemonSet.Status.NumberReady)).To(BeNumerically(">", 0),
 								"Device-plugin DaemonSet should have ready pods")
 						}
 					}
@@ -182,8 +212,6 @@ var _ = Describe("Neuron DRA Migration Tests", Ordered,
 
 			It("should migrate to DRA mode by updating DeviceConfig",
 				reportxml.ID("90501"), func() {
-					neuronCfg := neuronconfig.NewNeuronConfig()
-
 					By("Pulling DeviceConfig and switching to DRA mode")
 
 					dcBuilder, err := neuron.Pull(
@@ -241,6 +269,8 @@ var _ = Describe("Neuron DRA Migration Tests", Ordered,
 					labels := dcBuilder.Object.Labels
 					Expect(labels).To(HaveKeyWithValue(
 						"kmm.node.kubernetes.io/module.name", params.DefaultDeviceConfigName))
+					Expect(labels).To(HaveKeyWithValue(
+						"kmm.node.kubernetes.io/module.namespace", params.NeuronNamespace))
 				})
 
 			It("should have ResourceSlices published after migration to DRA",
@@ -267,6 +297,14 @@ var _ = Describe("Neuron DRA Migration Tests", Ordered,
 						Expect(err).ToNot(HaveOccurred())
 					}
 
+					DeferCleanup(func() {
+						cleanupNS := namespace.NewBuilder(APIClient, migrationTestNS)
+						if cleanupNS.Exists() {
+							err := cleanupNS.DeleteAndWait(migrationPollTimeout)
+							Expect(err).ToNot(HaveOccurred())
+						}
+					})
+
 					rctBuilder := resource.NewResourceClaimTemplateBuilder(
 						APIClient, migrationClaimTpl, migrationTestNS).
 						WithDeviceRequest("neuron-device", params.DRADefaultDeviceClassName, 1)
@@ -292,21 +330,11 @@ var _ = Describe("Neuron DRA Migration Tests", Ordered,
 					Expect(err).ToNot(HaveOccurred())
 					Expect(hasDevices).To(BeTrue(),
 						"Pod should have /dev/neuron* device after migration to DRA")
-
-					By("Cleaning up test namespace")
-
-					nsBuilder = namespace.NewBuilder(APIClient, migrationTestNS)
-					if nsBuilder.Exists() {
-						err = nsBuilder.DeleteAndWait(migrationPollTimeout)
-						Expect(err).ToNot(HaveOccurred())
-					}
 				})
 		})
 
 		// DRA-10: DRA to Device-Plugin Rollback
 		Context("DRA to device-plugin rollback", Label(tsparams.LabelSuite), func() {
-			neuronCfg := neuronconfig.NewNeuronConfig()
-
 			BeforeAll(func() {
 				if !neuronCfg.IsDRAMigrationConfigured() {
 					Skip("DRA migration not configured - requires both device-plugin and DRA images")
@@ -389,11 +417,11 @@ var _ = Describe("Neuron DRA Migration Tests", Ordered,
 
 					dpFound := false
 
-					for _, ds := range dsList.Items {
-						if strings.HasPrefix(ds.Name, params.DevicePluginDaemonSetPrefix) {
+					for _, daemonSet := range dsList.Items {
+						if strings.HasPrefix(daemonSet.Name, params.DevicePluginDaemonSetPrefix) {
 							dpFound = true
 
-							Expect(int(ds.Status.NumberReady)).To(Equal(len(neuronNodes)),
+							Expect(int(daemonSet.Status.NumberReady)).To(Equal(len(neuronNodes)),
 								"Device-plugin should have one ready pod per Neuron node")
 						}
 					}
@@ -406,7 +434,7 @@ var _ = Describe("Neuron DRA Migration Tests", Ordered,
 				reportxml.ID("90507"), func() {
 					By("Waiting for scheduler deployment to be ready")
 
-					err := await.SchedulerDeployment(
+					err := await.SchedulerDeploymentBySubstring(
 						APIClient, params.NeuronNamespace, migrationTimeout)
 					Expect(err).ToNot(HaveOccurred(),
 						"Custom scheduler should be ready after rollback")

--- a/tests/hw-accel/neuron/dra/tests/dra-migration-test.go
+++ b/tests/hw-accel/neuron/dra/tests/dra-migration-test.go
@@ -296,16 +296,21 @@ var _ = Describe("Neuron DRA Migration Tests", Ordered,
 
 			It("should have ResourceSlices published after migration to DRA",
 				reportxml.ID("90503"), func() {
-					By("Listing ResourceSlices for neuron.aws.com driver")
+					By("Waiting for ResourceSlices to be published")
 
-					slices, err := resource.ListResourceSlicesByDriver(
-						APIClient, params.DRADriverName)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(slices).ToNot(BeEmpty(),
+					Eventually(func() bool {
+						slices, err := resource.ListResourceSlicesByDriver(
+							APIClient, params.DRADriverName)
+						if err != nil || len(slices) == 0 {
+							return false
+						}
+
+						klog.V(params.NeuronLogLevel).Infof(
+							"Found %d ResourceSlices after migration", len(slices))
+
+						return true
+					}, migrationTimeout, 10*time.Second).Should(BeTrue(),
 						"ResourceSlices should be published after migration to DRA")
-
-					klog.V(params.NeuronLogLevel).Infof(
-						"Found %d ResourceSlices after migration", len(slices))
 				})
 
 			It("should allocate a device via DRA after migration",

--- a/tests/hw-accel/neuron/dra/tests/dra-migration-test.go
+++ b/tests/hw-accel/neuron/dra/tests/dra-migration-test.go
@@ -493,23 +493,25 @@ var _ = Describe("Neuron DRA Migration Tests", Ordered,
 					Expect(err).ToNot(HaveOccurred(),
 						"Custom scheduler should be ready after rollback")
 
-					By("Verifying scheduler extension exists")
+					By("Waiting for scheduler extension to exist")
 
-					deployList, err := APIClient.K8sClient.AppsV1().Deployments(
-						params.NeuronNamespace).List(
-						context.TODO(), metav1.ListOptions{})
-					Expect(err).ToNot(HaveOccurred())
-
-					extensionFound := false
-
-					for _, deploy := range deployList.Items {
-						if strings.HasPrefix(deploy.Name,
-							params.SchedulerExtensionDeploymentPrefix) {
-							extensionFound = true
+					Eventually(func() bool {
+						deployList, listErr := APIClient.K8sClient.AppsV1().Deployments(
+							params.NeuronNamespace).List(
+							context.TODO(), metav1.ListOptions{})
+						if listErr != nil {
+							return false
 						}
-					}
 
-					Expect(extensionFound).To(BeTrue(),
+						for _, deploy := range deployList.Items {
+							if strings.HasPrefix(deploy.Name,
+								params.SchedulerExtensionDeploymentPrefix) {
+								return true
+							}
+						}
+
+						return false
+					}, migrationTimeout, 10*time.Second).Should(BeTrue(),
 						"Scheduler extension deployment should exist after rollback")
 				})
 

--- a/tests/hw-accel/neuron/dra/tests/dra-migration-test.go
+++ b/tests/hw-accel/neuron/dra/tests/dra-migration-test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/neuronhelpers"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/params"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 )
@@ -108,9 +109,23 @@ var _ = Describe("Neuron DRA Migration Tests", Ordered,
 					APIClient, params.NeuronNamespace, migrationTimeout)
 				Expect(err).ToNot(HaveOccurred(), "Device-plugin DaemonSet should be ready")
 
-				err = await.SchedulerDeployment(
-					APIClient, params.NeuronNamespace, migrationTimeout)
-				Expect(err).ToNot(HaveOccurred(), "Custom scheduler should be ready")
+				Eventually(func(g Gomega) {
+					deployList, listErr := APIClient.K8sClient.AppsV1().Deployments(
+						params.NeuronNamespace).List(
+						context.TODO(), metav1.ListOptions{})
+					g.Expect(listErr).ToNot(HaveOccurred())
+
+					schedulerFound := false
+
+					for _, deploy := range deployList.Items {
+						if strings.Contains(deploy.Name, "scheduler") &&
+							deploy.Status.ReadyReplicas > 0 {
+							schedulerFound = true
+						}
+					}
+
+					g.Expect(schedulerFound).To(BeTrue(), "Custom scheduler should be ready")
+				}, migrationTimeout, 10*time.Second).Should(Succeed())
 			})
 
 			It("should have device-plugin and scheduler running before migration",
@@ -127,6 +142,7 @@ var _ = Describe("Neuron DRA Migration Tests", Ordered,
 					for _, ds := range dsList.Items {
 						if strings.HasPrefix(ds.Name, params.DevicePluginDaemonSetPrefix) {
 							dpFound = true
+
 							Expect(int(ds.Status.NumberReady)).To(BeNumerically(">", 0),
 								"Device-plugin DaemonSet should have ready pods")
 						}
@@ -376,6 +392,7 @@ var _ = Describe("Neuron DRA Migration Tests", Ordered,
 					for _, ds := range dsList.Items {
 						if strings.HasPrefix(ds.Name, params.DevicePluginDaemonSetPrefix) {
 							dpFound = true
+
 							Expect(int(ds.Status.NumberReady)).To(Equal(len(neuronNodes)),
 								"Device-plugin should have one ready pod per Neuron node")
 						}
@@ -444,6 +461,8 @@ var _ = Describe("Neuron DRA Migration Tests", Ordered,
 						context.TODO(), params.DRADefaultDeviceClassName, metav1.GetOptions{})
 					Expect(err).To(HaveOccurred(),
 						"DeviceClass should not exist after rollback")
+					Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+						"DeviceClass error should be NotFound, got: %v", err)
 
 					By("Verifying no ResourceSlices for neuron driver")
 

--- a/tests/hw-accel/neuron/dra/tests/dra-migration-test.go
+++ b/tests/hw-accel/neuron/dra/tests/dra-migration-test.go
@@ -1,0 +1,461 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/neuron"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/resource"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/dra/internal/tsparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/await"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/check"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/do"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/neuronconfig"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/neuronhelpers"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/params"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	migrationTestNS      = "neuron-dra-migration-test"
+	migrationClaimTpl    = "neuron-migration-claim"
+	migrationTimeout     = 10 * time.Minute
+	migrationPollTimeout = 5 * time.Minute
+)
+
+var _ = Describe("Neuron DRA Migration Tests", Ordered,
+	Label(params.Label, params.DRALabel, params.DRAMigrationLabel), func() {
+		// DRA-8: Device-Plugin to DRA Migration
+		Context("Device-plugin to DRA migration", Label(tsparams.LabelSuite), func() {
+			neuronCfg := neuronconfig.NewNeuronConfig()
+
+			BeforeAll(func() {
+				if !neuronCfg.IsDRAMigrationConfigured() {
+					Skip("DRA migration not configured - requires both device-plugin and DRA images")
+				}
+
+				By("Verifying all required operators are ready")
+
+				var options *neuronhelpers.NeuronInstallConfigOptions
+				if neuronCfg.CatalogSource != "" {
+					options = &neuronhelpers.NeuronInstallConfigOptions{
+						CatalogSource: neuronhelpers.StringPtr(neuronCfg.CatalogSource),
+					}
+				}
+
+				Expect(neuronhelpers.AreAllOperatorsReady(APIClient, options)).To(BeTrue(),
+					"All operators (NFD, KMM, Neuron) must be pre-installed and ready")
+
+				By("Verifying Neuron nodes exist")
+
+				exists, err := check.NeuronNodesExist(APIClient)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(exists).To(BeTrue(), "At least one Neuron node must exist")
+
+				By("Cleaning up any existing DeviceConfig")
+
+				if existingDC, _ := neuron.Pull(
+					APIClient, params.DefaultDeviceConfigName, params.NeuronNamespace); existingDC != nil {
+					_, err := existingDC.Delete()
+					Expect(err).ToNot(HaveOccurred())
+
+					Eventually(func() bool {
+						_, pullErr := neuron.Pull(
+							APIClient, params.DefaultDeviceConfigName, params.NeuronNamespace)
+
+						return pullErr != nil
+					}, migrationPollTimeout, 5*time.Second).Should(BeTrue(),
+						"Existing DeviceConfig should be deleted")
+				}
+
+				By("Creating device-plugin mode DeviceConfig")
+
+				builder := neuron.NewBuilder(
+					APIClient,
+					params.DefaultDeviceConfigName,
+					params.NeuronNamespace,
+					neuronCfg.DriversImage,
+					neuronCfg.DriverVersion,
+					neuronCfg.DevicePluginImage,
+				).WithSelector(map[string]string{
+					params.NeuronNFDLabelKey: params.NeuronNFDLabelValue,
+				}).WithScheduler(
+					neuronCfg.SchedulerImage,
+					neuronCfg.SchedulerExtensionImage,
+				).WithNodeMetricsImage(neuronCfg.NodeMetricsImage)
+
+				if neuronCfg.ImageRepoSecretName != "" {
+					builder = builder.WithImageRepoSecret(neuronCfg.ImageRepoSecretName)
+				}
+
+				_, err = builder.Create()
+				Expect(err).ToNot(HaveOccurred(), "Failed to create device-plugin mode DeviceConfig")
+
+				By("Waiting for device-plugin mode to be fully ready")
+
+				err = neuronhelpers.WaitForClusterStabilityAfterDeviceConfig(APIClient)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = await.DevicePluginDeployment(
+					APIClient, params.NeuronNamespace, migrationTimeout)
+				Expect(err).ToNot(HaveOccurred(), "Device-plugin DaemonSet should be ready")
+
+				err = await.SchedulerDeployment(
+					APIClient, params.NeuronNamespace, migrationTimeout)
+				Expect(err).ToNot(HaveOccurred(), "Custom scheduler should be ready")
+			})
+
+			It("should have device-plugin and scheduler running before migration",
+				reportxml.ID("90500"), func() {
+					By("Verifying device-plugin DaemonSet exists")
+
+					dsList, err := APIClient.K8sClient.AppsV1().DaemonSets(
+						params.NeuronNamespace).List(
+						context.TODO(), metav1.ListOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					dpFound := false
+
+					for _, ds := range dsList.Items {
+						if strings.HasPrefix(ds.Name, params.DevicePluginDaemonSetPrefix) {
+							dpFound = true
+							Expect(int(ds.Status.NumberReady)).To(BeNumerically(">", 0),
+								"Device-plugin DaemonSet should have ready pods")
+						}
+					}
+
+					Expect(dpFound).To(BeTrue(), "Device-plugin DaemonSet should exist")
+
+					By("Verifying custom scheduler deployment exists")
+
+					deployList, err := APIClient.K8sClient.AppsV1().Deployments(
+						params.NeuronNamespace).List(
+						context.TODO(), metav1.ListOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					schedulerFound := false
+
+					for _, deploy := range deployList.Items {
+						if strings.Contains(deploy.Name, "scheduler") {
+							schedulerFound = true
+						}
+					}
+
+					Expect(schedulerFound).To(BeTrue(), "Custom scheduler should exist")
+
+					By("Verifying no DRA DaemonSet exists")
+
+					draDSList, err := APIClient.K8sClient.AppsV1().DaemonSets(
+						params.NeuronNamespace).List(
+						context.TODO(), metav1.ListOptions{
+							LabelSelector: fmt.Sprintf("%s=%s",
+								params.DRADaemonSetLabelKey, params.DRADaemonSetLabelValue),
+						})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(draDSList.Items).To(BeEmpty(),
+						"DRA DaemonSet should not exist in device-plugin mode")
+				})
+
+			It("should migrate to DRA mode by updating DeviceConfig",
+				reportxml.ID("90501"), func() {
+					neuronCfg := neuronconfig.NewNeuronConfig()
+
+					By("Pulling DeviceConfig and switching to DRA mode")
+
+					dcBuilder, err := neuron.Pull(
+						APIClient, params.DefaultDeviceConfigName, params.NeuronNamespace)
+					Expect(err).ToNot(HaveOccurred())
+
+					dcBuilder.Definition.Spec.DevicePluginImage = ""
+					dcBuilder.Definition.Spec.CustomSchedulerImage = ""
+					dcBuilder.Definition.Spec.SchedulerExtensionImage = ""
+					dcBuilder.Definition.Spec.DRADriverImage = neuronCfg.DRADriverImage
+
+					_, err = dcBuilder.Update(false)
+					Expect(err).ToNot(HaveOccurred(), "Failed to update DeviceConfig to DRA mode")
+
+					By("Waiting for device-plugin DaemonSet to be removed")
+
+					err = await.DevicePluginDaemonSetGone(
+						APIClient, params.NeuronNamespace, migrationPollTimeout)
+					Expect(err).ToNot(HaveOccurred(),
+						"Device-plugin DaemonSet should be removed after migration")
+
+					By("Waiting for scheduler deployments to be removed")
+
+					err = await.NoSchedulerDeployments(
+						APIClient, params.NeuronNamespace, migrationPollTimeout)
+					Expect(err).ToNot(HaveOccurred(),
+						"Scheduler deployments should be removed after migration")
+
+					By("Waiting for DRA DaemonSet to be ready")
+
+					err = await.DRADaemonSet(
+						APIClient, params.NeuronNamespace, migrationTimeout)
+					Expect(err).ToNot(HaveOccurred(),
+						"DRA DaemonSet should be ready after migration")
+
+					klog.V(params.NeuronLogLevel).Info(
+						"Migration to DRA mode complete")
+				})
+
+			It("should have DeviceClass created after migration to DRA",
+				reportxml.ID("90502"), func() {
+					By("Waiting for DeviceClass to exist")
+
+					err := await.DeviceClassExists(
+						APIClient, params.DRADefaultDeviceClassName, tsparams.DeviceClassTimeout)
+					Expect(err).ToNot(HaveOccurred(),
+						"DeviceClass %s should exist after migration", params.DRADefaultDeviceClassName)
+
+					By("Verifying DeviceClass has KMM ownership labels")
+
+					dcBuilder, err := resource.PullDeviceClass(
+						APIClient, params.DRADefaultDeviceClassName)
+					Expect(err).ToNot(HaveOccurred())
+
+					labels := dcBuilder.Object.Labels
+					Expect(labels).To(HaveKeyWithValue(
+						"kmm.node.kubernetes.io/module.name", params.DefaultDeviceConfigName))
+				})
+
+			It("should have ResourceSlices published after migration to DRA",
+				reportxml.ID("90503"), func() {
+					By("Listing ResourceSlices for neuron.aws.com driver")
+
+					slices, err := resource.ListResourceSlicesByDriver(
+						APIClient, params.DRADriverName)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(slices).ToNot(BeEmpty(),
+						"ResourceSlices should be published after migration to DRA")
+
+					klog.V(params.NeuronLogLevel).Infof(
+						"Found %d ResourceSlices after migration", len(slices))
+				})
+
+			It("should allocate a device via DRA after migration",
+				reportxml.ID("90504"), func() {
+					By("Creating test namespace and ResourceClaimTemplate")
+
+					nsBuilder := namespace.NewBuilder(APIClient, migrationTestNS)
+					if !nsBuilder.Exists() {
+						_, err := nsBuilder.Create()
+						Expect(err).ToNot(HaveOccurred())
+					}
+
+					rctBuilder := resource.NewResourceClaimTemplateBuilder(
+						APIClient, migrationClaimTpl, migrationTestNS).
+						WithDeviceRequest("neuron-device", params.DRADefaultDeviceClassName, 1)
+					Expect(rctBuilder).ToNot(BeNil())
+
+					if !rctBuilder.Exists() {
+						_, err := rctBuilder.Create()
+						Expect(err).ToNot(HaveOccurred())
+					}
+
+					By("Creating DRA consumer pod")
+
+					err := do.CreateDRAConsumerPodAndWait(
+						APIClient, "migration-consumer", migrationTestNS,
+						migrationClaimTpl, migrationPollTimeout)
+					Expect(err).ToNot(HaveOccurred(),
+						"DRA consumer pod should be Running after migration")
+
+					By("Verifying Neuron device is visible")
+
+					hasDevices, err := check.PodHasNeuronDevices(
+						APIClient, "migration-consumer", migrationTestNS)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(hasDevices).To(BeTrue(),
+						"Pod should have /dev/neuron* device after migration to DRA")
+
+					By("Cleaning up test namespace")
+
+					nsBuilder = namespace.NewBuilder(APIClient, migrationTestNS)
+					if nsBuilder.Exists() {
+						err = nsBuilder.DeleteAndWait(migrationPollTimeout)
+						Expect(err).ToNot(HaveOccurred())
+					}
+				})
+		})
+
+		// DRA-10: DRA to Device-Plugin Rollback
+		Context("DRA to device-plugin rollback", Label(tsparams.LabelSuite), func() {
+			neuronCfg := neuronconfig.NewNeuronConfig()
+
+			BeforeAll(func() {
+				if !neuronCfg.IsDRAMigrationConfigured() {
+					Skip("DRA migration not configured - requires both device-plugin and DRA images")
+				}
+
+				By("Verifying DeviceConfig is in DRA mode from previous context")
+
+				dcBuilder, err := neuron.Pull(
+					APIClient, params.DefaultDeviceConfigName, params.NeuronNamespace)
+				Expect(err).ToNot(HaveOccurred(), "DeviceConfig must exist")
+				Expect(dcBuilder.Definition.Spec.DRADriverImage).ToNot(BeEmpty(),
+					"DeviceConfig must be in DRA mode (set by previous migration context)")
+
+				By("Verifying DRA DaemonSet is running")
+
+				err = await.DRADaemonSet(
+					APIClient, params.NeuronNamespace, migrationTimeout)
+				Expect(err).ToNot(HaveOccurred(), "DRA DaemonSet must be ready before rollback")
+			})
+
+			It("should rollback to device-plugin mode by updating DeviceConfig",
+				reportxml.ID("90505"), func() {
+					By("Pulling DeviceConfig and switching to device-plugin mode")
+
+					dcBuilder, err := neuron.Pull(
+						APIClient, params.DefaultDeviceConfigName, params.NeuronNamespace)
+					Expect(err).ToNot(HaveOccurred())
+
+					dcBuilder.Definition.Spec.DRADriverImage = ""
+					dcBuilder.Definition.Spec.DevicePluginImage = neuronCfg.DevicePluginImage
+					dcBuilder.Definition.Spec.CustomSchedulerImage = neuronCfg.SchedulerImage
+					dcBuilder.Definition.Spec.SchedulerExtensionImage = neuronCfg.SchedulerExtensionImage
+
+					_, err = dcBuilder.Update(false)
+					Expect(err).ToNot(HaveOccurred(),
+						"Failed to update DeviceConfig to device-plugin mode")
+
+					By("Waiting for DRA DaemonSet to be removed")
+
+					err = await.DRADaemonSetGone(
+						APIClient, params.NeuronNamespace, migrationPollTimeout)
+					Expect(err).ToNot(HaveOccurred(),
+						"DRA DaemonSet should be removed after rollback")
+
+					By("Waiting for DeviceClass to be removed")
+
+					err = await.DeviceClassGone(
+						APIClient, params.DRADefaultDeviceClassName, tsparams.DeviceClassTimeout)
+					Expect(err).ToNot(HaveOccurred(),
+						"DeviceClass should be removed after rollback")
+
+					By("Waiting for ResourceSlices to be cleaned up")
+
+					err = await.ResourceSlicesGone(
+						APIClient, params.DRADriverName, migrationPollTimeout)
+					Expect(err).ToNot(HaveOccurred(),
+						"ResourceSlices should be removed after rollback")
+
+					klog.V(params.NeuronLogLevel).Info("DRA resources cleaned up after rollback")
+				})
+
+			It("should have device-plugin DaemonSet running after rollback",
+				reportxml.ID("90506"), func() {
+					By("Waiting for device-plugin DaemonSet to be ready")
+
+					err := await.DevicePluginDeployment(
+						APIClient, params.NeuronNamespace, migrationTimeout)
+					Expect(err).ToNot(HaveOccurred(),
+						"Device-plugin DaemonSet should be ready after rollback")
+
+					By("Verifying device-plugin pods are running on Neuron nodes")
+
+					neuronNodes, err := check.GetNeuronNodes(APIClient)
+					Expect(err).ToNot(HaveOccurred())
+
+					dsList, err := APIClient.K8sClient.AppsV1().DaemonSets(
+						params.NeuronNamespace).List(
+						context.TODO(), metav1.ListOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					dpFound := false
+
+					for _, ds := range dsList.Items {
+						if strings.HasPrefix(ds.Name, params.DevicePluginDaemonSetPrefix) {
+							dpFound = true
+							Expect(int(ds.Status.NumberReady)).To(Equal(len(neuronNodes)),
+								"Device-plugin should have one ready pod per Neuron node")
+						}
+					}
+
+					Expect(dpFound).To(BeTrue(),
+						"Device-plugin DaemonSet should exist after rollback")
+				})
+
+			It("should have custom scheduler running after rollback",
+				reportxml.ID("90507"), func() {
+					By("Waiting for scheduler deployment to be ready")
+
+					err := await.SchedulerDeployment(
+						APIClient, params.NeuronNamespace, migrationTimeout)
+					Expect(err).ToNot(HaveOccurred(),
+						"Custom scheduler should be ready after rollback")
+
+					By("Verifying scheduler extension exists")
+
+					deployList, err := APIClient.K8sClient.AppsV1().Deployments(
+						params.NeuronNamespace).List(
+						context.TODO(), metav1.ListOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					extensionFound := false
+
+					for _, deploy := range deployList.Items {
+						if strings.HasPrefix(deploy.Name,
+							params.SchedulerExtensionDeploymentPrefix) {
+							extensionFound = true
+						}
+					}
+
+					Expect(extensionFound).To(BeTrue(),
+						"Scheduler extension deployment should exist after rollback")
+				})
+
+			It("should have Neuron device resources on nodes after rollback",
+				reportxml.ID("90508"), func() {
+					By("Waiting for all Neuron nodes to have device resources")
+
+					err := await.AllNeuronNodesResourceAvailable(
+						APIClient, migrationTimeout)
+					Expect(err).ToNot(HaveOccurred(),
+						"Neuron device resources should be available after rollback")
+				})
+
+			It("should NOT have any DRA resources after rollback",
+				reportxml.ID("90509"), func() {
+					By("Verifying no DRA DaemonSet exists")
+
+					draDSList, err := APIClient.K8sClient.AppsV1().DaemonSets(
+						params.NeuronNamespace).List(
+						context.TODO(), metav1.ListOptions{
+							LabelSelector: fmt.Sprintf("%s=%s",
+								params.DRADaemonSetLabelKey, params.DRADaemonSetLabelValue),
+						})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(draDSList.Items).To(BeEmpty(),
+						"DRA DaemonSet should not exist after rollback")
+
+					By("Verifying no DeviceClass exists")
+
+					_, err = APIClient.K8sClient.ResourceV1().DeviceClasses().Get(
+						context.TODO(), params.DRADefaultDeviceClassName, metav1.GetOptions{})
+					Expect(err).To(HaveOccurred(),
+						"DeviceClass should not exist after rollback")
+
+					By("Verifying no ResourceSlices for neuron driver")
+
+					sliceList, err := APIClient.K8sClient.ResourceV1().ResourceSlices().List(
+						context.TODO(), metav1.ListOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					for idx := range sliceList.Items {
+						Expect(sliceList.Items[idx].Spec.Driver).ToNot(Equal(params.DRADriverName),
+							"No ResourceSlice should have driver %s after rollback",
+							params.DRADriverName)
+					}
+				})
+		})
+	})

--- a/tests/hw-accel/neuron/dra/tests/dra-migration-test.go
+++ b/tests/hw-accel/neuron/dra/tests/dra-migration-test.go
@@ -504,8 +504,7 @@ var _ = Describe("Neuron DRA Migration Tests", Ordered,
 						}
 
 						for _, deploy := range deployList.Items {
-							if strings.HasPrefix(deploy.Name,
-								params.SchedulerExtensionDeploymentPrefix) {
+							if strings.Contains(deploy.Name, "scheduler-extension") {
 								return true
 							}
 						}

--- a/tests/hw-accel/neuron/internal/await/await.go
+++ b/tests/hw-accel/neuron/internal/await/await.go
@@ -492,13 +492,13 @@ func NoSchedulerDeployments(apiClient *clients.Settings, namespace string,
 		})
 }
 
-// SchedulerDeploymentBySubstring waits for any deployment containing "scheduler" in its name
-// to be ready. The operator creates "neuron-custom-scheduler", not the constant
-// SchedulerDeploymentName ("neuron-scheduler").
+// SchedulerDeploymentBySubstring waits for the custom-scheduler deployment to be ready.
+// The operator creates "<name>-custom-scheduler", not the constant SchedulerDeploymentName.
+// Matches "custom-scheduler" but excludes "custom-scheduler-extension".
 func SchedulerDeploymentBySubstring(apiClient *clients.Settings, namespace string,
 	timeout time.Duration) error {
 	klog.V(params.NeuronLogLevel).Infof(
-		"Waiting for scheduler deployment (by substring) in namespace %s", namespace)
+		"Waiting for custom-scheduler deployment in namespace %s", namespace)
 
 	return wait.PollUntilContextTimeout(
 		context.TODO(), 10*time.Second, timeout, true,
@@ -510,7 +510,8 @@ func SchedulerDeploymentBySubstring(apiClient *clients.Settings, namespace strin
 			}
 
 			for _, deploy := range deployList.Items {
-				if strings.Contains(deploy.Name, "scheduler") &&
+				if strings.Contains(deploy.Name, "custom-scheduler") &&
+					!strings.Contains(deploy.Name, "scheduler-extension") &&
 					deploy.Status.ReadyReplicas > 0 {
 					klog.V(params.NeuronLogLevel).Infof(
 						"Scheduler deployment %s is ready", deploy.Name)

--- a/tests/hw-accel/neuron/internal/await/await.go
+++ b/tests/hw-accel/neuron/internal/await/await.go
@@ -492,6 +492,64 @@ func NoSchedulerDeployments(apiClient *clients.Settings, namespace string,
 		})
 }
 
+// DevicePluginDaemonSetGone waits for all device-plugin DaemonSets to be deleted from a namespace.
+func DevicePluginDaemonSetGone(apiClient *clients.Settings, namespace string,
+	timeout time.Duration) error {
+	klog.V(params.NeuronLogLevel).Infof(
+		"Waiting for device-plugin DaemonSets to be deleted from namespace %s", namespace)
+
+	return wait.PollUntilContextTimeout(
+		context.TODO(), 5*time.Second, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			dsList, err := apiClient.K8sClient.AppsV1().DaemonSets(namespace).List(
+				ctx, metav1.ListOptions{})
+			if err != nil {
+				return false, nil
+			}
+
+			for _, ds := range dsList.Items {
+				if strings.HasPrefix(ds.Name, params.DevicePluginDaemonSetPrefix) {
+					klog.V(params.NeuronLogLevel).Infof(
+						"Device-plugin DaemonSet %s still exists", ds.Name)
+
+					return false, nil
+				}
+			}
+
+			klog.V(params.NeuronLogLevel).Info("All device-plugin DaemonSets deleted")
+
+			return true, nil
+		})
+}
+
+// ResourceSlicesGone waits for all ResourceSlices with the given driver to be deleted.
+func ResourceSlicesGone(apiClient *clients.Settings, driverName string,
+	timeout time.Duration) error {
+	klog.V(params.NeuronLogLevel).Infof(
+		"Waiting for ResourceSlices with driver %s to be deleted", driverName)
+
+	return wait.PollUntilContextTimeout(
+		context.TODO(), 5*time.Second, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			sliceList, err := apiClient.K8sClient.ResourceV1().ResourceSlices().List(
+				ctx, metav1.ListOptions{})
+			if err != nil {
+				return false, nil
+			}
+
+			for idx := range sliceList.Items {
+				if sliceList.Items[idx].Spec.Driver == driverName {
+					return false, nil
+				}
+			}
+
+			klog.V(params.NeuronLogLevel).Infof(
+				"All ResourceSlices for driver %s deleted", driverName)
+
+			return true, nil
+		})
+}
+
 // DevicePluginRunningOnNode waits for the device plugin pod to be running on a specific node.
 func DevicePluginRunningOnNode(apiClient *clients.Settings, nodeName string,
 	timeout time.Duration) error {

--- a/tests/hw-accel/neuron/internal/await/await.go
+++ b/tests/hw-accel/neuron/internal/await/await.go
@@ -492,6 +492,37 @@ func NoSchedulerDeployments(apiClient *clients.Settings, namespace string,
 		})
 }
 
+// SchedulerDeploymentBySubstring waits for any deployment containing "scheduler" in its name
+// to be ready. The operator creates "neuron-custom-scheduler", not the constant
+// SchedulerDeploymentName ("neuron-scheduler").
+func SchedulerDeploymentBySubstring(apiClient *clients.Settings, namespace string,
+	timeout time.Duration) error {
+	klog.V(params.NeuronLogLevel).Infof(
+		"Waiting for scheduler deployment (by substring) in namespace %s", namespace)
+
+	return wait.PollUntilContextTimeout(
+		context.TODO(), 10*time.Second, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			deployList, err := apiClient.K8sClient.AppsV1().Deployments(namespace).List(
+				ctx, metav1.ListOptions{})
+			if err != nil {
+				return false, nil
+			}
+
+			for _, deploy := range deployList.Items {
+				if strings.Contains(deploy.Name, "scheduler") &&
+					deploy.Status.ReadyReplicas > 0 {
+					klog.V(params.NeuronLogLevel).Infof(
+						"Scheduler deployment %s is ready", deploy.Name)
+
+					return true, nil
+				}
+			}
+
+			return false, nil
+		})
+}
+
 // DevicePluginDaemonSetGone waits for all device-plugin DaemonSets to be deleted from a namespace.
 func DevicePluginDaemonSetGone(apiClient *clients.Settings, namespace string,
 	timeout time.Duration) error {

--- a/tests/hw-accel/neuron/internal/neuronconfig/config.go
+++ b/tests/hw-accel/neuron/internal/neuronconfig/config.go
@@ -171,3 +171,12 @@ func (c *NeuronConfig) IsKServeConfigured() bool {
 func (c *NeuronConfig) IsDRAConfigured() bool {
 	return c.DRADriverImage != ""
 }
+
+// IsDRAMigrationConfigured checks if both device-plugin and DRA modes are configured,
+// enabling mode-switching tests (device-plugin ↔ DRA migration/rollback).
+func (c *NeuronConfig) IsDRAMigrationConfigured() bool {
+	return c.IsDRAConfigured() &&
+		c.DevicePluginImage != "" &&
+		c.SchedulerImage != "" &&
+		c.SchedulerExtensionImage != ""
+}

--- a/tests/hw-accel/neuron/internal/neuronconfig/config.go
+++ b/tests/hw-accel/neuron/internal/neuronconfig/config.go
@@ -176,6 +176,7 @@ func (c *NeuronConfig) IsDRAConfigured() bool {
 // enabling mode-switching tests (device-plugin ↔ DRA migration/rollback).
 func (c *NeuronConfig) IsDRAMigrationConfigured() bool {
 	return c.IsDRAConfigured() &&
+		c.NodeMetricsImage != "" &&
 		c.DevicePluginImage != "" &&
 		c.SchedulerImage != "" &&
 		c.SchedulerExtensionImage != ""

--- a/tests/hw-accel/neuron/internal/neuronconfig/config.go
+++ b/tests/hw-accel/neuron/internal/neuronconfig/config.go
@@ -175,7 +175,10 @@ func (c *NeuronConfig) IsDRAConfigured() bool {
 // IsDRAMigrationConfigured checks if both device-plugin and DRA modes are configured,
 // enabling mode-switching tests (device-plugin ↔ DRA migration/rollback).
 func (c *NeuronConfig) IsDRAMigrationConfigured() bool {
+	hasDriverSource := c.DriversImage != "" || c.DriverVersion != ""
+
 	return c.IsDRAConfigured() &&
+		hasDriverSource &&
 		c.NodeMetricsImage != "" &&
 		c.DevicePluginImage != "" &&
 		c.SchedulerImage != "" &&

--- a/tests/hw-accel/neuron/params/consts.go
+++ b/tests/hw-accel/neuron/params/consts.go
@@ -73,6 +73,9 @@ const (
 	// DRADaemonSetPrefix is the prefix for DRA DaemonSet names created by KMM.
 	DRADaemonSetPrefix = "neuron-dra-"
 
+	// DRAMigrationLabel represents the label for DRA migration test cases.
+	DRAMigrationLabel = "dra-migration"
+
 	// SchedulerExtensionDeploymentPrefix is the prefix for the scheduler extension deployment.
 	SchedulerExtensionDeploymentPrefix = "neuron-scheduler-extension"
 )


### PR DESCRIPTION
## Summary
- Add device-plugin ↔ DRA mode switching tests for the Neuron operator
- **DRA-8**: Verifies migration from device-plugin mode to DRA mode — device-plugin/scheduler cleanup, DRA DaemonSet creation, DeviceClass + ResourceSlice publication, and DRA allocation with consumer pod
- **DRA-10**: Verifies rollback from DRA mode to device-plugin mode — DRA resource cleanup, device-plugin/scheduler restoration, and node resource availability
- 10 test cases: OCP-90500 to OCP-90509

### Changes
- `dra-migration-test.go`: Ordered test contexts for migration (5 tests) and rollback (5 tests)
- `await.go`: `DevicePluginDaemonSetGone()` and `ResourceSlicesGone()` wait helpers
- `config.go`: `IsDRAMigrationConfigured()` — requires both device-plugin and DRA images
- `params/consts.go`: `DRAMigrationLabel` constant

### Prerequisites
Requires all four mode images configured:
- `ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE`
- `ECO_HWACCEL_NEURON_SCHEDULER_IMAGE`
- `ECO_HWACCEL_NEURON_SCHEDULER_EXTENSION_IMAGE`
- `ECO_HWACCEL_NEURON_DRA_DRIVER_IMAGE`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved validation of Neuron hardware-accelerator DRA migration and rollback workflows.
  - Added stronger checks for scheduler readiness, resource cleanup, device configuration restoration, and expected API responses.
  - Improved polling and timeout handling to reduce flaky test results.
  - Added validation for required driver and metrics configuration before migration testing.
  - Added a dedicated label for selecting DRA migration test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->