### PR TITLE
ptp: node reboot recovery scoped to the ptp, monitoring, ingress & API

### DIFF
--- a/tests/cnf/ran/internal/ranparam/const.go
+++ b/tests/cnf/ran/internal/ranparam/const.go
@@ -11,6 +11,11 @@ import (
 const UnreachableIPv4Address = "192.0.2.1"
 
 const (
+	// OpenshiftAPINamespace is the namespace where OCP API is.
+	OpenshiftAPINamespace = "openshift-apiserver"
+)
+
+const (
 	// Label represents the label for the ran test cases.
 	Label = "ran"
 	// LabelNoContainer is the label for RAN test cases that should not be executed in a container.

--- a/tests/cnf/ran/ptp/tests/ptp-node-reboot.go
+++ b/tests/cnf/ran/ptp/tests/ptp-node-reboot.go
@@ -27,6 +27,13 @@ import (
 // This test must be ordered so that we only need to reboot the node once. It may continue on failure since the test
 // cases are not necessarily dependent on each other.
 var _ = Describe("PTP Node Reboot", Ordered, ContinueOnFailure, Label(tsparams.LabelNodeReboot), func() {
+	var testCriticalNs = []string{
+		ranparam.OpenshiftAPINamespace,
+		ranparam.OpenshiftIngressNamespace,
+		ranparam.PtpOperatorNamespace,
+		ranparam.OpenshiftMonitoringNamespace,
+	}
+
 	var (
 		nodeName   string
 		rebootTime time.Time
@@ -39,7 +46,7 @@ var _ = Describe("PTP Node Reboot", Ordered, ContinueOnFailure, Label(tsparams.L
 		Expect(err).ToNot(HaveOccurred(), "Failed to check if the cluster is SNO")
 
 		By("selecting a node to reboot")
-		// list all the ptp daemon set pods, select the first, then use spec.nodeName to get the node name
+
 		ptpDaemonPods, err := pod.List(RANConfig.Spoke1APIClient, ranparam.PtpOperatorNamespace, metav1.ListOptions{
 			LabelSelector: ranparam.PtpDaemonsetLabelSelector,
 		})
@@ -59,9 +66,14 @@ var _ = Describe("PTP Node Reboot", Ordered, ContinueOnFailure, Label(tsparams.L
 		Expect(err).ToNot(HaveOccurred(), "Failed to soft reboot the node")
 
 		if isSNO {
+			By("Wait for SNO cluster to be unreachable")
+
+			err = cluster.WaitForUnreachable(RANConfig.Spoke1APIClient, 30*time.Second)
+			Expect(err).ToNot(HaveOccurred(), "Failed to wait for kubeapi becoming unreachable")
+
 			By("waiting for the SNO node to recover")
 
-			err = cluster.WaitForRecover(RANConfig.Spoke1APIClient, []string{}, 45*time.Minute)
+			err = cluster.WaitForRecover(RANConfig.Spoke1APIClient, testCriticalNs, 45*time.Minute)
 			Expect(err).ToNot(HaveOccurred(), "Failed to wait for the node to recover")
 		} else {
 			By("waiting for the node to recover")
@@ -78,9 +90,10 @@ var _ = Describe("PTP Node Reboot", Ordered, ContinueOnFailure, Label(tsparams.L
 
 			By("waiting for all pods on rebooted node to be healthy")
 
-			err = pod.WaitForPodsInNamespacesHealthy(RANConfig.Spoke1APIClient, nil, 10*time.Minute, metav1.ListOptions{
-				FieldSelector: fields.OneTermEqualSelector("spec.nodeName", nodeName).String(),
-			})
+			err = pod.WaitForPodsInNamespacesHealthy(
+				RANConfig.Spoke1APIClient, testCriticalNs, 10*time.Minute, metav1.ListOptions{
+					FieldSelector: fields.OneTermEqualSelector("spec.nodeName", nodeName).String(),
+				})
 			Expect(err).ToNot(HaveOccurred(), "Failed to wait for all pods on rebooted node to be healthy")
 		}
 	})
@@ -88,6 +101,10 @@ var _ = Describe("PTP Node Reboot", Ordered, ContinueOnFailure, Label(tsparams.L
 	// 59858 - verify the system returns to stability after reboot node
 	It("should return to same stable status after ptp node soft reboot", reportxml.ID("59858"), func() {
 		By("waiting for all clocks to be locked")
+
+		err := cluster.WaitForRouteAPIAvailable(
+			RANConfig.Spoke1APIClient, ranparam.ThanosQuerierRouteName, ranparam.OpenshiftMonitoringNamespace, 3*time.Minute)
+		Expect(err).ToNot(HaveOccurred(), "Failed to wait for monitoring Route API availability")
 
 		prometheusAPI, err := querier.CreatePrometheusAPIForCluster(RANConfig.Spoke1APIClient)
 		Expect(err).ToNot(HaveOccurred(), "Failed to create Prometheus API client")

--- a/tests/internal/cluster/cluster.go
+++ b/tests/internal/cluster/cluster.go
@@ -6,6 +6,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/infrastructure"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/mco"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/route"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
@@ -296,6 +297,22 @@ func WaitForRecover(client *clients.Settings, namespaces []string, timeout time.
 	}
 
 	return nil
+}
+
+// WaitForRouteAPIAvailable waits up to timeout for the given Route to be readable.
+func WaitForRouteAPIAvailable(
+	client *clients.Settings, routeName, routeNamespace string, timeout time.Duration) error {
+	klog.V(90).Infof("Wait for route.openshift.io API available with timeout: %v", timeout)
+
+	return wait.PollUntilContextTimeout(
+		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+			_, err := route.Pull(client, routeName, routeNamespace)
+			if err != nil {
+				return true, nil
+			}
+
+			return false, nil
+		})
 }
 
 // SoftRebootSNO executes systemctl reboot on a node.


### PR DESCRIPTION
Resolves ticket: https://redhat.atlassian.net/browse/CNF-26169

- cluster.WaitForRouteAPIAvailable(): Serves as a readiness guard for other calls to the 'Route' API.
- cluster.WaitForUnreachable(): Serves as a post-shutdown guard; stops a race in which the API is succcesfully probed right after shutdown.
- cosnt.OpenshiftAPINamespace: The OC API Namespace holds the API for 'Route' resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved PTP node reboot test coverage by validating cluster reachability and recovery after reboot.
  - Added checks that critical namespaces and pods return to a healthy state across supported cluster configurations.
  - Added route availability validation before stability tests interact with the Prometheus API.
  - Added validation for detecting temporarily unavailable clusters and confirming API route readiness.
  - Improved reliability of recovery checks following node disruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->