### PR TITLE
global: switch to go 1.27

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.26"
+  go: "1.27"
 output:
   formats:
     text:
@@ -276,13 +276,13 @@ linters:
 
       # Let the team control how to handle these deprecated fields.
       - path: tests/cnf/core/network
-        text: "SA1019: corev1.ServiceExternalTrafficPolicyType is deprecated"
+        text: "SA1019: k8s.io/api/core/v1.ServiceExternalTrafficPolicyType is deprecated"
       - path: tests/cnf/core/network
-        text: "SA1019: corev1.IPFamilyPolicyType is deprecated"
+        text: "SA1019: k8s.io/api/core/v1.IPFamilyPolicyType is deprecated"
 
       # These tests only run in versions where the field is not deprecated.
       - path: tests/cnf/ran/talm/tests/talm-backup.go
-        text: "SA1019: cguBuilder.Definition.Spec.Backup is deprecated"
+        text: "SA1019: .*ClusterGroupUpgradeSpec\\)\\.Backup is deprecated"
     paths:
       - third_party$
       - builtin$

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/ubi:latest AS fetcher
 
-ARG GO_VER=go1.26.4
+ARG GO_VER=go1.27.1
 RUN dnf install -y tar
 
 ARG TARGETARCH
@@ -14,7 +14,7 @@ FROM registry.access.redhat.com/ubi9/ubi:latest
 # architecture.
 COPY --from=fetcher /usr/local/go /usr/local/go
 
-ARG GO_VER=go1.26.4
+ARG GO_VER=go1.27.1
 ARG GINKGO_VER=ginkgo@v2.32.0
 ARG CONTAINERUSER=testuser
 

--- a/go.mod
+++ b/go.mod
@@ -1,79 +1,8 @@
 module github.com/rh-ecosystem-edge/eco-gotests
 
-go 1.26.3
+go 1.27.0
 
