### PR TITLE
cnf network: fix networkpolicy-flake

### DIFF
--- a/tests/cnf/core/network/policy/tests/multinetpolicysriov.go
+++ b/tests/cnf/core/network/policy/tests/multinetpolicysriov.go
@@ -312,6 +312,10 @@ var _ = Describe("SRIOV", Ordered, Label("multinetworkpolicy"), ContinueOnFailur
 
 		// 55990
 		It("Disable multi-network policy", reportxml.ID("55990"), func() {
+			DeferCleanup(func() {
+				enableMultiNetworkPolicy(true)
+			})
+
 			By("Apply MultiNetworkPolicy with ingress rule deny all")
 
 			_, err := networkpolicy.NewMultiNetworkPolicyBuilder(
@@ -350,13 +354,13 @@ var _ = Describe("SRIOV", Ordered, Label("multinetworkpolicy"), ContinueOnFailur
 			// All traffic is accepted and there is no any policy because feature is off
 			Eventually(func() error {
 				return runTraffic(firstClientPod, ipaddr.RemovePrefix(serverPodIP), tcpProtocol, port5001)
-			}, tsparams.WaitTrafficTimeout, tsparams.RetryTrafficInterval).ShouldNot(HaveOccurred(),
+			}, tsparams.WaitTimeout, tsparams.RetryTrafficInterval).ShouldNot(HaveOccurred(),
 				fmt.Sprintf("pod %s can NOT reach %s with port %d",
 					firstClientPod.Definition.Name, serverPod.Definition.Name, port5001))
 
 			Eventually(func() error {
 				return runTraffic(secondClientPod, ipaddr.RemovePrefix(serverPodIP), tcpProtocol, port5003)
-			}, tsparams.WaitTrafficTimeout, tsparams.RetryTrafficInterval).ShouldNot(HaveOccurred(),
+			}, tsparams.WaitTimeout, tsparams.RetryTrafficInterval).ShouldNot(HaveOccurred(),
 				fmt.Sprintf("pod %s can NOT reach %s with port %d",
 					secondClientPod.Definition.Name, serverPod.Definition.Name, port5003))
 


### PR DESCRIPTION
DeferCleanup(enableMultiNetworkPolicy(true)) at the start of 55990 so the feature is turned back on even if the spec fails, before the next specs run. The explicit re-enable at the end of the spec is unchanged.

Longer post-disable TCP waits: after disable, the two “traffic should work again” Eventually checks use tsparams.WaitTimeout (3m) instead of WaitTrafficTimeout (1m). Deny-all checks before disable still use 1m.