### PR TITLE
deploymenttypes: skip preinstall-test Go templates in YAML scan

### DIFF
--- a/tests/cnf/ran-deployment/deploymenttypes/tests/deployment-types.go
+++ b/tests/cnf/ran-deployment/deploymenttypes/tests/deployment-types.go
@@ -40,12 +40,13 @@ const (
 
 var (
 	reHubSideTemplate           = regexp.MustCompile(`\{\{\s*hub[^\r\n]+hub\s*\}\}`)
-	ignorePaths       [5]string = [5]string{
+	ignorePaths       [6]string = [6]string{
 		"source-crs/",
 		"custom-crs/",
 		"extra-manifest/",
 		"extra-manifests/",
 		"ztp-test/",
+		"preinstall-test/",
 	}
 )
 


### PR DESCRIPTION
IBI preinstall configs under preinstall-test/ are text/template files, not static Kubernetes manifests, so deployment-types must ignore them like ztp-test/ and extra-manifest/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated deployment type test filtering to exclude files under `preinstall-test/`, alongside the existing ignored paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->