-toolchain go1.26.4
-
-require (
-	github.com/BurntSushi/toml v1.6.0
-	github.com/Juniper/go-netconf v0.3.1
-	github.com/Masterminds/semver/v3 v3.5.0
-	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/NVIDIA/gpu-operator v1.11.1
-	github.com/cavaliergopher/cpio v1.0.1
-	github.com/cavaliergopher/grab/v3 v3.0.1
-	github.com/containers/image/v5 v5.36.2
-	github.com/coreos/ignition/v2 v2.26.0
-	github.com/go-git/go-git/v5 v5.19.1
-	github.com/go-logr/logr v1.4.3
-	github.com/go-openapi/runtime v0.32.4
-	github.com/go-openapi/strfmt v0.26.4
-	github.com/google/uuid v1.6.0
-	github.com/grafana/loki/operator/apis/loki v0.0.0-20241021105923-5e970e50b166
-	github.com/hashicorp/go-version v1.9.0
-	github.com/k8snetworkplumbingwg/multi-networkpolicy v1.0.1
-	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7
-	github.com/k8snetworkplumbingwg/sriov-network-operator v1.6.0
-	github.com/kedacore/keda-olm-operator v0.0.0-20260618141108-6814218d455e // aligned with k8s v0.35
-	github.com/kedacore/keda/v2 v2.19.0 // aligned with k8s v0.35
-	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/klauspost/compress v1.19.0
-	github.com/metal3-io/baremetal-operator/apis v0.13.1
-	github.com/nmstate/kubernetes-nmstate/api v0.0.0-20260707144101-8853341855d6
-	github.com/onsi/ginkgo/v2 v2.32.0
-	github.com/onsi/gomega v1.42.1
-	github.com/openshift-kni/cluster-group-upgrades-operator v0.0.0-20260707161822-9b9043d4494b // release-4.22
-	github.com/openshift-kni/k8sreporter v1.0.7
-	github.com/openshift-kni/lifecycle-agent v0.0.0-20260707161814-ec769a366476 // release-4.22
-	github.com/openshift-kni/numaresources-operator v0.4.18-0.2024100201.0.20260707092512-254b162fcd0f // release-4.22
-	github.com/openshift-kni/oran-o2ims v0.0.0-20260707122918-22ed0a55833b // release-4.22
-	github.com/openshift/api v0.0.0-20260521125114-09730f85d883 // release-4.22
-	github.com/openshift/client-go v0.0.0-20260330134249-7e1499aaacd7 // release-4.22
-	github.com/openshift/cluster-nfd-operator v0.0.0-20260629131115-e53505ffcb61 // release-4.22
-	github.com/openshift/cluster-node-tuning-operator v0.0.0-20260209053755-f5fe4460e852 // release-4.22, prior to controller-runtime v0.23
-	github.com/openshift/installer v0.0.0-00010101000000-000000000000
-	github.com/openshift/local-storage-operator v0.0.0-20260630133617-4d174e9c9eff // release-4.22
-	github.com/operator-framework/api v0.43.1-0.20260609071724-52c4c326869d // aligned with k8s v0.35
-	github.com/povsister/scp v0.0.0-20250701154629-777cf82de5df
-	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.91.0 // aligned with k8s v0.35
-	github.com/prometheus/alertmanager v0.33.1
-	github.com/prometheus/client_golang v1.23.2
-	github.com/prometheus/common v1.20.99
-	github.com/redhat-cne/sdk-go v1.23.6
-	github.com/stmcginnis/gofish v0.20.0 // v0.21.0 contains many breaking changes. Should be upgraded separately.
-	github.com/stretchr/testify v1.11.1
-	github.com/vmware-tanzu/velero v1.18.0
-	github.com/walle/targz v0.0.0-20140417120357-57fe4206da5a
-	github.com/wk8/go-ordered-map/v2 v2.1.8
-	golang.org/x/crypto v0.53.0
-	golang.org/x/exp v0.0.0-20260611194520-c48552f49976
-	golang.org/x/oauth2 v0.36.0
-	gopkg.in/k8snetworkplumbingwg/multus-cni.v4 v4.3.0
-	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.1
-	k8s.io/api v0.35.6
-	k8s.io/apiextensions-apiserver v0.35.6
-	k8s.io/apimachinery v0.35.6
-	k8s.io/client-go v12.0.0+incompatible
-	k8s.io/klog/v2 v2.140.0
-	k8s.io/kubelet v0.35.6
-	k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3
-	open-cluster-management.io/api v1.3.0
-	open-cluster-management.io/config-policy-controller v0.19.0
-	open-cluster-management.io/governance-policy-propagator v0.18.1-0.20260302212915-815d063a291a // prior to controller-runtime v0.23
-	open-cluster-management.io/multicloud-operators-subscription v0.16.0
-	sigs.k8s.io/controller-runtime v0.23.3
-)
+toolchain go1.27.1
 
 require (
 	dario.cat/mergo v1.0.2 // indirect
@@ -278,7 +207,77 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-require github.com/rh-ecosystem-edge/eco-goinfra v0.0.0-20260904180917-8da9cd3edff2
+require (
+	github.com/BurntSushi/toml v1.6.0
+	github.com/Juniper/go-netconf v0.3.1
+	github.com/Masterminds/semver/v3 v3.5.0
+	github.com/Masterminds/sprig/v3 v3.3.0
+	github.com/NVIDIA/gpu-operator v1.11.1
+	github.com/cavaliergopher/cpio v1.0.1
+	github.com/cavaliergopher/grab/v3 v3.0.1
+	github.com/containers/image/v5 v5.36.2
+	github.com/coreos/ignition/v2 v2.26.0
+	github.com/go-git/go-git/v5 v5.19.1
+	github.com/go-logr/logr v1.4.3
+	github.com/go-openapi/runtime v0.32.4
+	github.com/go-openapi/strfmt v0.26.4
+	github.com/google/uuid v1.6.0
+	github.com/grafana/loki/operator/apis/loki v0.0.0-20241021105923-5e970e50b166
+	github.com/hashicorp/go-version v1.9.0
+	github.com/k8snetworkplumbingwg/multi-networkpolicy v1.0.1
+	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7
+	github.com/k8snetworkplumbingwg/sriov-network-operator v1.6.0
+	github.com/kedacore/keda-olm-operator v0.0.0-20260618141108-6814218d455e // aligned with k8s v0.35
+	github.com/kedacore/keda/v2 v2.19.0 // aligned with k8s v0.35
+	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/klauspost/compress v1.19.0
+	github.com/metal3-io/baremetal-operator/apis v0.13.1
+	github.com/nmstate/kubernetes-nmstate/api v0.0.0-20260707144101-8853341855d6
+	github.com/onsi/ginkgo/v2 v2.32.0
+	github.com/onsi/gomega v1.42.1
+	github.com/openshift-kni/cluster-group-upgrades-operator v0.0.0-20260707161822-9b9043d4494b // release-4.22
+	github.com/openshift-kni/k8sreporter v1.0.7
+	github.com/openshift-kni/lifecycle-agent v0.0.0-20260707161814-ec769a366476 // release-4.22
+	github.com/openshift-kni/numaresources-operator v0.4.18-0.2024100201.0.20260707092512-254b162fcd0f // release-4.22
+	github.com/openshift-kni/oran-o2ims v0.0.0-20260707122918-22ed0a55833b // release-4.22
+	github.com/openshift/api v0.0.0-20260521125114-09730f85d883 // release-4.22
+	github.com/openshift/client-go v0.0.0-20260330134249-7e1499aaacd7 // release-4.22
+	github.com/openshift/cluster-nfd-operator v0.0.0-20260629131115-e53505ffcb61 // release-4.22
+	github.com/openshift/cluster-node-tuning-operator v0.0.0-20260209053755-f5fe4460e852 // release-4.22, prior to controller-runtime v0.23
+	github.com/openshift/installer v0.0.0-00010101000000-000000000000
+	github.com/openshift/local-storage-operator v0.0.0-20260630133617-4d174e9c9eff // release-4.22
+	github.com/operator-framework/api v0.43.1-0.20260609071724-52c4c326869d // aligned with k8s v0.35
+	github.com/povsister/scp v0.0.0-20250701154629-777cf82de5df
+	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.91.0 // aligned with k8s v0.35
+	github.com/prometheus/alertmanager v0.33.1
+	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/common v1.20.99
+	github.com/redhat-cne/sdk-go v1.23.6
+	github.com/rh-ecosystem-edge/eco-goinfra v0.0.0-20260904180917-8da9cd3edff2
+	github.com/stmcginnis/gofish v0.20.0 // v0.21.0 contains many breaking changes. Should be upgraded separately.
+	github.com/stretchr/testify v1.11.1
+	github.com/vmware-tanzu/velero v1.18.0
+	github.com/walle/targz v0.0.0-20140417120357-57fe4206da5a
+	github.com/wk8/go-ordered-map/v2 v2.1.8
+	golang.org/x/crypto v0.53.0
+	golang.org/x/exp v0.0.0-20260611194520-c48552f49976
+	golang.org/x/oauth2 v0.36.0
+	gopkg.in/k8snetworkplumbingwg/multus-cni.v4 v4.3.0
+	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/api v0.35.6
+	k8s.io/apiextensions-apiserver v0.35.6
+	k8s.io/apimachinery v0.35.6
+	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/klog/v2 v2.140.0
+	k8s.io/kubelet v0.35.6
+	k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3
+	open-cluster-management.io/api v1.3.0
+	open-cluster-management.io/config-policy-controller v0.19.0
+	open-cluster-management.io/governance-policy-propagator v0.18.1-0.20260302212915-815d063a291a // prior to controller-runtime v0.23
+	open-cluster-management.io/multicloud-operators-subscription v0.16.0
+	sigs.k8s.io/controller-runtime v0.23.3
+)
 
 replace (
 	github.com/imdario/mergo => github.com/imdario/mergo v0.3.16

--- a/scripts/golangci-lint.sh
+++ b/scripts/golangci-lint.sh
@@ -4,7 +4,7 @@ set -e
 
 . "$(dirname "$0")"/common.sh
 
-GOLANGCI_LINT_VERSION="2.12.2"
+GOLANGCI_LINT_VERSION="2.13.2"
 
 # IsGoLangCiLintInstalled is used to check whether golangci-lint executable is on the $PATH.
 function IsGolangCiLintInstalled() {

--- a/tests/cnf/ran/talm/tests/talm-backup.go
+++ b/tests/cnf/ran/talm/tests/talm-backup.go
@@ -183,6 +183,7 @@ var _ = Describe("TALM backup tests", Label(tsparams.LabelBackupTestCases), func
 				WithCluster(RANConfig.Spoke1Name).
 				WithCluster(RANConfig.Spoke2Name).
 				WithManagedPolicy(tsparams.PolicyName)
+
 			cguBuilder.Definition.Spec.Backup = true
 
 			_, err = helper.SetupCguWithNamespace(cguBuilder, "")

--- a/tests/hw-accel/amdgpu/internal/amdgpuhelpers/wait.go
+++ b/tests/hw-accel/amdgpu/internal/amdgpuhelpers/wait.go
@@ -164,10 +164,10 @@ func waitForNodesReadiness(ctx context.Context, wg *sync.WaitGroup, apiClients *
 	_, err := watchtools.UntilWithSync(ctx,
 
 		&cache.ListWatch{
-			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
 				return apiClients.CoreV1Interface.Nodes().List(ctx, options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				return apiClients.CoreV1Interface.Nodes().Watch(ctx, options)
 			},
 		},
@@ -216,10 +216,10 @@ func waitForClientConfig(ctx context.Context, wg *sync.WaitGroup, apiClients *cl
 
 	_, err = watchtools.UntilWithSync(ctx,
 		&cache.ListWatch{
-			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
 				return configClient.ConfigV1().ClusterOperators().List(ctx, options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				return configClient.ConfigV1().ClusterOperators().Watch(ctx, options)
 			},
 		},

--- a/tests/system-tests/ran-du/CLAUDE.md
+++ b/tests/system-tests/ran-du/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 RAN DU system tests for OpenShift — Ginkgo v2 tests that validate workload lifecycle, node reboots, kernel crash recovery, PTP synchronization, ZTP policy compliance, cert-manager certificate management, and long-running stability on a live OCP cluster with RAN DU profile.
 
-Part of the [eco-gotests](../../../CLAUDE.local.md) framework. Go 1.26, Ginkgo v2.
+Part of the [eco-gotests](../../../CLAUDE.local.md) framework. Go 1.27, Ginkgo v2.
 
 ## Build and Lint
 


### PR DESCRIPTION
This commit updates to go 1.27. All references are updated, including in the golangci-lint config, CLAUDE.md, and the Dockerfile. The version of golangci-lint has also been updated to one which supports go 1.27. This new golangci-lint version update required making a few changes due to deprecation warnings which were not previously captured.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance**
  - Updated the project and test environments to Go 1.27.
  - Updated the linting tool to version 2.13.2.

- **Bug Fixes**
  - Improved context handling when monitoring node readiness and client configuration changes.

- **Tests**
  - Adjusted backup-related test checks for compatibility with supported TALM versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->