### PR TITLE
cnf ran talm: fix 5.0 failures by creating MCSB

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,6 +79,7 @@ linters:
             - open-cluster-management.io/governance-policy-propagator/api
             - open-cluster-management.io/config-policy-controller/api
             - open-cluster-management.io/multicloud-operators-subscription/pkg/apis
+            - open-cluster-management.io/api
             - sigs.k8s.io/controller-runtime
             - $gostd
             - github.com/stretchr/testify

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/kubelet v0.35.6
 	k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3
+	open-cluster-management.io/api v1.3.0
 	open-cluster-management.io/config-policy-controller v0.19.0
 	open-cluster-management.io/governance-policy-propagator v0.18.1-0.20260302212915-815d063a291a // prior to controller-runtime v0.23
 	open-cluster-management.io/multicloud-operators-subscription v0.16.0
@@ -266,7 +267,6 @@ require (
 	k8s.io/kubectl v0.35.6 // indirect
 	knative.dev/pkg v0.0.0-20260120122510-4a022ed9999a // indirect
 	maistra.io/api v0.0.0-20240319144440-ffa91c765143 // indirect
-	open-cluster-management.io/api v1.3.0 // indirect
 	sigs.k8s.io/cluster-api v1.11.8 // indirect
 	sigs.k8s.io/cluster-api-provider-azure v1.21.1-0.20250929163617-2c4eaa611a39 // indirect
 	sigs.k8s.io/container-object-storage-interface-api v0.1.0 // indirect

--- a/tests/cnf/ran/talm/internal/helper/cgu.go
+++ b/tests/cnf/ran/talm/internal/helper/cgu.go
@@ -148,6 +148,11 @@ func waitForPolicyComponentsExist(client *clients.Settings, suffix string) error
 				return false, nil
 			}
 
+			mcsb := ocm.NewMCSBBuilder(client, tsparams.ManagedClusterSetName, tsparams.TestNamespace)
+			if !mcsb.Exists() {
+				return false, nil
+			}
+
 			return true, nil
 		})
 }

--- a/tests/cnf/ran/talm/internal/helper/policy.go
+++ b/tests/cnf/ran/talm/internal/helper/policy.go
@@ -74,8 +74,18 @@ func CreatePolicyComponents(
 		})
 
 	_, err = placementBinding.Create()
+	if err != nil {
+		return err
+	}
 
-	return err
+	// MCSB is namespace-scoped and shared across tests in talm-test, so there is no harm in keeping it around. We
+	// just use Create to create if it does not exist (since the method is idempotent).
+	_, err = ocm.NewMCSBBuilder(client, tsparams.ManagedClusterSetName, tsparams.TestNamespace).Create()
+	if err != nil {
+		return fmt.Errorf("failed to create ManagedClusterSetBinding: %w", err)
+	}
+
+	return nil
 }
 
 // GetPolicyNameWithPrefix returns the name of the first policy to start with prefix in the provided namespace, or an

--- a/tests/cnf/ran/talm/internal/tsparams/consts.go
+++ b/tests/cnf/ran/talm/internal/tsparams/consts.go
@@ -42,6 +42,11 @@ const (
 	PlacementRuleName = "talm-placementrule"
 	// PlacementBindingName is the name for the test talm placement binding.
 	PlacementBindingName = "talm-placementbinding"
+	// ManagedClusterSetName is the ManagedClusterSet bound into the policy namespace on TALM 5.0+. TALM 5.0+
+	// requires a ManagedClusterSetBinding in the policy namespace for Placement API discovery. We use "global"
+	// rather than the operator's "default" because the Telco RAN RDS binds the global ManagedClusterSet, which
+	// includes all managed clusters in our test hub configuration.
+	ManagedClusterSetName = "global"
 	// CatalogSourceName is the name for the test talm catalog source.
 	CatalogSourceName = "talm-catsrc"
 	// PreCachingConfigName is the name for the test talm pre caching config.

--- a/tests/cnf/ran/talm/internal/tsparams/talmvars.go
+++ b/tests/cnf/ran/talm/internal/tsparams/talmvars.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	policiesv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
 	placementrulev1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
@@ -44,6 +45,7 @@ var (
 		{Cr: &policiesv1.PlacementBindingList{}, Namespace: ptr.To(TestNamespace)},
 		{Cr: &placementrulev1.PlacementRuleList{}, Namespace: ptr.To(TestNamespace)},
 		{Cr: &policiesv1beta1.PolicySetList{}, Namespace: ptr.To(TestNamespace)},
+		{Cr: &clusterv1beta2.ManagedClusterSetBindingList{}, Namespace: ptr.To(TestNamespace)},
 	}
 
 	// ReporterSpokeCRsToDump is the CRs the reporter should dump on the spokes.


### PR DESCRIPTION
This commit fixes the many failures when running the TALM suite with TALM 5.0. These failures are due to the switch to use the Placement API instead of PlacementRules. With the Placement API, a ManagedClusterSetBinding must be present in the policy namespace for TALM to function properly.

This commit does not switch the suite to use the Placement API directly, however.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated TALM test setup to create and verify the required ManagedClusterSetBinding before policy components are considered ready.
  * Improved failure diagnostics by including ManagedClusterSetBinding resources in collected test reports.
* **Tests**
  * Added support for the global ManagedClusterSetBinding used by current TALM and Placement API discovery requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->