### PR TITLE
cnf-network: require one worker for accelerator tests

### DIFF
--- a/tests/cnf/core/network/accelerator/accelerator_suite_test.go
+++ b/tests/cnf/core/network/accelerator/accelerator_suite_test.go
@@ -43,7 +43,7 @@ var _ = BeforeSuite(func() {
 
 	By("Verifying if accelerator tests can be executed on given cluster")
 
-	err = netenv.DoesClusterHasEnoughNodes(APIClient, NetConfig, 1, 2)
+	err = netenv.DoesClusterHasEnoughNodes(APIClient, NetConfig, 1, 1)
 	if err != nil {
 		Skip(fmt.Sprintf("Skipping test - cluster doesn't have enough nodes: %v", err))
 	}


### PR DESCRIPTION
The ACC100 specs pin work to a single FEC node, so requiring two workers skipped valid single-worker clusters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reduced the minimum worker-node requirement for the accelerator test suite from two nodes to one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->