### PR TITLE
lca: redesign CNF TALM IBU suite around spoke health and fail-fast waits

### DIFF
--- a/tests/internal/reporter/schemes.go
+++ b/tests/internal/reporter/schemes.go
@@ -31,8 +31,10 @@ import (
 	ibiv1alpha1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/imagebasedinstall/api/hiveextensions/v1alpha1"
 	mcmv1beta1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/kmm-hub/v1beta1"
 	modulev1beta1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/kmm/v1beta1"
+	oadpv1alpha1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/oadp/api/v1alpha1"
 	olmv1alpha1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/olm/operators/v1alpha1"
 	ptpv1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/ptp/v1"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
@@ -76,8 +78,13 @@ var reporterSchemes = []clients.SchemeAttacher{
 	inventoryv1alpha1.AddToScheme,
 	ptpv1.AddToScheme,
 	lcasgv1.AddToScheme,
+	// Velero and OADP are required to dump BSL/Backup/Restore/DPA on TALM IBU
+	// spoke failures. Extra attachers are unused by other suites.
+	velerov1.AddToScheme,
+	oadpv1alpha1.AddToScheme,
 }
 
+// setReporterSchemes registers every CRD scheme the failure reporter needs to dump.
 func setReporterSchemes(scheme *runtime.Scheme) error {
 	for _, schemeAttacher := range reporterSchemes {
 		if err := schemeAttacher(scheme); err != nil {

--- a/tests/lca/imagebasedupgrade/cnf/internal/cnfhelper/health.go
+++ b/tests/lca/imagebasedupgrade/cnf/internal/cnfhelper/health.go
@@ -1,0 +1,533 @@
+package cnfhelper
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/certificate"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clusteroperator"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/infrastructure"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/mco"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/oadp"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/olm"
+	oadpv1alpha1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/oadp/api/v1alpha1"
+	olmv1alpha1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/olm/operators/v1alpha1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/sriov"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/velero"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfparams"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// DefaultHealthTimeout is the overall timeout used by tests when claiming
+	// the spoke is healthy, including DefaultHealthStablePeriod.
+	DefaultHealthTimeout = 15 * time.Minute
+	// DefaultHealthStablePeriod is how long Check must stay healthy before
+	// WaitUntilHealthy succeeds. An unhealthy snapshot restarts this window.
+	DefaultHealthStablePeriod = 3 * time.Minute
+	// RecoverHealthTimeout is the overall timeout Recover uses after abort,
+	// reboot, or cleanup, including DefaultHealthStablePeriod.
+	RecoverHealthTimeout = 45 * time.Minute
+
+	healthPollInterval     = 15 * time.Second
+	sriovSyncSucceeded     = "Succeeded"
+	oadpNamespace          = "openshift-adp"
+	nodeRoleControlPlane   = "node-role.kubernetes.io/control-plane"
+	nodeRoleMaster         = "node-role.kubernetes.io/master"
+	nodeRoleWorker         = "node-role.kubernetes.io/worker"
+	lifecycleAgentCSVToken = "lifecycle-agent"
+)
+
+// CheckName identifies a single spoke health check.
+type CheckName string
+
+const (
+	checkClusterOperators CheckName = "clusterOperators"
+	checkMachineConfig    CheckName = "machineConfigPools"
+	checkSriov            CheckName = "sriovNetworkNodeState"
+	checkDPA              CheckName = "dataProtectionApplication"
+	checkBackupStorage    CheckName = "backupStorageLocation"
+	checkNode             CheckName = "node"
+	checkCSV              CheckName = "clusterServiceVersion"
+	checkCSR              CheckName = "certificateSigningRequest"
+)
+
+// CheckResult is the outcome of one health check.
+type CheckResult struct {
+	Name    CheckName
+	Healthy bool
+	Skipped bool
+	Message string
+}
+
+// Report is a point-in-time snapshot of spoke health.
+type Report struct {
+	Results []CheckResult
+}
+
+// Healthy reports whether every check passed or was skipped.
+func (report Report) Healthy() bool {
+	for _, result := range report.Results {
+		if !result.Healthy {
+			return false
+		}
+	}
+
+	return true
+}
+
+// FailureSummary returns a joined description of failed checks.
+func (report Report) FailureSummary() string {
+	var failures []string
+
+	for _, result := range report.Results {
+		if result.Healthy {
+			continue
+		}
+
+		failures = append(failures, fmt.Sprintf("%s: %s", result.Name, result.Message))
+	}
+
+	return strings.Join(failures, "; ")
+}
+
+// result returns the named check from the report, if present.
+func (report Report) result(name CheckName) (CheckResult, bool) {
+	for _, result := range report.Results {
+		if result.Name == name {
+			return result, true
+		}
+	}
+
+	return CheckResult{}, false
+}
+
+// unhealthy reports whether the named check ran and failed.
+func (report Report) unhealthy(name CheckName) bool {
+	result, found := report.result(name)
+
+	return found && !result.Healthy
+}
+
+// skippedResult is a passing check that was not applicable on this spoke.
+func skippedResult(name CheckName, message string) CheckResult {
+	return CheckResult{Name: name, Healthy: true, Skipped: true, Message: message}
+}
+
+// failedResult is a failing check with the given message.
+func failedResult(name CheckName, message string) CheckResult {
+	return CheckResult{Name: name, Message: message}
+}
+
+// passedResult is a successful check with the given message.
+func passedResult(name CheckName, message string) CheckResult {
+	return CheckResult{Name: name, Healthy: true, Message: message}
+}
+
+// Check snapshots spoke health without waiting. API errors are recorded as failed
+// checks so WaitUntilHealthy can retry while the spoke API is unreachable.
+func Check() Report {
+	apiClient := cnfinittools.TargetSNOAPIClient
+	if apiClient == nil {
+		return Report{Results: []CheckResult{
+			failedResult(checkClusterOperators, "target SNO API client is nil"),
+		}}
+	}
+
+	dpaResult := checkDPAReconciled(apiClient)
+	backupResult := skippedResult(checkBackupStorage, "skipped: no reconciled DataProtectionApplication")
+
+	if dpaResult.Healthy && !dpaResult.Skipped {
+		backupResult = checkBackupStorageAvailable(apiClient)
+	}
+
+	return Report{Results: []CheckResult{
+		checkClusterOperatorsReady(apiClient),
+		checkMachineConfigPoolsReady(apiClient),
+		checkSriovReady(apiClient),
+		dpaResult,
+		backupResult,
+		checkNodeReady(apiClient),
+		checkCSVsReady(apiClient),
+		checkCSRsApproved(apiClient),
+	}}
+}
+
+// WaitUntilHealthy polls Check until every check has stayed passing for
+// DefaultHealthStablePeriod, or timeout is reached. An unhealthy snapshot
+// restarts the stability window.
+func WaitUntilHealthy(timeout time.Duration) error {
+	var last Report
+
+	var healthySince time.Time
+
+	pollErr := wait.PollUntilContextTimeout(
+		context.TODO(), healthPollInterval, timeout, true,
+		func(_ context.Context) (bool, error) {
+			last = Check()
+
+			return healthStayedStable(last, &healthySince, time.Now()), nil
+		})
+	if pollErr != nil {
+		return waitUntilHealthyTimeoutError(timeout, last, healthySince)
+	}
+
+	return nil
+}
+
+// healthStayedStable updates healthySince from report at now. It returns true
+// when report has been healthy for DefaultHealthStablePeriod. An unhealthy
+// snapshot restarts the window.
+func healthStayedStable(report Report, healthySince *time.Time, now time.Time) bool {
+	if !report.Healthy() {
+		if !healthySince.IsZero() {
+			klog.V(cnfparams.CNFLogLevel).Infof(
+				"spoke health flipped after %s, restarting %s stability window: %s",
+				now.Sub(*healthySince).Truncate(time.Second),
+				DefaultHealthStablePeriod, report.FailureSummary())
+		} else {
+			klog.V(cnfparams.CNFLogLevel).Infof("spoke health not ready: %s", report.FailureSummary())
+		}
+
+		*healthySince = time.Time{}
+
+		return false
+	}
+
+	if healthySince.IsZero() {
+		*healthySince = now
+
+		klog.V(cnfparams.CNFLogLevel).Infof(
+			"spoke health is green, waiting %s for stability", DefaultHealthStablePeriod)
+
+		return false
+	}
+
+	return now.Sub(*healthySince) >= DefaultHealthStablePeriod
+}
+
+// waitUntilHealthyTimeoutError describes a WaitUntilHealthy failure after timeout.
+func waitUntilHealthyTimeoutError(timeout time.Duration, last Report, healthySince time.Time) error {
+	if last.Healthy() && !healthySince.IsZero() {
+		return fmt.Errorf("spoke did not stay healthy for %s within %s (last healthy streak: %s)",
+			DefaultHealthStablePeriod, timeout, time.Since(healthySince).Truncate(time.Second))
+	}
+
+	return fmt.Errorf("spoke did not stay healthy for %s within %s: %s",
+		DefaultHealthStablePeriod, timeout, last.FailureSummary())
+}
+
+// checkClusterOperatorsReady reports whether every ClusterOperator is available
+// and neither progressing nor degraded.
+func checkClusterOperatorsReady(apiClient *clients.Settings) CheckResult {
+	operators, err := clusteroperator.List(apiClient)
+	if err != nil {
+		return failedResult(checkClusterOperators, err.Error())
+	}
+
+	var notReady []string
+
+	for _, operator := range operators {
+		if !operator.IsAvailable() || operator.IsProgressing() || operator.IsDegraded() {
+			notReady = append(notReady, operator.Object.Name)
+		}
+	}
+
+	if len(notReady) > 0 {
+		return failedResult(checkClusterOperators,
+			fmt.Sprintf("one or more ClusterOperators not yet ready: %s", strings.Join(notReady, ", ")))
+	}
+
+	return passedResult(checkClusterOperators, "all cluster operators are ready")
+}
+
+// checkMachineConfigPoolsReady reports whether every MachineConfigPool has all
+// machines ready.
+func checkMachineConfigPoolsReady(apiClient *clients.Settings) CheckResult {
+	pools, err := mco.ListMCP(apiClient)
+	if err != nil {
+		return failedResult(checkMachineConfig, err.Error())
+	}
+
+	var notReady []string
+
+	for _, pool := range pools {
+		if pool.Object.Status.MachineCount != pool.Object.Status.ReadyMachineCount {
+			notReady = append(notReady, pool.Object.Name)
+		}
+	}
+
+	if len(notReady) > 0 {
+		return failedResult(checkMachineConfig,
+			fmt.Sprintf("one or more MachineConfigPools not yet ready: %s", strings.Join(notReady, ", ")))
+	}
+
+	return passedResult(checkMachineConfig, "all machine config pools are ready")
+}
+
+// checkSriovReady reports whether every SriovNetworkNodeState has SyncStatus
+// Succeeded. A missing CRD is skipped; an empty list is a failure.
+func checkSriovReady(apiClient *clients.Settings) CheckResult {
+	if cnfinittools.CNFConfig == nil {
+		return failedResult(checkSriov, "CNF config is nil")
+	}
+
+	namespace := cnfinittools.CNFConfig.SriovOperatorNamespace
+
+	nodeStates, err := sriov.ListNetworkNodeState(
+		apiClient, namespace, client.ListOptions{Namespace: namespace})
+	if err != nil {
+		if isMissingCRD(err) {
+			return skippedResult(checkSriov, "skipped: SriovNetworkNodeState CRD is not present")
+		}
+
+		return failedResult(checkSriov, err.Error())
+	}
+
+	if len(nodeStates) == 0 {
+		return failedResult(checkSriov, "no SriovNetworkNodeStates present")
+	}
+
+	var notReady []string
+
+	for _, nodeState := range nodeStates {
+		if nodeState.Objects.Status.SyncStatus != sriovSyncSucceeded {
+			notReady = append(notReady,
+				fmt.Sprintf("%s syncStatus=%s", nodeState.Objects.Name, nodeState.Objects.Status.SyncStatus))
+		}
+	}
+
+	if len(notReady) > 0 {
+		return failedResult(checkSriov,
+			fmt.Sprintf("sriovNetworkNodeState not ready: %s", strings.Join(notReady, ", ")))
+	}
+
+	return passedResult(checkSriov, "all SriovNetworkNodeStates are Succeeded")
+}
+
+// checkDPAReconciled reports whether at least one DataProtectionApplication is
+// reconciled. A missing CRD or empty list is skipped.
+func checkDPAReconciled(apiClient *clients.Settings) CheckResult {
+	dpaList, err := oadp.ListDataProtectionApplication(apiClient, oadpNamespace)
+	if err != nil {
+		if isMissingCRD(err) {
+			return skippedResult(checkDPA, "skipped: DataProtectionApplication CRD is not present")
+		}
+
+		return failedResult(checkDPA, err.Error())
+	}
+
+	if len(dpaList) == 0 {
+		return skippedResult(checkDPA, "skipped: no DataProtectionApplication present")
+	}
+
+	for _, dpaBuilder := range dpaList {
+		if isDPAReconciled(dpaBuilder.Object) {
+			return passedResult(checkDPA,
+				fmt.Sprintf("DataProtectionApplication %s is reconciled", dpaBuilder.Object.Name))
+		}
+	}
+
+	return failedResult(checkDPA, "dataProtectionApplication not reconciled")
+}
+
+// isDPAReconciled reports whether the DPA Reconciled condition is True.
+func isDPAReconciled(dpaObject *oadpv1alpha1.DataProtectionApplication) bool {
+	if dpaObject == nil {
+		return false
+	}
+
+	for _, condition := range dpaObject.Status.Conditions {
+		if condition.Type == oadpv1alpha1.ConditionReconciled && condition.Status == metav1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}
+
+// checkBackupStorageAvailable reports whether every BackupStorageLocation is
+// Available. A missing CRD or empty list is a failure because a reconciled DPA
+// should have created the locations.
+func checkBackupStorageAvailable(apiClient *clients.Settings) CheckResult {
+	locations, err := velero.ListBackupStorageLocationBuilder(apiClient, oadpNamespace)
+	if err != nil {
+		if isMissingCRD(err) {
+			return failedResult(checkBackupStorage, "backupsStorageLocations not yet created")
+		}
+
+		return failedResult(checkBackupStorage, err.Error())
+	}
+
+	if len(locations) == 0 {
+		return failedResult(checkBackupStorage, "backupsStorageLocations not yet created")
+	}
+
+	for _, location := range locations {
+		if location.Object.Status.Phase != velerov1.BackupStorageLocationPhaseAvailable {
+			return failedResult(checkBackupStorage,
+				fmt.Sprintf("backupStorageLocation %s not available", location.Object.Name))
+		}
+	}
+
+	return passedResult(checkBackupStorage, "all BackupStorageLocations are available")
+}
+
+// checkNodeReady reports SNO node Ready, network, and role-label health.
+// Non-SNO topologies are skipped.
+func checkNodeReady(apiClient *clients.Settings) CheckResult {
+	infra, err := infrastructure.Pull(apiClient)
+	if err != nil {
+		return failedResult(checkNode, err.Error())
+	}
+
+	if infra.Object.Status.InfrastructureTopology != configv1.SingleReplicaTopologyMode {
+		return skippedResult(checkNode,
+			fmt.Sprintf("skipped: InfrastructureTopology is %s", infra.Object.Status.InfrastructureTopology))
+	}
+
+	nodeList, err := nodes.List(apiClient)
+	if err != nil {
+		return failedResult(checkNode, err.Error())
+	}
+
+	for _, nodeBuilder := range nodeList {
+		if result := snoNodeCheck(nodeBuilder); !result.Healthy {
+			return result
+		}
+	}
+
+	return passedResult(checkNode, "node is ready")
+}
+
+// snoNodeCheck reports whether one node is Ready, networked, and labeled for
+// control-plane, master, and worker roles.
+func snoNodeCheck(nodeBuilder *nodes.Builder) CheckResult {
+	ready, err := nodeBuilder.IsReady()
+	if err != nil {
+		return failedResult(checkNode, err.Error())
+	}
+
+	if !ready {
+		return failedResult(checkNode, fmt.Sprintf("node is not yet ready: %s", nodeBuilder.Object.Name))
+	}
+
+	if nodeConditionTrue(nodeBuilder.Object.Status.Conditions, corev1.NodeNetworkUnavailable) {
+		return failedResult(checkNode, fmt.Sprintf("node network unavailable: %s", nodeBuilder.Object.Name))
+	}
+
+	labels := nodeBuilder.Object.GetLabels()
+	required := []string{nodeRoleControlPlane, nodeRoleMaster, nodeRoleWorker}
+
+	for _, label := range required {
+		if _, found := labels[label]; !found {
+			return failedResult(checkNode,
+				fmt.Sprintf("node missing %s label: %s", label, nodeBuilder.Object.Name))
+		}
+	}
+
+	return passedResult(checkNode, "node is ready")
+}
+
+// nodeConditionTrue reports whether the named node condition is True.
+func nodeConditionTrue(conditions []corev1.NodeCondition, conditionType corev1.NodeConditionType) bool {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+
+	return false
+}
+
+// checkCSVsReady reports whether every ClusterServiceVersion except
+// lifecycle-agent is Succeeded. LCA is skipped because IBU stages restart it.
+func checkCSVsReady(apiClient *clients.Settings) CheckResult {
+	csvList, err := olm.ListClusterServiceVersionInAllNamespaces(apiClient)
+	if err != nil {
+		return failedResult(checkCSV, err.Error())
+	}
+
+	var notReady []string
+
+	for _, csvBuilder := range csvList {
+		if strings.Contains(csvBuilder.Object.Name, lifecycleAgentCSVToken) {
+			continue
+		}
+
+		if csvBuilder.Object.Status.Phase != olmv1alpha1.CSVPhaseSucceeded {
+			notReady = append(notReady, csvBuilder.Object.Name)
+		}
+	}
+
+	if len(notReady) > 0 {
+		return failedResult(checkCSV,
+			fmt.Sprintf("one or more ClusterServiceVersions not yet ready: %s", strings.Join(notReady, ", ")))
+	}
+
+	return passedResult(checkCSV, "all CSVs are ready")
+}
+
+// checkCSRsApproved reports whether every CertificateSigningRequest is Approved.
+func checkCSRsApproved(apiClient *clients.Settings) CheckResult {
+	csrList, err := certificate.ListSigningRequests(apiClient)
+	if err != nil {
+		return failedResult(checkCSR, err.Error())
+	}
+
+	for _, csrBuilder := range csrList {
+		if csrBuilder.Object == nil || !csrApproved(*csrBuilder.Object) {
+			name := "<nil>"
+			if csrBuilder.Object != nil {
+				name = csrBuilder.Object.Name
+			}
+
+			return failedResult(checkCSR,
+				fmt.Sprintf("certificateSigningRequest (csr) %s not yet approved", name))
+		}
+	}
+
+	return passedResult(checkCSR, "all CSRs are approved")
+}
+
+// csrApproved reports whether the CSR has an Approved=True condition.
+func csrApproved(csrObject certificatesv1.CertificateSigningRequest) bool {
+	for _, condition := range csrObject.Status.Conditions {
+		if condition.Type == certificatesv1.CertificateApproved && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isMissingCRD reports whether err is a missing-kind or unregistered-type API error.
+func isMissingCRD(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if meta.IsNoMatchError(err) || k8sruntime.IsNotRegisteredError(err) {
+		return true
+	}
+
+	message := err.Error()
+
+	return strings.Contains(message, "no matches for kind") ||
+		strings.Contains(message, "no kind is registered") ||
+		strings.Contains(message, "could not find the requested resource")
+}

--- a/tests/lca/imagebasedupgrade/cnf/internal/cnfhelper/ibgu.go
+++ b/tests/lca/imagebasedupgrade/cnf/internal/cnfhelper/ibgu.go
@@ -1,0 +1,361 @@
+package cnfhelper
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/ibgu"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/ocm"
+	ibguv1alpha1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/imagebasedgroupupgrades/v1alpha1"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfparams"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+	goclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// RecoverIbguName is created by Recover and deleted before/after that plan.
+	RecoverIbguName = "recoveribgu"
+	// IbguNamespace is the hub namespace used for TALM IBGUs.
+	IbguNamespace = "default"
+
+	ibguPollInterval   = 10 * time.Second
+	ibguDeleteTimeout  = 1 * time.Minute
+	labelUpdateRetries = 5
+
+	ibguPrepCompletedLabel     = "lcm.openshift.io/ibgu-prep-completed"
+	ibguUpgradeCompletedLabel  = "lcm.openshift.io/ibgu-upgrade-completed"
+	ibguRollbackCompletedLabel = "lcm.openshift.io/ibgu-rollback-completed"
+	localClusterLabel          = "local-cluster"
+	ibguConditionProgressing   = "Progressing"
+)
+
+var (
+	// ClusterLabelSelector is the hub cluster label applied to TALM IBGUs.
+	ClusterLabelSelector = map[string]string{"common": "true"}
+)
+
+// IbguState is an expected terminal hub IBGU state.
+type IbguState string
+
+const (
+	// IbguCompleted is Progressing=False Reason=Completed.
+	IbguCompleted IbguState = "Completed"
+	// IbguFailed is a failed or timed-out IBGU, including cluster failedActions.
+	IbguFailed IbguState = "Failed"
+)
+
+// NewIbgu returns a hub IBGU builder with the CNF seed image, OADP content,
+// and cluster selector. The caller must set the plan and Create it.
+func NewIbgu(name string) *ibgu.IbguBuilder {
+	return ibgu.NewIbguBuilder(cnfinittools.TargetHubAPIClient, name, IbguNamespace).
+		WithClusterLabelSelectors(ClusterLabelSelector).
+		WithSeedImageRef(cnfinittools.CNFConfig.IbguSeedImage, cnfinittools.CNFConfig.IbguSeedImageVersion).
+		WithOadpContent(cnfinittools.CNFConfig.IbguOadpCmName, cnfinittools.CNFConfig.IbguOadpCmNamespace)
+}
+
+// DeleteIbgus deletes the named hub IBGUs if they exist. It does not recover spoke health.
+func DeleteIbgus(names ...string) error {
+	var deleteErrs []string
+
+	for _, name := range names {
+		if err := deleteIbgu(name); err != nil {
+			deleteErrs = append(deleteErrs, fmt.Sprintf("%s: %v", name, err))
+		}
+	}
+
+	if len(deleteErrs) > 0 {
+		return fmt.Errorf("failed to delete leftover IBGUs: %s", strings.Join(deleteErrs, "; "))
+	}
+
+	return nil
+}
+
+// deleteIbgu deletes the named hub IBGU if it exists.
+func deleteIbgu(name string) error {
+	_, err := ibgu.NewIbguBuilder(cnfinittools.TargetHubAPIClient, name, IbguNamespace).
+		DeleteAndWait(ibguDeleteTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to delete IBGU %s: %w", name, err)
+	}
+
+	return nil
+}
+
+// createPlanIbgu creates a hub IBGU named name with the given TALM actions.
+// AutoRollbackOnFailure is copied from the spoke IBU so TALM does not try to
+// clear it; LCA rejects that change while the IBU is in progress.
+func createPlanIbgu(name string, actions []string) (*ibgu.IbguBuilder, error) {
+	if cnfinittools.CNFConfig == nil {
+		return nil, fmt.Errorf("CNF config is nil")
+	}
+
+	builder := NewIbgu(name)
+
+	if imageUpgrade, err := pullSpokeIBU(); err == nil {
+		if autoRollback := imageUpgrade.Object.Spec.AutoRollbackOnFailure; autoRollback != nil {
+			builder = builder.WithAutoRollbackOnFailure(autoRollback.InitMonitorTimeoutSeconds)
+		}
+	}
+
+	created, err := builder.WithPlan(actions, 5, 30).Create()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create IBGU %s with plan %v: %w", name, actions, err)
+	}
+
+	return created, nil
+}
+
+// WaitForIbgu waits until the hub IBGU reaches expected, failing immediately
+// when the opposite terminal state is observed.
+func WaitForIbgu(builder *ibgu.IbguBuilder, expected IbguState, timeout time.Duration) error {
+	if builder == nil {
+		return fmt.Errorf("ibgu builder is nil")
+	}
+
+	var lastStatus string
+
+	pollErr := wait.PollUntilContextTimeout(
+		context.TODO(), ibguPollInterval, timeout, true,
+		func(_ context.Context) (bool, error) {
+			object, err := builder.Get()
+			if err != nil {
+				klog.V(cnfparams.CNFLogLevel).Infof("waiting for IBGU %s: get failed: %v", expected, err)
+
+				return false, nil
+			}
+
+			builder.Object = object
+			builder.Definition = object
+			lastStatus = formatIbgu(object)
+
+			if failErr := unexpectedIbguState(object, expected); failErr != nil {
+				return false, failErr
+			}
+
+			if matchesIbguState(object, expected) {
+				return true, nil
+			}
+
+			klog.V(cnfparams.CNFLogLevel).Infof("waiting for IBGU %s; current: %s", expected, lastStatus)
+
+			return false, nil
+		})
+	if pollErr != nil {
+		return fmt.Errorf("IBGU did not reach %s within %s: %w (last status: %s)",
+			expected, timeout, pollErr, lastStatus)
+	}
+
+	return nil
+}
+
+// matchesIbguState reports whether the hub IBGU currently matches expected.
+func matchesIbguState(object *ibguv1alpha1.ImageBasedGroupUpgrade, expected IbguState) bool {
+	switch expected {
+	case IbguCompleted:
+		return ibguReasonIs(object, reasonCompleted) && !ibguHasFailedActions(object)
+	case IbguFailed:
+		return ibguReasonIs(object, reasonFailed) ||
+			ibguReasonIs(object, reasonTimedOut) ||
+			ibguHasFailedActions(object)
+	default:
+		return false
+	}
+}
+
+// unexpectedIbguState fail-fasts when the IBGU reached the opposite terminal
+// state from expected.
+func unexpectedIbguState(object *ibguv1alpha1.ImageBasedGroupUpgrade, expected IbguState) error {
+	if expected == IbguCompleted && ibguCompletedWithoutClusters(object) {
+		return fmt.Errorf("IBGU completed without selecting any clusters: %s", formatIbgu(object))
+	}
+
+	if expected == IbguCompleted && (ibguReasonIs(object, reasonFailed) ||
+		ibguReasonIs(object, reasonTimedOut) || ibguHasFailedActions(object)) {
+		return fmt.Errorf("IBGU failed while waiting for Completed: %s", formatIbgu(object))
+	}
+
+	if expected == IbguFailed && ibguReasonIs(object, reasonCompleted) && !ibguHasFailedActions(object) {
+		return fmt.Errorf("IBGU completed while waiting for Failed: %s", formatIbgu(object))
+	}
+
+	return nil
+}
+
+// ibguCompletedWithoutClusters reports a vacuous TALM completion when no
+// clusters were selected for the plan.
+func ibguCompletedWithoutClusters(object *ibguv1alpha1.ImageBasedGroupUpgrade) bool {
+	if object == nil {
+		return false
+	}
+
+	return ibguReasonIs(object, reasonCompleted) && len(object.Status.Clusters) == 0
+}
+
+// ibguReasonIs reports whether Progressing is False with the given reason.
+func ibguReasonIs(object *ibguv1alpha1.ImageBasedGroupUpgrade, reason string) bool {
+	if object == nil {
+		return false
+	}
+
+	for _, condition := range object.Status.Conditions {
+		if condition.Type == ibguConditionProgressing &&
+			condition.Status == metav1.ConditionFalse &&
+			condition.Reason == reason {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ibguHasFailedActions reports whether any cluster in the IBGU status lists a
+// failed action.
+func ibguHasFailedActions(object *ibguv1alpha1.ImageBasedGroupUpgrade) bool {
+	if object == nil {
+		return false
+	}
+
+	for _, clusterState := range object.Status.Clusters {
+		if len(clusterState.FailedActions) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// formatIbgu returns a compact name/conditions/clusters string for logs.
+func formatIbgu(object *ibguv1alpha1.ImageBasedGroupUpgrade) string {
+	if object == nil {
+		return "ibgu=<nil>"
+	}
+
+	return fmt.Sprintf("name=%s/%s conditions=%s clusters=%v",
+		object.Namespace, object.Name, formatConditions(object.Status.Conditions), object.Status.Clusters)
+}
+
+// labelClustersForPlan sets the TALM IBGU action labels so Rollback/Abort CGUs
+// actually select the spoke. Rollback requires ibgu-upgrade-completed; Abort
+// requires that label to be absent.
+func labelClustersForPlan(actions []string) error {
+	if cnfinittools.TargetHubAPIClient == nil {
+		return fmt.Errorf("target hub API client is nil")
+	}
+
+	clusters, err := ocm.ListManagedClusters(
+		cnfinittools.TargetHubAPIClient, goclient.MatchingLabels(ClusterLabelSelector))
+	if err != nil {
+		return fmt.Errorf("failed to list managed clusters for IBGU plan: %w", err)
+	}
+
+	var labeled []string
+
+	for _, managedCluster := range clusters {
+		if managedCluster == nil || managedCluster.Definition == nil || isLocalManagedCluster(managedCluster) {
+			continue
+		}
+
+		if err := patchClusterActionLabels(managedCluster, actions); err != nil {
+			return err
+		}
+
+		labeled = append(labeled, managedCluster.Definition.Name)
+	}
+
+	if len(labeled) == 0 {
+		return fmt.Errorf("no managed clusters matched %v for IBGU plan %v", ClusterLabelSelector, actions)
+	}
+
+	klog.V(cnfparams.CNFLogLevel).Infof("labeled managed clusters %v for IBGU plan %v", labeled, actions)
+
+	return nil
+}
+
+// patchClusterActionLabels adds or removes IBGU stage labels required by TALM
+// for the given recover plan actions.
+func patchClusterActionLabels(cluster *ocm.ManagedClusterBuilder, actions []string) error {
+	var lastErr error
+
+	for attempt := 0; attempt < labelUpdateRetries; attempt++ {
+		current, err := cluster.Get()
+		if err != nil {
+			return fmt.Errorf("failed to get managedcluster %s: %w", cluster.Definition.Name, err)
+		}
+
+		if current.Labels == nil {
+			current.Labels = map[string]string{}
+		}
+
+		if !mutateActionLabels(current.Labels, actions) {
+			return nil
+		}
+
+		cluster.Definition = current
+
+		_, lastErr = cluster.Update()
+		if lastErr == nil {
+			return nil
+		}
+
+		if !k8serrors.IsConflict(lastErr) {
+			return fmt.Errorf("failed to update managedcluster %s labels: %w", current.Name, lastErr)
+		}
+	}
+
+	return fmt.Errorf("failed to update managedcluster %s labels: %w", cluster.Definition.Name, lastErr)
+}
+
+// mutateActionLabels updates labels for TALM IBGU action selection. It reports
+// whether any label changed.
+func mutateActionLabels(labels map[string]string, actions []string) bool {
+	changed := false
+
+	if slices.Contains(actions, ibguv1alpha1.Rollback) {
+		if _, found := labels[ibguUpgradeCompletedLabel]; !found {
+			labels[ibguUpgradeCompletedLabel] = ""
+			changed = true
+		}
+	}
+
+	if slices.Contains(actions, ibguv1alpha1.Abort) {
+		if _, found := labels[ibguUpgradeCompletedLabel]; found {
+			delete(labels, ibguUpgradeCompletedLabel)
+
+			changed = true
+		}
+	}
+
+	if slices.Contains(actions, ibguv1alpha1.FinalizeRollback) &&
+		!slices.Contains(actions, ibguv1alpha1.Rollback) {
+		if _, found := labels[ibguRollbackCompletedLabel]; !found {
+			labels[ibguRollbackCompletedLabel] = ""
+			changed = true
+		}
+	}
+
+	if slices.Contains(actions, ibguv1alpha1.Abort) ||
+		slices.Contains(actions, ibguv1alpha1.Rollback) {
+		if _, found := labels[ibguPrepCompletedLabel]; !found {
+			labels[ibguPrepCompletedLabel] = ""
+			changed = true
+		}
+	}
+
+	return changed
+}
+
+// isLocalManagedCluster reports whether the cluster is the ACM hub local-cluster.
+func isLocalManagedCluster(cluster *ocm.ManagedClusterBuilder) bool {
+	if cluster == nil || cluster.Definition == nil || cluster.Definition.Labels == nil {
+		return false
+	}
+
+	return cluster.Definition.Labels[localClusterLabel] == "true"
+}

--- a/tests/lca/imagebasedupgrade/cnf/internal/cnfhelper/ibu.go
+++ b/tests/lca/imagebasedupgrade/cnf/internal/cnfhelper/ibu.go
@@ -1,0 +1,492 @@
+package cnfhelper
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/lca"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfparams"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// IBUAvailableTimeout is how long to wait for the spoke IBU CR after an ostree pivot.
+	IBUAvailableTimeout = 15 * time.Minute
+
+	spokePollInterval  = 5 * time.Second
+	abortPlanTimeout   = 10 * time.Minute
+	ensureReadyTimeout = 1 * time.Minute
+
+	stageIdle     = "Idle"
+	stagePrep     = "Prep"
+	stageUpgrade  = "Upgrade"
+	stageRollback = "Rollback"
+
+	conditionIdle               = "Idle"
+	conditionPrepCompleted      = "PrepCompleted"
+	conditionUpgradeCompleted   = "UpgradeCompleted"
+	conditionRollbackCompleted  = "RollbackCompleted"
+	conditionPrepInProgress     = "PrepInProgress"
+	conditionUpgradeInProgress  = "UpgradeInProgress"
+	conditionRollbackInProgress = "RollbackInProgress"
+
+	reasonCompleted      = "Completed"
+	reasonFailed         = "Failed"
+	reasonTimedOut       = "TimedOut"
+	reasonAbortFailed    = "AbortFailed"
+	reasonFinalizeFailed = "FinalizeFailed"
+)
+
+// SpokeIBUState is an expected terminal spoke IBU state.
+type SpokeIBUState string
+
+const (
+	// SpokeIdle is Idle with the Idle condition True.
+	SpokeIdle SpokeIBUState = "Idle"
+	// SpokePrepCompleted is Prep completed successfully.
+	SpokePrepCompleted SpokeIBUState = "PrepCompleted"
+	// SpokeUpgradeCompleted is Upgrade completed successfully.
+	SpokeUpgradeCompleted SpokeIBUState = "UpgradeCompleted"
+	// SpokeUpgradeInProgress is Upgrade started and not yet completed. Abort
+	// is only valid until pre-pivot, so a successful pull at this state means
+	// the API is still up and pivot has not begun.
+	SpokeUpgradeInProgress SpokeIBUState = "UpgradeInProgress"
+	// SpokeRollbackCompleted is Rollback completed successfully.
+	SpokeRollbackCompleted SpokeIBUState = "RollbackCompleted"
+	// SpokeUpgradeFailed is UpgradeCompleted with Reason Failed.
+	SpokeUpgradeFailed SpokeIBUState = "UpgradeFailed"
+)
+
+// WaitForSpokeIBU waits until the spoke IBU reaches expected, failing immediately
+// if a stage reports Failed and that failure is not the expected end state.
+// When expected is SpokeRollbackCompleted, SpokeIdle also counts as success
+// because FinalizeRollback can clear RollbackCompleted before the next poll.
+// When expected is SpokeUpgradeInProgress, a completed Upgrade fails immediately
+// because the pre-pivot abort window has already closed.
+func WaitForSpokeIBU(expected SpokeIBUState, timeout time.Duration) error {
+	return waitForSpokeIBUState(expected, timeout, metav1.Condition{})
+}
+
+// waitForSpokeIBUState waits for expected. ignoreFailure, when set, is the
+// pre-existing Idle AbortFailed/FinalizeFailed condition that Recover already
+// observed; that instance is not treated as a new terminal failure.
+func waitForSpokeIBUState(expected SpokeIBUState, timeout time.Duration, ignoreFailure metav1.Condition) error {
+	var lastStatus string
+
+	pollErr := wait.PollUntilContextTimeout(
+		context.TODO(), spokePollInterval, timeout, true,
+		func(_ context.Context) (bool, error) {
+			imageUpgrade, err := pullSpokeIBU()
+			if err != nil {
+				klog.V(cnfparams.CNFLogLevel).Infof("waiting for spoke IBU %s: pull failed: %v", expected, err)
+
+				return false, nil
+			}
+
+			lastStatus = formatIBU(imageUpgrade)
+
+			if failErr := unexpectedIBUFailureIgnoring(imageUpgrade, expected, ignoreFailure); failErr != nil {
+				return false, failErr
+			}
+
+			if expected == SpokeUpgradeInProgress && matchesSpokeState(imageUpgrade, SpokeUpgradeCompleted) {
+				return false, fmt.Errorf(
+					"spoke IBU completed Upgrade before abort (pivot already happened): %s", lastStatus)
+			}
+
+			if matchesSpokeState(imageUpgrade, expected) {
+				return true, nil
+			}
+
+			if expected == SpokeRollbackCompleted && matchesSpokeState(imageUpgrade, SpokeIdle) {
+				return true, nil
+			}
+
+			klog.V(cnfparams.CNFLogLevel).Infof("waiting for spoke IBU %s; current: %s", expected, lastStatus)
+
+			return false, nil
+		})
+	if pollErr != nil {
+		return fmt.Errorf("spoke IBU did not reach %s within %s: %w (last status: %s)",
+			expected, timeout, pollErr, lastStatus)
+	}
+
+	return nil
+}
+
+// EnsureSpokeReadyForNextIbgu is a fail-fast BeforeEach sanity check. It retries
+// IBU pulls for up to a minute, then immediately fails if the spoke is not Idle
+// with Prep valid or if a single health snapshot fails. It does not wait for
+// operators to stay healthy; BeforeSuite and the previous spec's WaitUntilHealthy
+// are responsible for that. It does not recover leftover state; Recover in
+// AfterEach does that.
+func EnsureSpokeReadyForNextIbgu() error {
+	imageUpgrade, err := waitForSpokeIBUObject(ensureReadyTimeout)
+	if err != nil {
+		return err
+	}
+
+	if !isPrepReady(imageUpgrade) {
+		return notPrepReadyError(imageUpgrade)
+	}
+
+	report := Check()
+	if !report.Healthy() {
+		return fmt.Errorf("spoke is not healthy: %s", report.FailureSummary())
+	}
+
+	return nil
+}
+
+// WaitUntilIBUAvailable waits until the spoke ImageBasedUpgrade CR exists. After
+// an ostree pivot the CR is missing until LCA recreates it, and a single pull
+// can also return a nil object when the API is still coming up.
+func WaitUntilIBUAvailable(timeout time.Duration) error {
+	_, err := waitForSpokeIBUObject(timeout)
+
+	return err
+}
+
+// waitForSpokeIBUObject retries PullImageBasedUpgrade until the IBU object exists.
+// After an ostree pivot the CR is missing until LCA recreates it.
+func waitForSpokeIBUObject(timeout time.Duration) (*lca.ImageBasedUpgradeBuilder, error) {
+	var imageUpgrade *lca.ImageBasedUpgradeBuilder
+
+	var lastErr error
+
+	pollErr := wait.PollUntilContextTimeout(
+		context.TODO(), spokePollInterval, timeout, true,
+		func(_ context.Context) (bool, error) {
+			pulled, err := pullSpokeIBU()
+			if err != nil {
+				lastErr = err
+				klog.V(cnfparams.CNFLogLevel).Infof("waiting for spoke IBU object: %v", err)
+
+				return false, nil
+			}
+
+			imageUpgrade = pulled
+
+			return true, nil
+		})
+	if pollErr != nil {
+		if lastErr != nil {
+			return nil, fmt.Errorf("spoke IBU was not available within %s: %w", timeout, lastErr)
+		}
+
+		return nil, fmt.Errorf("spoke IBU was not available within %s: %w", timeout, pollErr)
+	}
+
+	return imageUpgrade, nil
+}
+
+// pullSpokeIBU pulls the spoke IBU and requires a real object. eco-goinfra Exists
+// treats non-NotFound API errors as exists, which can return a nil object.
+func pullSpokeIBU() (*lca.ImageBasedUpgradeBuilder, error) {
+	imageUpgrade, err := lca.PullImageBasedUpgrade(cnfinittools.TargetSNOAPIClient)
+	if err != nil {
+		return nil, err
+	}
+
+	if imageUpgrade == nil || imageUpgrade.Object == nil {
+		return nil, fmt.Errorf("imagebasedupgrade object upgrade does not exist")
+	}
+
+	return imageUpgrade, nil
+}
+
+// waitUntilPrepReady waits until the spoke IBU is Idle with Prep in
+// validNextStages. After reboot LCA can report Idle=False/Blocked (IPC is not
+// idle) while ostree IPC is still busy; Abort cannot clear that.
+func waitUntilPrepReady(timeout time.Duration) error {
+	var lastStatus string
+
+	pollErr := wait.PollUntilContextTimeout(
+		context.TODO(), spokePollInterval, timeout, true,
+		func(_ context.Context) (bool, error) {
+			imageUpgrade, err := pullSpokeIBU()
+			if err != nil {
+				klog.V(cnfparams.CNFLogLevel).Infof(
+					"waiting for spoke IBU Idle with Prep valid: pull failed: %v", err)
+
+				return false, nil
+			}
+
+			lastStatus = formatIBU(imageUpgrade)
+
+			if failErr := unexpectedIBUFailure(imageUpgrade, SpokeIdle); failErr != nil {
+				return false, failErr
+			}
+
+			if isPrepReady(imageUpgrade) {
+				return true, nil
+			}
+
+			klog.V(cnfparams.CNFLogLevel).Infof(
+				"waiting for spoke IBU Idle with Prep valid; current: %s", lastStatus)
+
+			return false, nil
+		})
+	if pollErr != nil {
+		return fmt.Errorf("spoke IBU did not become Idle with Prep valid within %s: %w (last status: %s)",
+			timeout, pollErr, lastStatus)
+	}
+
+	return nil
+}
+
+// isPrepReady reports whether the spoke IBU is Idle with the Idle condition
+// True and Prep in validNextStages.
+func isPrepReady(imageUpgrade *lca.ImageBasedUpgradeBuilder) bool {
+	return isIdleWithPrepValid(imageUpgrade) &&
+		conditionStatus(imageUpgrade, conditionIdle) == metav1.ConditionTrue
+}
+
+// isIdleWithPrepValid reports whether spec.stage is Idle and Prep is a valid
+// next stage. The Idle condition may still be False.
+func isIdleWithPrepValid(imageUpgrade *lca.ImageBasedUpgradeBuilder) bool {
+	return currentStage(imageUpgrade) == stageIdle && hasValidNext(imageUpgrade, stagePrep)
+}
+
+// HasSuccessfulUpgrade reports whether the spoke IBU completed Upgrade and
+// Rollback is a valid next stage. Ordered e2e rollback (69058) uses this so it
+// can run alone after a previous successful 68954 job.
+func HasSuccessfulUpgrade() (bool, error) {
+	imageUpgrade, err := pullSpokeIBU()
+	if err != nil {
+		return false, err
+	}
+
+	return isSuccessfulUpgrade(imageUpgrade), nil
+}
+
+// isSuccessfulUpgrade reports whether Upgrade completed and Rollback is a valid
+// next stage, so Recover must not abort it.
+func isSuccessfulUpgrade(imageUpgrade *lca.ImageBasedUpgradeBuilder) bool {
+	return conditionStatus(imageUpgrade, conditionUpgradeCompleted) == metav1.ConditionTrue &&
+		conditionReason(imageUpgrade, conditionUpgradeCompleted) == reasonCompleted &&
+		hasValidNext(imageUpgrade, stageRollback)
+}
+
+// needsManualCleanup reports whether Idle is AbortFailed or FinalizeFailed and
+// LCA is waiting for the manual-cleanup-done annotation.
+func needsManualCleanup(imageUpgrade *lca.ImageBasedUpgradeBuilder) bool {
+	reason := conditionReason(imageUpgrade, conditionIdle)
+
+	return reason == reasonAbortFailed || reason == reasonFinalizeFailed
+}
+
+// currentStage returns the IBU spec.stage, or empty if the object is missing.
+func currentStage(imageUpgrade *lca.ImageBasedUpgradeBuilder) string {
+	if imageUpgrade == nil || imageUpgrade.Object == nil {
+		return ""
+	}
+
+	return string(imageUpgrade.Object.Spec.Stage)
+}
+
+// hasValidNext reports whether stage is listed in IBU status.validNextStages.
+func hasValidNext(imageUpgrade *lca.ImageBasedUpgradeBuilder, stage string) bool {
+	if imageUpgrade == nil || imageUpgrade.Object == nil {
+		return false
+	}
+
+	for _, nextStage := range imageUpgrade.Object.Status.ValidNextStages {
+		if string(nextStage) == stage {
+			return true
+		}
+	}
+
+	return false
+}
+
+// conditionStatus returns the status of the named IBU condition, or empty if it
+// is not present.
+func conditionStatus(imageUpgrade *lca.ImageBasedUpgradeBuilder, conditionType string) metav1.ConditionStatus {
+	condition, found := findCondition(imageUpgrade, conditionType)
+	if !found {
+		return ""
+	}
+
+	return condition.Status
+}
+
+// conditionReason returns the reason of the named IBU condition, or empty if it
+// is not present.
+func conditionReason(imageUpgrade *lca.ImageBasedUpgradeBuilder, conditionType string) string {
+	condition, found := findCondition(imageUpgrade, conditionType)
+	if !found {
+		return ""
+	}
+
+	return condition.Reason
+}
+
+// findCondition returns the named IBU condition if it is present.
+func findCondition(imageUpgrade *lca.ImageBasedUpgradeBuilder, conditionType string) (metav1.Condition, bool) {
+	if imageUpgrade == nil || imageUpgrade.Object == nil {
+		return metav1.Condition{}, false
+	}
+
+	for _, condition := range imageUpgrade.Object.Status.Conditions {
+		if condition.Type == conditionType {
+			return condition, true
+		}
+	}
+
+	return metav1.Condition{}, false
+}
+
+// matchesSpokeState reports whether the IBU currently matches expected.
+func matchesSpokeState(imageUpgrade *lca.ImageBasedUpgradeBuilder, expected SpokeIBUState) bool {
+	switch expected {
+	case SpokeIdle:
+		return currentStage(imageUpgrade) == stageIdle &&
+			conditionStatus(imageUpgrade, conditionIdle) == metav1.ConditionTrue
+	case SpokePrepCompleted:
+		return completedCondition(imageUpgrade, conditionPrepCompleted, conditionPrepInProgress, "Prep completed")
+	case SpokeUpgradeCompleted:
+		return completedCondition(imageUpgrade, conditionUpgradeCompleted, conditionUpgradeInProgress, "Upgrade completed")
+	case SpokeUpgradeInProgress:
+		return currentStage(imageUpgrade) == stageUpgrade &&
+			conditionStatus(imageUpgrade, conditionUpgradeInProgress) == metav1.ConditionTrue
+	case SpokeRollbackCompleted:
+		return completedCondition(imageUpgrade, conditionRollbackCompleted, conditionRollbackInProgress, "Rollback completed")
+	case SpokeUpgradeFailed:
+		return conditionStatus(imageUpgrade, conditionUpgradeCompleted) == metav1.ConditionFalse &&
+			conditionReason(imageUpgrade, conditionUpgradeCompleted) == reasonFailed
+	default:
+		return false
+	}
+}
+
+// completedCondition reports a successful stage via Completed=True/Completed or
+// the older InProgress=False/Completed message used by some LCA versions.
+func completedCondition(
+	imageUpgrade *lca.ImageBasedUpgradeBuilder, completedType, inProgressType, message string) bool {
+	if conditionStatus(imageUpgrade, completedType) == metav1.ConditionTrue &&
+		conditionReason(imageUpgrade, completedType) == reasonCompleted {
+		return true
+	}
+
+	condition, found := findCondition(imageUpgrade, inProgressType)
+	if !found {
+		return false
+	}
+
+	return condition.Status == metav1.ConditionFalse &&
+		condition.Reason == reasonCompleted &&
+		condition.Message == message
+}
+
+// unexpectedIBUFailure fail-fasts on Failed/TimedOut for the stage being waited
+// for. Other stages are ignored because LCA keeps prior conditions (for example
+// UpgradeCompleted=Failed) until ResetStatusConditions when Idle is reached.
+func unexpectedIBUFailure(imageUpgrade *lca.ImageBasedUpgradeBuilder, expected SpokeIBUState) error {
+	return unexpectedIBUFailureIgnoring(imageUpgrade, expected, metav1.Condition{})
+}
+
+// unexpectedIBUFailureIgnoring is unexpectedIBUFailure, except ignoreFailure is
+// skipped until Type, Reason, or LastTransitionTime changes.
+func unexpectedIBUFailureIgnoring(
+	imageUpgrade *lca.ImageBasedUpgradeBuilder, expected SpokeIBUState, ignoreFailure metav1.Condition) error {
+	if imageUpgrade == nil || imageUpgrade.Object == nil {
+		return nil
+	}
+
+	watched := failureWatchTypes(expected)
+	if len(watched) == 0 {
+		return nil
+	}
+
+	for _, condition := range imageUpgrade.Object.Status.Conditions {
+		if !slices.Contains(watched, condition.Type) || !isFailureReason(condition.Reason) {
+			continue
+		}
+
+		if isIgnoredFailure(condition, ignoreFailure) {
+			continue
+		}
+
+		return fmt.Errorf("spoke IBU failed while waiting for %s: type=%s status=%s reason=%s message=%s (%s)",
+			expected, condition.Type, condition.Status, condition.Reason, condition.Message, formatIBU(imageUpgrade))
+	}
+
+	return nil
+}
+
+// isIgnoredFailure reports whether condition is the same AbortFailed/FinalizeFailed
+// instance Recover already observed before setting manual-cleanup-done.
+func isIgnoredFailure(condition, ignoreFailure metav1.Condition) bool {
+	if ignoreFailure.Type == "" || ignoreFailure.LastTransitionTime.IsZero() {
+		return false
+	}
+
+	return condition.Type == ignoreFailure.Type &&
+		condition.Reason == ignoreFailure.Reason &&
+		condition.LastTransitionTime.Equal(&ignoreFailure.LastTransitionTime)
+}
+
+// failureWatchTypes returns the IBU condition types that should fail-fast while
+// waiting for expected. SpokeUpgradeFailed watches nothing so Failed is the goal.
+func failureWatchTypes(expected SpokeIBUState) []string {
+	switch expected {
+	case SpokePrepCompleted:
+		return []string{conditionPrepCompleted, conditionPrepInProgress}
+	case SpokeUpgradeCompleted, SpokeUpgradeInProgress:
+		return []string{conditionUpgradeCompleted, conditionUpgradeInProgress}
+	case SpokeRollbackCompleted:
+		return []string{conditionRollbackCompleted, conditionRollbackInProgress}
+	case SpokeIdle:
+		return []string{conditionIdle}
+	case SpokeUpgradeFailed:
+		return nil
+	default:
+		return nil
+	}
+}
+
+// isFailureReason reports whether reason is a terminal IBU failure.
+func isFailureReason(reason string) bool {
+	switch reason {
+	case reasonFailed, reasonTimedOut, reasonAbortFailed, reasonFinalizeFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+// formatIBU returns a compact stage/validNextStages/conditions string for logs.
+func formatIBU(imageUpgrade *lca.ImageBasedUpgradeBuilder) string {
+	if imageUpgrade == nil || imageUpgrade.Object == nil {
+		return "ibu=<nil>"
+	}
+
+	return fmt.Sprintf("stage=%s validNextStages=%v conditions=%s",
+		imageUpgrade.Object.Spec.Stage,
+		imageUpgrade.Object.Status.ValidNextStages,
+		formatConditions(imageUpgrade.Object.Status.Conditions))
+}
+
+// formatConditions joins condition type/status/reason/message for log output.
+func formatConditions(conditions []metav1.Condition) string {
+	parts := make([]string, 0, len(conditions))
+
+	for _, condition := range conditions {
+		parts = append(parts, fmt.Sprintf("%s=%s/%s (%s)",
+			condition.Type, condition.Status, condition.Reason, condition.Message))
+	}
+
+	return strings.Join(parts, "; ")
+}
+
+// notPrepReadyError describes an IBU that is not Idle with Prep in validNextStages.
+func notPrepReadyError(imageUpgrade *lca.ImageBasedUpgradeBuilder) error {
+	return fmt.Errorf("spoke IBU is not Idle with Prep in validNextStages: %s", formatIBU(imageUpgrade))
+}

--- a/tests/lca/imagebasedupgrade/cnf/internal/cnfhelper/recover.go
+++ b/tests/lca/imagebasedupgrade/cnf/internal/cnfhelper/recover.go
@@ -1,0 +1,317 @@
+package cnfhelper
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/ibgu"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/lca"
+	ibguv1alpha1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/imagebasedgroupupgrades/v1alpha1"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/cluster"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/internal/safeapirequest"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+)
+
+const (
+	sriovSettleTimeout      = 2 * time.Minute
+	rollbackPlanTimeout     = 30 * time.Minute
+	bslWaitTimeout          = 10 * time.Minute
+	rebootCommandRetries    = 3
+	rebootRetryInterval     = 10 * time.Second
+	manualCleanupAnnotation = "lca.openshift.io/manual-cleanup-done"
+)
+
+// Recover snapshots spoke health and IBU stage, then dispatches leftover abort,
+// rollback, manual cleanup, or an SR-IOV reboot. SR-IOV is recovered before
+// IBU Abort/Rollback because a bad SriovNetworkNodeState blocks LCA health
+// gates. It always finishes with WaitUntilHealthy. Unless a completed Upgrade
+// is being left for Ordered e2e rollback, it then waits for Idle with Prep
+// valid so the next spec's fail-fast BeforeEach does not race LCA
+// Idle=False/Blocked after reboot.
+//
+// Call Recover only after a failed spec that entered the It body. A passing It
+// already waited for spoke health to stay stable, and recovering on success can
+// reboot after 68954 and break the post-upgrade reboot count check. Recover
+// after a BeforeEach/BeforeAll failure cannot fix that setup error and can hang
+// the suite.
+//
+// If leaveSuccessfulUpgrade is true, a completed Upgrade is left in place so
+// Ordered e2e test 69058 can still roll it back. Independent failed specs must
+// pass false so leftover Upgrade is rolled back to Idle.
+func Recover(leaveSuccessfulUpgrade bool) error {
+	report := Check()
+	if report.Healthy() {
+		klog.V(cnfparams.CNFLogLevel).Info("Recover: spoke health checks passed")
+	} else {
+		klog.V(cnfparams.CNFLogLevel).Infof("Recover: spoke health: %s", report.FailureSummary())
+	}
+
+	if sriovNeedsReboot(report) {
+		if recoverErr := recoverSriov(report); recoverErr != nil {
+			return recoverErr
+		}
+	}
+
+	imageUpgrade, err := waitForSpokeIBUObject(IBUAvailableTimeout)
+	if err != nil {
+		klog.V(cnfparams.CNFLogLevel).Infof("Recover: failed to pull IBU, continuing with health recovery: %v", err)
+	} else {
+		klog.V(cnfparams.CNFLogLevel).Infof("Recover: spoke IBU %s", formatIBU(imageUpgrade))
+
+		if recoverErr := recoverIBU(imageUpgrade, leaveSuccessfulUpgrade); recoverErr != nil {
+			return recoverErr
+		}
+	}
+
+	if healthErr := WaitUntilHealthy(RecoverHealthTimeout); healthErr != nil {
+		return healthErr
+	}
+
+	if leaveSuccessfulUpgrade {
+		return nil
+	}
+
+	return waitUntilPrepReady(abortPlanTimeout)
+}
+
+// recoverIBU drives leftover IBU state to Idle, or annotates for manual cleanup
+// after AbortFailed/FinalizeFailed.
+func recoverIBU(imageUpgrade *lca.ImageBasedUpgradeBuilder, leaveSuccessfulUpgrade bool) error {
+	if needsManualCleanup(imageUpgrade) {
+		idleFailure, _ := findCondition(imageUpgrade, conditionIdle)
+
+		if err := recoverManualCleanup(); err != nil {
+			return err
+		}
+
+		// WaitForSpokeIBU fail-fasts on Idle AbortFailed/FinalizeFailed. Ignore
+		// the pre-annotation instance until LCA reconciles manual-cleanup-done.
+		return waitForSpokeIBUState(SpokeIdle, abortPlanTimeout, idleFailure)
+	}
+
+	plan := recoverIdlePlan(imageUpgrade, leaveSuccessfulUpgrade)
+	if len(plan) == 0 {
+		return nil
+	}
+
+	return applyPlanAndWaitIdle(plan)
+}
+
+// recoverManualCleanup waits for BackupStorageLocation, then sets
+// lca.openshift.io/manual-cleanup-done so LCA retries abort/finalize cleanup.
+func recoverManualCleanup() error {
+	klog.V(cnfparams.CNFLogLevel).Info(
+		"Recover: waiting for BackupStorageLocation before manual-cleanup-done annotation")
+
+	if err := wait.PollUntilContextTimeout(
+		context.TODO(), healthPollInterval, bslWaitTimeout, true,
+		func(_ context.Context) (bool, error) {
+			return !Check().unhealthy(checkBackupStorage), nil
+		}); err != nil {
+		return fmt.Errorf("BackupStorageLocation did not become available for manual cleanup: %w", err)
+	}
+
+	return safeapirequest.Do(func() error {
+		imageUpgrade, err := lca.PullImageBasedUpgrade(cnfinittools.TargetSNOAPIClient)
+		if err != nil {
+			return err
+		}
+
+		if imageUpgrade.Definition.Annotations == nil {
+			imageUpgrade.Definition.Annotations = map[string]string{}
+		}
+
+		imageUpgrade.Definition.Annotations[manualCleanupAnnotation] = "true"
+		_, err = imageUpgrade.Update()
+
+		return err
+	})
+}
+
+// recoverSriov waits briefly for SriovNetworkNodeState to recover, then soft
+// reboots the SNO and waits for cluster recovery if it stays unhealthy.
+func recoverSriov(report Report) error {
+	result, found := report.result(checkSriov)
+	message := "unknown SR-IOV failure"
+
+	if found {
+		message = result.Message
+	}
+
+	klog.V(cnfparams.CNFLogLevel).Infof(
+		"Recover: SR-IOV is unhealthy (%s), waiting %s before reboot", message, sriovSettleTimeout)
+
+	settleErr := wait.PollUntilContextTimeout(
+		context.TODO(), healthPollInterval, sriovSettleTimeout, true,
+		func(_ context.Context) (bool, error) {
+			return !Check().unhealthy(checkSriov), nil
+		})
+	if settleErr == nil {
+		klog.V(cnfparams.CNFLogLevel).Info("Recover: SR-IOV became healthy without reboot")
+
+		return nil
+	}
+
+	klog.V(cnfparams.CNFLogLevel).Info("Recover: SR-IOV still unhealthy, issuing SNO soft reboot")
+
+	rebootErr := cluster.SoftRebootSNO(
+		cnfinittools.TargetSNOAPIClient, rebootCommandRetries, rebootRetryInterval)
+	klog.V(cnfparams.CNFLogLevel).Infof("Recover: soft reboot result: %v", rebootErr)
+
+	namespaces := []string{oadpNamespace}
+	if cnfinittools.CNFConfig != nil {
+		namespaces = []string{
+			cnfinittools.CNFConfig.SriovOperatorNamespace,
+			cnfinittools.CNFConfig.MCONamespace,
+		}
+	}
+
+	if err := cluster.WaitForRecover(
+		cnfinittools.TargetSNOAPIClient, namespaces, RecoverHealthTimeout); err != nil {
+		return fmt.Errorf("cluster did not recover after SR-IOV reboot: %w", err)
+	}
+
+	return nil
+}
+
+// sriovNeedsReboot reports whether SR-IOV health failed with a syncStatus or
+// empty-list error that a reboot can recover.
+func sriovNeedsReboot(report Report) bool {
+	result, found := report.result(checkSriov)
+	if !found || result.Healthy || result.Skipped {
+		return false
+	}
+
+	return strings.Contains(result.Message, "syncStatus") ||
+		strings.Contains(result.Message, "no SriovNetworkNodeStates")
+}
+
+// recoverIdlePlan returns the IBGU actions needed to return leftover IBU state
+// to Idle. Spec.stage Idle is left untouched because Abort is not a valid next
+// stage once LCA has already moved to Idle. A completed Upgrade is left only
+// when leaveSuccessfulUpgrade is true.
+func recoverIdlePlan(imageUpgrade *lca.ImageBasedUpgradeBuilder, leaveSuccessfulUpgrade bool) []string {
+	if currentStage(imageUpgrade) == stageIdle {
+		if !isPrepReady(imageUpgrade) {
+			klog.V(cnfparams.CNFLogLevel).Infof(
+				"Recover: spoke IBU already at Idle, skipping abort: %s",
+				formatIBU(imageUpgrade))
+		}
+
+		return nil
+	}
+
+	if leaveSuccessfulUpgrade && isSuccessfulUpgrade(imageUpgrade) {
+		klog.V(cnfparams.CNFLogLevel).Info("Recover: leaving successful Upgrade in place for Ordered e2e rollback")
+
+		return nil
+	}
+
+	return idlePlan(imageUpgrade)
+}
+
+// idlePlan selects Abort, Rollback+FinalizeRollback, or FinalizeRollback from
+// the IBU validNextStages and current stage.
+func idlePlan(imageUpgrade *lca.ImageBasedUpgradeBuilder) []string {
+	if hasValidNext(imageUpgrade, stageRollback) {
+		return []string{ibguv1alpha1.Rollback, ibguv1alpha1.FinalizeRollback}
+	}
+
+	if hasValidNext(imageUpgrade, stageIdle) && currentStage(imageUpgrade) == stageRollback {
+		return []string{ibguv1alpha1.FinalizeRollback}
+	}
+
+	return []string{ibguv1alpha1.Abort}
+}
+
+// applyPlanAndWaitIdle creates a recover IBGU with actions, waits for spoke Idle
+// and IBGU Completed, then deletes the recover IBGU. TALM Rollback/FinalizeRollback
+// CGUs only select clusters with the matching lcm.openshift.io/ibgu-*-completed
+// labels, so those labels are applied first when the original IBGU was deleted
+// before it could set them.
+func applyPlanAndWaitIdle(actions []string) error {
+	if err := deleteIbgu(RecoverIbguName); err != nil {
+		return err
+	}
+
+	if err := labelClustersForPlan(actions); err != nil {
+		return err
+	}
+
+	builder, err := createPlanIbgu(RecoverIbguName, actions)
+	if err != nil {
+		return err
+	}
+
+	timeout := abortPlanTimeout
+	if slices.Contains(actions, ibguv1alpha1.Rollback) ||
+		slices.Contains(actions, ibguv1alpha1.FinalizeRollback) {
+		timeout = rollbackPlanTimeout
+	}
+
+	if err := waitForRecoverPlanIdle(builder, timeout); err != nil {
+		return err
+	}
+
+	if err := WaitForIbgu(builder, IbguCompleted, timeout); err != nil {
+		return err
+	}
+
+	return deleteIbgu(RecoverIbguName)
+}
+
+// waitForRecoverPlanIdle waits for spoke Idle while fail-fasting if the recover
+// IBGU completes without selecting any clusters.
+func waitForRecoverPlanIdle(builder *ibgu.IbguBuilder, timeout time.Duration) error {
+	var lastIBU, lastIBGU string
+
+	pollErr := wait.PollUntilContextTimeout(
+		context.TODO(), spokePollInterval, timeout, true,
+		func(_ context.Context) (bool, error) {
+			imageUpgrade, err := pullSpokeIBU()
+			if err != nil {
+				klog.V(cnfparams.CNFLogLevel).Infof("waiting for spoke IBU Idle: pull failed: %v", err)
+
+				return false, nil
+			}
+
+			lastIBU = formatIBU(imageUpgrade)
+			if failErr := unexpectedIBUFailure(imageUpgrade, SpokeIdle); failErr != nil {
+				return false, failErr
+			}
+
+			if builder != nil {
+				object, getErr := builder.Get()
+				if getErr == nil {
+					builder.Object = object
+					builder.Definition = object
+					lastIBGU = formatIbgu(object)
+
+					if failErr := unexpectedIbguState(object, IbguCompleted); failErr != nil {
+						return false, failErr
+					}
+				}
+			}
+
+			if matchesSpokeState(imageUpgrade, SpokeIdle) {
+				return true, nil
+			}
+
+			klog.V(cnfparams.CNFLogLevel).Infof(
+				"waiting for spoke IBU Idle; current: %s; ibgu: %s", lastIBU, lastIBGU)
+
+			return false, nil
+		})
+	if pollErr != nil {
+		return fmt.Errorf("spoke IBU did not reach Idle within %s: %w (last status: %s; ibgu: %s)",
+			timeout, pollErr, lastIBU, lastIBGU)
+	}
+
+	return nil
+}

--- a/tests/lca/imagebasedupgrade/cnf/internal/validations/post_ibu_validations.go
+++ b/tests/lca/imagebasedupgrade/cnf/internal/validations/post_ibu_validations.go
@@ -30,13 +30,21 @@ var (
 	err      error
 )
 
-// PostUpgradeValidations is a dedicated func to run post upgrade test validations.
+// UpgradeSucceeded is set by the TALM e2e upgrade It after 68954 passes.
+var UpgradeSucceeded bool
+
+// PostUpgradeValidations registers post-upgrade checks. Call it from inside the
+// Ordered e2e Describe after test 68954 so this nested BeforeAll runs after that It.
 func PostUpgradeValidations() {
 	Describe(
 		"PostIBUValidations",
 		Ordered,
 		Label("PostIBUValidations"), func() {
 			BeforeAll(func() {
+				if !UpgradeSucceeded {
+					Skip("post-upgrade validations require a successful 68954 upgrade")
+				}
+
 				By("Retrieve seed image info", func() {
 					Eventually(func() bool {
 						ibu, err = lca.PullImageBasedUpgrade(TargetSNOAPIClient)

--- a/tests/lca/imagebasedupgrade/cnf/upgrade-talm/internal/tsparams/const.go
+++ b/tests/lca/imagebasedupgrade/cnf/upgrade-talm/internal/tsparams/const.go
@@ -51,4 +51,9 @@ const (
 	RollbackCguName = "cgu-ibu-rollback"
 	// RollbackPolicyName is the name of managed policy for ibu rollback stage validation.
 	RollbackPolicyName = "group-ibu-rollback-stage-policy"
+
+	// SpecRollbackSuccessfulUpgrade is the It text for test 69058. AfterEach
+	// matches CurrentSpecReport().LeafNodeText against this so Recover leaves
+	// a completed Upgrade in place for that Ordered spec.
+	SpecRollbackSuccessfulUpgrade = "Rollback successful upgrade"
 )

--- a/tests/lca/imagebasedupgrade/cnf/upgrade-talm/internal/tsparams/upgradevars.go
+++ b/tests/lca/imagebasedupgrade/cnf/upgrade-talm/internal/tsparams/upgradevars.go
@@ -1,11 +1,18 @@
 package tsparams
 
 import (
+	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	cguv1alpha1 "github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/clustergroupupgrades/v1alpha1"
 	lcav1 "github.com/openshift-kni/lifecycle-agent/api/imagebasedupgrade/v1"
 	configv1 "github.com/openshift/api/config/v1"
+	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
 	ibguv1alpha1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/imagebasedgroupupgrades/v1alpha1"
+	oadpv1alpha1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/oadp/api/v1alpha1"
+	olmv1alpha1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/olm/operators/v1alpha1"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 
@@ -47,13 +54,17 @@ var (
 		{Cr: &corev1.PodList{}},
 		{Cr: &policiesv1.PolicyList{}},
 		{Cr: &ibguv1alpha1.ImageBasedGroupUpgradeList{}},
+		{Cr: &cguv1alpha1.ClusterGroupUpgradeList{}},
 	}
 
 	// ReporterSpokeNamespacesToDump tells the reporter which namespaces on the spokes to collect pod logs from.
 	ReporterSpokeNamespacesToDump = map[string]string{
-		LCANamespace:           "lca",
-		LCAWorkloadName:        "workload",
-		LCAKlusterletNamespace: "klusterlet",
+		LCANamespace:                     "lca",
+		LCAWorkloadName:                  "workload",
+		LCAKlusterletNamespace:           "klusterlet",
+		LCAOADPNamespace:                 "oadp",
+		CNFConfig.SriovOperatorNamespace: "sriov",
+		CNFConfig.MCONamespace:           "mco",
 	}
 
 	// ReporterSpokeCRsToDump is the CRs the reporter should dump on the spokes.
@@ -65,11 +76,19 @@ var (
 		{Cr: &corev1.ServiceList{}},
 		{Cr: &lcav1.ImageBasedUpgradeList{}},
 		{Cr: &configv1.ClusterOperatorList{}},
+		{Cr: &machineconfigv1.MachineConfigPoolList{}},
+		{Cr: &olmv1alpha1.ClusterServiceVersionList{}},
+		{Cr: &sriovv1.SriovNetworkNodeStateList{}},
+		{Cr: &sriovv1.SriovNetworkNodePolicyList{}},
+		{Cr: &sriovv1.SriovNetworkList{}},
+		{Cr: &corev1.NodeList{}},
+		{Cr: &certificatesv1.CertificateSigningRequestList{}},
+		{Cr: &velerov1.BackupStorageLocationList{}},
+		{Cr: &velerov1.BackupList{}},
+		{Cr: &velerov1.RestoreList{}},
+		{Cr: &oadpv1alpha1.DataProtectionApplicationList{}},
 	}
 
 	// TargetSnoClusterName is the name of target sno cluster.
 	TargetSnoClusterName string
-
-	// ClusterLabelSelector is the cluster label passed to IBGUs.
-	ClusterLabelSelector = map[string]string{"common": "true"}
 )

--- a/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/cleanup.go
+++ b/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/cleanup.go
@@ -1,0 +1,70 @@
+package upgrade_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfhelper"
+	cnfibuvalidations "github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/validations"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/upgrade-talm/internal/tsparams"
+)
+
+// setupNodeTypes are Ginkgo nodes that run before the It body. A failure there
+// means the spec never entered the test, so AfterEach Recover cannot fix the
+// setup failure and only delays the suite.
+var setupNodeTypes = types.NodeTypeBeforeEach |
+	types.NodeTypeJustBeforeEach |
+	types.NodeTypeBeforeAll |
+	types.NodeTypeBeforeSuite |
+	types.NodeTypeSynchronizedBeforeSuite
+
+// deleteIbgusAndRecoverIfFailed deletes leftover hub IBGUs after every spec.
+// Recover runs only after a failed spec that entered the It body, so a
+// successful upgrade is left for the Ordered rollback test and setup failures
+// (BeforeEach/BeforeAll) fail fast instead of hanging in Recover.
+func deleteIbgusAndRecoverIfFailed() {
+	By("Deleting leftover IBGUs on the hub")
+
+	deleteErr := cnfhelper.DeleteIbgus(tsparams.IbguName, tsparams.AbortIbguName, cnfhelper.RecoverIbguName)
+
+	if shouldRecoverAfterFailedSpec() {
+		By("Recovering spoke cluster health after failed spec")
+
+		Expect(cnfhelper.Recover(leaveSuccessfulUpgrade())).To(Succeed(),
+			"spoke cluster was not recovered after the failed test")
+	}
+
+	// Delayed failure check so Recover is still attempted after an It-body
+	// failure even when leftover IBGU delete fails.
+	Expect(deleteErr).To(Succeed(), "failed to delete leftover IBGUs")
+}
+
+// shouldRecoverAfterFailedSpec reports whether AfterEach should run Recover.
+// Recover is skipped when the spec passed, or when it failed in setup before
+// the It body ran.
+func shouldRecoverAfterFailedSpec() bool {
+	report := CurrentSpecReport()
+	if !report.Failed() {
+		return false
+	}
+
+	if report.Failure.FailureNodeType.Is(setupNodeTypes) {
+		By("Skipping Recover because the spec failed in " +
+			report.Failure.FailureNodeType.String() + " before entering the It body")
+
+		return false
+	}
+
+	return true
+}
+
+// leaveSuccessfulUpgrade reports whether Recover must not roll back a completed
+// Upgrade. That is only true after 68954 passed and before Ordered test 69058
+// runs; a failed 69058 or any independent spec must still recover to Idle.
+func leaveSuccessfulUpgrade() bool {
+	if !cnfibuvalidations.UpgradeSucceeded {
+		return false
+	}
+
+	return CurrentSpecReport().LeafNodeText != tsparams.SpecRollbackSuccessfulUpgrade
+}

--- a/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/prep-abort-test.go
+++ b/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/prep-abort-test.go
@@ -5,11 +5,10 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/ibgu"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/lca"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	ibguv1alpha1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/imagebasedgroupupgrades/v1alpha1"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfclusterinfo"
-	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfhelper"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/upgrade-talm/internal/tsparams"
 )
 
@@ -17,48 +16,51 @@ var _ = Describe(
 	"Performing upgrade prep abort flow",
 	Label(tsparams.LabelPrepAbortFlow), func() {
 		BeforeEach(func() {
-			By("Fetching target sno cluster name", func() {
-				err := cnfclusterinfo.PreUpgradeClusterInfo.SaveClusterInfo()
-				Expect(err).ToNot(HaveOccurred(), "Failed to extract target sno cluster name")
+			By("Ensuring the spoke IBU is Idle and ready for Prep")
 
-				tsparams.TargetSnoClusterName = cnfclusterinfo.PreUpgradeClusterInfo.Name
+			Expect(cnfhelper.EnsureSpokeReadyForNextIbgu()).To(Succeed(),
+				"spoke IBU was not Idle with Prep in validNextStages before prep abort")
 
-				ibu, err = lca.PullImageBasedUpgrade(cnfinittools.TargetSNOAPIClient)
-				Expect(err).NotTo(HaveOccurred(), "error pulling ibu resource from cluster")
-			})
+			By("Fetching target sno cluster name")
+
+			err := cnfclusterinfo.PreUpgradeClusterInfo.SaveClusterInfo()
+			Expect(err).ToNot(HaveOccurred(), "Failed to extract target sno cluster name")
+
+			tsparams.TargetSnoClusterName = cnfclusterinfo.PreUpgradeClusterInfo.Name
 		})
 
 		AfterEach(func() {
-			By("Deleting IBGU on target hub cluster", func() {
-				_, err := ibgu.NewIbguBuilder(cnfinittools.TargetHubAPIClient,
-					tsparams.IbguName, tsparams.IbguNamespace).DeleteAndWait(1 * time.Minute)
-
-				Expect(err).ToNot(HaveOccurred(), "Failed to delete prep-upgrade ibgu on target hub cluster")
-			})
-			// Sleep for 10 seconds to allow talm to reconcile state.
-			// Sometimes if the next test re-creates the IBGUs too quickly,
-			// the policies compliance status is not updated correctly.
-			time.Sleep(10 * time.Second)
+			deleteIbgusAndRecoverIfFailed()
 		})
 
+		// 68956 - Upgrade prep abort flow
 		It("Upgrade prep abort flow", reportxml.ID("68956"), func() {
-			By("Creating IBGU and monitoring IBU status to report completed", func() {
-				newIbguBuilder := ibgu.NewIbguBuilder(cnfinittools.TargetHubAPIClient,
-					tsparams.IbguName, tsparams.IbguNamespace).
-					WithClusterLabelSelectors(tsparams.ClusterLabelSelector).
-					WithOadpContent(cnfinittools.CNFConfig.IbguOadpCmName, cnfinittools.CNFConfig.IbguOadpCmNamespace).
-					WithSeedImageRef(cnfinittools.CNFConfig.IbguSeedImage, cnfinittools.CNFConfig.IbguSeedImageVersion).
-					WithPlan([]string{"Prep"}, 20, 20).
-					WithPlan([]string{"Abort"}, 20, 20)
+			By("Creating Prep+Abort IBGU")
 
-				newIbguBuilder, err = newIbguBuilder.Create()
-				Expect(err).ToNot(HaveOccurred(), "Failed to create IBGU")
+			prepAbortIbgu, err := cnfhelper.NewIbgu(tsparams.IbguName).
+				WithPlan([]string{ibguv1alpha1.Prep}, 20, 20).
+				WithPlan([]string{ibguv1alpha1.Abort}, 20, 20).
+				Create()
+			Expect(err).ToNot(HaveOccurred(), "Failed to create IBGU")
 
-				_, err = ibu.WaitUntilStageComplete("Prep")
-				Expect(err).NotTo(HaveOccurred(), "error waiting for prep stage to complete")
+			By("Waiting until spoke IBU Prep completes")
 
-				_, err = newIbguBuilder.WaitUntilComplete(time.Minute * 10)
-				Expect(err).ToNot(HaveOccurred(), "error waiting for IBGU  complete")
-			})
+			Expect(cnfhelper.WaitForSpokeIBU(cnfhelper.SpokePrepCompleted, 20*time.Minute)).To(Succeed(),
+				"Prep did not complete on the spoke IBU")
+
+			By("Waiting until spoke IBU returns to Idle")
+
+			Expect(cnfhelper.WaitForSpokeIBU(cnfhelper.SpokeIdle, 10*time.Minute)).To(Succeed(),
+				"spoke IBU did not return to Idle after Abort")
+
+			By("Waiting until Prep+Abort IBGU completes")
+
+			Expect(cnfhelper.WaitForIbgu(prepAbortIbgu, cnfhelper.IbguCompleted, 10*time.Minute)).To(Succeed(),
+				"Prep+Abort IBGU did not complete")
+
+			By("Waiting until the spoke is healthy after prep abort")
+
+			Expect(cnfhelper.WaitUntilHealthy(cnfhelper.DefaultHealthTimeout)).To(Succeed(),
+				"spoke cluster was not healthy after prep abort")
 		})
 	})

--- a/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/rollback-after-failed-upgrade-test.go
+++ b/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/rollback-after-failed-upgrade-test.go
@@ -6,251 +6,173 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/ibgu"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/lca"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	ibguv1alpha1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/imagebasedgroupupgrades/v1alpha1"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/cluster"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfclusterinfo"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfhelper"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfinittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/upgrade-talm/internal/tsparams"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/internal/nodestate"
-	"k8s.io/klog/v2"
-)
-
-var (
-	ibu              *lca.ImageBasedUpgradeBuilder
-	seedImageVersion string
-	err              error
 )
 
 var _ = Describe(
 	"Validating rollback stage after a failed upgrade",
 	Label(tsparams.LabelRollbackFlow), func() {
 		BeforeEach(func() {
-			By("Saving target sno cluster info before the test", func() {
-				err := cnfclusterinfo.PreUpgradeClusterInfo.SaveClusterInfo()
-				Expect(err).NotTo(HaveOccurred(), "Failed to collect and save target sno cluster info before the test")
-			})
+			By("Ensuring the spoke IBU is Idle and ready for Prep")
 
-			By("Fetching target sno cluster name", func() {
-				err = cnfclusterinfo.PreUpgradeClusterInfo.SaveClusterInfo()
-				Expect(err).NotTo(HaveOccurred(), "Failed to extract target sno cluster name")
+			Expect(cnfhelper.EnsureSpokeReadyForNextIbgu()).To(Succeed(),
+				"spoke IBU was not Idle with Prep in validNextStages before auto-rollback")
 
-				tsparams.TargetSnoClusterName = cnfclusterinfo.PreUpgradeClusterInfo.Name
-			})
+			By("Saving target sno cluster info before the test")
 
-			By("Retrieve seed image version and updating LCA init-monitor watchdog timer ", func() {
-				ibu, err = lca.PullImageBasedUpgrade(TargetSNOAPIClient)
-				Expect(err).NotTo(HaveOccurred(), "error pulling ibu resource from cluster")
-			})
+			err := cnfclusterinfo.PreUpgradeClusterInfo.SaveClusterInfo()
+			Expect(err).NotTo(HaveOccurred(), "Failed to collect and save target sno cluster info before the test")
+
+			tsparams.TargetSnoClusterName = cnfclusterinfo.PreUpgradeClusterInfo.Name
 		})
 
 		AfterEach(func() {
-			By("Deleting IBGU on target hub cluster", func() {
-				newIbguBuilder := ibgu.NewIbguBuilder(TargetHubAPIClient,
-					tsparams.IbguName, tsparams.IbguNamespace).
-					WithClusterLabelSelectors(tsparams.ClusterLabelSelector).
-					WithSeedImageRef(CNFConfig.IbguSeedImage, CNFConfig.IbguSeedImageVersion).
-					WithOadpContent(CNFConfig.IbguOadpCmName, CNFConfig.IbguOadpCmNamespace).
-					WithPlan([]string{"Prep", "Upgrade"}, 5, 30)
-
-				_, err = newIbguBuilder.DeleteAndWait(1 * time.Minute)
-				Expect(err).ToNot(HaveOccurred(), "Failed to delete prep-upgrade ibgu on target hub cluster")
-
-				// Check if IBU is already Idle after auto-rollback
-				ibu, err = lca.PullImageBasedUpgrade(TargetSNOAPIClient)
-				Expect(err).ToNot(HaveOccurred(), "Failed to pull IBU resource")
-
-				// Check the Idle condition status
-				isIdle := false
-
-				for _, condition := range ibu.Object.Status.Conditions {
-					if condition.Type == "Idle" && condition.Status == "True" {
-						isIdle = true
-
-						break
-					}
-				}
-
-				// Only create abort IBGU if not already Idle
-				if !isIdle {
-					abortIbguBuilder := ibgu.NewIbguBuilder(TargetHubAPIClient, "abortibgu", tsparams.IbguNamespace).
-						WithClusterLabelSelectors(tsparams.ClusterLabelSelector).
-						WithSeedImageRef(CNFConfig.IbguSeedImage, CNFConfig.IbguSeedImageVersion).
-						WithPlan([]string{"Abort"}, 5, 10)
-
-					abortIbguBuilder, err = abortIbguBuilder.Create()
-					Expect(err).ToNot(HaveOccurred(), "Failed to create abort Ibgu.")
-
-					_, err = abortIbguBuilder.WaitUntilComplete(5 * time.Minute)
-					Expect(err).NotTo(HaveOccurred(), "abort IBGU did not complete in time.")
-
-					_, err = abortIbguBuilder.DeleteAndWait(1 * time.Minute)
-					Expect(err).ToNot(HaveOccurred(), "Failed to delete abort ibgu on target hub cluster")
-				} else {
-					klog.V(100).Infof("IBU already in Idle stage after auto-rollback, skipping abort IBGU")
-				}
-
-				// Sleep for 10 seconds to allow talm to reconcile state.
-				// Sometimes if the next test re-creates the IBGUs too quickly,
-				// the policies compliance status is not updated correctly.
-				time.Sleep(10 * time.Second)
-			})
-
-			By("Creating, enabling ibu finalize", func() {
-				_, err = ibu.WaitUntilStageComplete("Idle")
-				Expect(err).NotTo(HaveOccurred(), "error waiting for idle stage to complete")
-			})
-
-			// Sleep for 10 seconds to allow talm to reconcile state.
-			// Sometimes if the next test re-creates the CGUs too quickly,
-			// the policies compliance status is not updated correctly.
-			time.Sleep(10 * time.Second)
+			deleteIbgusAndRecoverIfFailed()
 		})
 
+		// 69054 - Rollback after a failed upgrade
 		It("Rollback after a failed upgrade", reportxml.ID("69054"), func() {
-			By("Creating Prep->Upgrade->FinalizeUpgrae IBGU and waiting for node rebooted into stateroot B", func() {
-				newIbguBuilder := ibgu.NewIbguBuilder(TargetHubAPIClient,
-					tsparams.IbguName, tsparams.IbguNamespace).
-					WithClusterLabelSelectors(tsparams.ClusterLabelSelector).
-					WithSeedImageRef(CNFConfig.IbguSeedImage, CNFConfig.IbguSeedImageVersion).
-					WithOadpContent(CNFConfig.IbguOadpCmName, CNFConfig.IbguOadpCmNamespace).
-					WithAutoRollbackOnFailure(300).
-					WithPlan([]string{"Prep"}, 20, 20).
-					WithPlan([]string{"Upgrade"}, 20, 20).
-					WithPlan([]string{"FinalizeUpgrade"}, 20, 20)
+			By("Creating Prep->Upgrade->FinalizeUpgrade IBGU with auto-rollback on failure")
 
-				_, err = newIbguBuilder.Create()
-				Expect(err).ToNot(HaveOccurred(), "Failed to create IBGU")
+			_, err := cnfhelper.NewIbgu(tsparams.IbguName).
+				WithAutoRollbackOnFailure(300).
+				WithPlan([]string{ibguv1alpha1.Prep}, 20, 20).
+				WithPlan([]string{ibguv1alpha1.Upgrade}, 20, 20).
+				WithPlan([]string{ibguv1alpha1.FinalizeUpgrade}, 20, 20).
+				Create()
+			Expect(err).ToNot(HaveOccurred(), "Failed to create IBGU")
 
-				By("Get list of node to be upgraded")
+			By("Get list of node to be upgraded")
 
-				ibuNode, err := nodes.List(TargetSNOAPIClient)
-				Expect(err).NotTo(HaveOccurred(), "error listing node")
+			ibuNodes, err := nodes.List(TargetSNOAPIClient)
+			Expect(err).NotTo(HaveOccurred(), "error listing node")
 
-				By("Wait until Prep stage is completed")
+			By("Waiting until spoke IBU Prep completes")
 
-				_, err = ibu.WaitUntilStageComplete("Prep")
-				Expect(err).NotTo(HaveOccurred(), "error waiting for prep stage to complete")
+			Expect(cnfhelper.WaitForSpokeIBU(cnfhelper.SpokePrepCompleted, 20*time.Minute)).To(Succeed(),
+				"Prep did not complete on the spoke IBU")
 
-				By("Wait for node to become unreachable")
+			waitNodesUnreachable(ibuNodes)
+			waitNodesAPIReachable(ibuNodes)
+			waitIBUAvailable()
+			waitBootedIntoStaterootB()
 
-				for _, node := range ibuNode {
-					kubeAPIUnreachable, err := nodestate.WaitForNodeToBeUnreachable(node.Object.Name, "6443", time.Minute*10)
+			By("Simulate a fault to make upgrade fail")
 
-					Expect(err).To(BeNil(), "error waiting for %s kube-api to become unreachable", node.Object.Name)
-					Expect(kubeAPIUnreachable).To(BeTrue(), "error: kube-api %s is still reachable", node.Object.Name)
+			faultInjectCmd := "echo a > /etc/mco/proxy.env"
+			_, err = cluster.ExecCmdWithStdout(TargetSNOAPIClient, faultInjectCmd)
+			Expect(err).NotTo(HaveOccurred(), "could not execute fault injection command")
 
-					unreachable, err := nodestate.WaitForNodeToBeUnreachable(node.Object.Name, "22", time.Minute*10)
+			By("Verifying auto rollback triggered upon upgrade failure")
 
-					Expect(err).To(BeNil(), "error waiting for %s node to shutdown", node.Object.Name)
-					Expect(unreachable).To(BeTrue(), "error: node %s is still reachable", node.Object.Name)
-				}
+			waitNodesUnreachable(ibuNodes)
+			waitNodesAPIReachable(ibuNodes)
+			waitIBUAvailable()
 
-				By("Wait for node to become reachable")
+			By("Waiting until spoke IBU reports UpgradeFailed")
 
-				for _, node := range ibuNode {
-					reachable, err := nodestate.WaitForNodeToBeReachable(node.Object.Name, "6443", time.Minute*30)
+			Expect(cnfhelper.WaitForSpokeIBU(cnfhelper.SpokeUpgradeFailed, 30*time.Minute)).To(Succeed(),
+				"spoke IBU did not report UpgradeFailed after auto-rollback")
 
-					Expect(err).To(BeNil(), "error waiting for %s node to become reachable", node.Object.Name)
-					Expect(reachable).To(BeTrue(), "error: node %s is still unreachable", node.Object.Name)
-				}
+			By("Saving target sno cluster info after the test")
 
-				By("Wait for IBU resource to be available")
+			err = cnfclusterinfo.PostUpgradeClusterInfo.SaveClusterInfo()
+			Expect(err).NotTo(HaveOccurred(), "Failed to collect and save target sno cluster info after the test")
 
-				err = nodestate.WaitForIBUToBeAvailable(TargetSNOAPIClient, ibu, time.Minute*15)
-				Expect(err).NotTo(HaveOccurred(), "error waiting for ibu resource to become available")
-			})
+			By("Validating target sno cluster version after auto rollback")
 
-			By("Verifying booted stateroot name on target sno cluster node", func() {
-				ibu, err = lca.PullImageBasedUpgrade(TargetSNOAPIClient)
-				Expect(err).NotTo(HaveOccurred(), "error pulling ibu resource from cluster")
+			Expect(cnfclusterinfo.PreUpgradeClusterInfo.Version).
+				To(Equal(cnfclusterinfo.PostUpgradeClusterInfo.Version),
+					"Target sno cluster reports old cluster version")
 
-				seedImageVersion = ibu.Definition.Spec.SeedImageRef.Version
+			By("Creating abort IBGU after auto-rollback")
 
-				var seedVersionFound bool
+			abortIbgu, err := cnfhelper.NewIbgu(tsparams.AbortIbguName).
+				WithPlan([]string{ibguv1alpha1.Abort}, 5, 10).
+				Create()
+			Expect(err).ToNot(HaveOccurred(), "Failed to create abort Ibgu.")
 
-				retries := 3
+			By("Waiting until spoke IBU returns to Idle")
 
-				// retry 3 times to get the stateroot name
-				for attempt := 1; attempt <= retries; attempt++ {
-					getDeploymentIndexCmd := "rpm-ostree status --json | jq '.deployments[0].osname'"
-					getDesiredStaterootName, err := cluster.ExecCmdWithStdout(TargetSNOAPIClient, getDeploymentIndexCmd)
-					Expect(err).NotTo(HaveOccurred(), "could not execute command: %s", err)
+			Expect(cnfhelper.WaitForSpokeIBU(cnfhelper.SpokeIdle, 10*time.Minute)).To(Succeed(),
+				"spoke IBU did not return to Idle after Abort")
 
-					for _, stdout := range getDesiredStaterootName {
-						bootedStaterootNameRes := strings.ReplaceAll(stdout, "_", "-")
-						if bootedStaterootNameRes != "" {
-							if strings.Contains(bootedStaterootNameRes, seedImageVersion) {
-								klog.V(100).Infof("Found "+seedImageVersion+" in %s", bootedStaterootNameRes)
+			By("Waiting until abort IBGU completes")
 
-								seedVersionFound = true
+			Expect(cnfhelper.WaitForIbgu(abortIbgu, cnfhelper.IbguCompleted, 10*time.Minute)).To(Succeed(),
+				"abort IBGU did not complete")
 
-								break
-							}
-						}
-					}
+			By("Waiting until the spoke is healthy after auto-rollback")
 
-					if seedVersionFound {
-						break
-					}
-
-					if attempt < retries {
-						time.Sleep(time.Second * 5) // Wait for 5 seconds before retrying
-					}
-				}
-
-				Expect(seedVersionFound).To(BeTrue(), "Target cluster node booted into stateroot B")
-			})
-
-			By("Simulate a fault to make upgrade fail", func() {
-				faultInjectCmd := "echo a > /etc/mco/proxy.env"
-				faultInjectCmdRes, err := cluster.ExecCmdWithStdout(TargetSNOAPIClient, faultInjectCmd)
-				Expect(err).NotTo(HaveOccurred(), "could not execute command: %s", faultInjectCmdRes)
-			})
-
-			By("Verifying auto rollback triggered upon upgrade failure", func() {
-				By("Waiting for node rebooted into stateroot A and cluster become available", func() {
-					By("Get list of node to be upgraded")
-
-					ibuNode, err := nodes.List(TargetSNOAPIClient)
-					Expect(err).NotTo(HaveOccurred(), "error listing node")
-
-					By("Wait for node to become unreachable")
-
-					for _, node := range ibuNode {
-						unreachable, err := nodestate.WaitForNodeToBeUnreachable(node.Object.Name, "6443", time.Minute*10)
-
-						Expect(err).To(BeNil(), "error waiting for %s node to shutdown", node.Object.Name)
-						Expect(unreachable).To(BeTrue(), "error: node %s is still reachable", node.Object.Name)
-					}
-
-					By("Wait for node to become reachable")
-
-					for _, node := range ibuNode {
-						reachable, err := nodestate.WaitForNodeToBeReachable(node.Object.Name, "6443", time.Minute*30)
-
-						Expect(err).To(BeNil(), "error waiting for %s node to become reachable", node.Object.Name)
-						Expect(reachable).To(BeTrue(), "error: node %s is still unreachable", node.Object.Name)
-					}
-
-					By("Wait for IBU resource to be available")
-
-					err = nodestate.WaitForIBUToBeAvailable(TargetSNOAPIClient, ibu, time.Minute*15)
-					Expect(err).NotTo(HaveOccurred(), "error waiting for ibu resource to become available")
-				})
-			})
-
-			By("Saving target sno cluster info after the test", func() {
-				err := cnfclusterinfo.PostUpgradeClusterInfo.SaveClusterInfo()
-				Expect(err).NotTo(HaveOccurred(), "Failed to collect and save target sno cluster info after the test")
-			})
-
-			By("Validating target sno cluster version after auto rollback", func() {
-				Expect(cnfclusterinfo.PreUpgradeClusterInfo.Version).
-					To(Equal(cnfclusterinfo.PostUpgradeClusterInfo.Version),
-						"Target sno cluster reports old cluster version")
-			})
+			Expect(cnfhelper.WaitUntilHealthy(cnfhelper.DefaultHealthTimeout)).To(Succeed(),
+				"spoke cluster was not healthy after auto-rollback")
 		})
 	})
+
+// waitNodesUnreachable waits until kube-apiserver and SSH on each node are down.
+func waitNodesUnreachable(nodeList []*nodes.Builder) {
+	By("Wait for node to become unreachable")
+
+	for _, node := range nodeList {
+		kubeAPIUnreachable, err := nodestate.WaitForNodeToBeUnreachable(node.Object.Name, "6443", time.Minute*10)
+		Expect(err).To(BeNil(), "error waiting for %s kube-api to become unreachable", node.Object.Name)
+		Expect(kubeAPIUnreachable).To(BeTrue(), "error: kube-api %s is still reachable", node.Object.Name)
+
+		sshUnreachable, err := nodestate.WaitForNodeToBeUnreachable(node.Object.Name, "22", time.Minute*10)
+		Expect(err).To(BeNil(), "error waiting for %s node to shutdown", node.Object.Name)
+		Expect(sshUnreachable).To(BeTrue(), "error: node %s is still reachable", node.Object.Name)
+	}
+}
+
+// waitNodesAPIReachable waits until kube-apiserver on each node is reachable.
+func waitNodesAPIReachable(nodeList []*nodes.Builder) {
+	By("Wait for node to become reachable")
+
+	for _, node := range nodeList {
+		reachable, err := nodestate.WaitForNodeToBeReachable(node.Object.Name, "6443", time.Minute*30)
+		Expect(err).To(BeNil(), "error waiting for %s node to become reachable", node.Object.Name)
+		Expect(reachable).To(BeTrue(), "error: node %s is still unreachable", node.Object.Name)
+	}
+}
+
+// waitIBUAvailable waits until the spoke ImageBasedUpgrade CR exists after an ostree pivot.
+func waitIBUAvailable() {
+	By("Wait for IBU resource to be available")
+
+	Expect(cnfhelper.WaitUntilIBUAvailable(cnfhelper.IBUAvailableTimeout)).To(Succeed(),
+		"error waiting for ibu resource to become available")
+}
+
+// waitBootedIntoStaterootB waits until rpm-ostree reports the seed-image stateroot.
+func waitBootedIntoStaterootB() {
+	By("Waiting until the node has booted into stateroot B")
+
+	seedImageVersion := CNFConfig.IbguSeedImageVersion
+	Expect(seedImageVersion).NotTo(BeEmpty(), "seed image version is empty")
+
+	Eventually(func() bool {
+		stdoutByNode, execErr := cluster.ExecCmdWithStdout(TargetSNOAPIClient,
+			"rpm-ostree status --json | jq '.deployments[0].osname'")
+		if execErr != nil {
+			return false
+		}
+
+		for _, stdout := range stdoutByNode {
+			bootedStateroot := strings.ReplaceAll(stdout, "_", "-")
+			if strings.Contains(bootedStateroot, seedImageVersion) {
+				return true
+			}
+		}
+
+		return false
+	}, 2*time.Minute, 5*time.Second).Should(BeTrue(),
+		"Target cluster node has not booted into stateroot B (%s)", seedImageVersion)
+}

--- a/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/upgrade-abort-test.go
+++ b/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/upgrade-abort-test.go
@@ -5,89 +5,83 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/ibgu"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/lca"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	ibguv1alpha1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/imagebasedgroupupgrades/v1alpha1"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfclusterinfo"
-	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfhelper"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/upgrade-talm/internal/tsparams"
 )
 
 var _ = Describe(
 	"Validating abort at IBU upgrade stage",
 	Label(tsparams.LabelUpgradeAbortFlow), func() {
-		var abortIbguBuilder *ibgu.IbguBuilder
-
 		BeforeEach(func() {
-			By("Fetching target sno cluster name", func() {
-				err := cnfclusterinfo.PreUpgradeClusterInfo.SaveClusterInfo()
-				Expect(err).ToNot(HaveOccurred(), "Failed to extract target sno cluster name")
+			By("Ensuring the spoke IBU is Idle and ready for Prep")
 
-				tsparams.TargetSnoClusterName = cnfclusterinfo.PreUpgradeClusterInfo.Name
+			Expect(cnfhelper.EnsureSpokeReadyForNextIbgu()).To(Succeed(),
+				"spoke IBU was not Idle with Prep in validNextStages before upgrade abort")
 
-				ibu, err = lca.PullImageBasedUpgrade(cnfinittools.TargetSNOAPIClient)
-				Expect(err).NotTo(HaveOccurred(), "error pulling ibu resource from cluster")
-			})
+			By("Fetching target sno cluster name")
+
+			err := cnfclusterinfo.PreUpgradeClusterInfo.SaveClusterInfo()
+			Expect(err).ToNot(HaveOccurred(), "Failed to extract target sno cluster name")
+
+			tsparams.TargetSnoClusterName = cnfclusterinfo.PreUpgradeClusterInfo.Name
 		})
 
 		AfterEach(func() {
-			By("Deleting IBGUs on target hub cluster", func() {
-				_, err := ibgu.NewIbguBuilder(cnfinittools.TargetHubAPIClient,
-					tsparams.IbguName, tsparams.IbguNamespace).DeleteAndWait(1 * time.Minute)
-
-				Expect(err).ToNot(HaveOccurred(), "Failed to delete prep-upgrade ibgu on target hub cluster")
-
-				_, err = ibgu.NewIbguBuilder(cnfinittools.TargetHubAPIClient,
-					tsparams.AbortIbguName, tsparams.IbguNamespace).DeleteAndWait(1 * time.Minute)
-
-				Expect(err).ToNot(HaveOccurred(), "Failed to delete Abort IBGU cgu on target hub cluster")
-			})
-
-			// Sleep for 10 seconds to allow talm to reconcile state.
-			// Sometimes if the next test re-creates the IBGUs too quickly,
-			// the policies compliance status is not updated correctly.
-			time.Sleep(10 * time.Second)
+			deleteIbgusAndRecoverIfFailed()
 		})
 
+		// 69055 - Aborts an upgrade at IBU upgrade stage, before pivot.
+		// A second Abort IBGU is required: the CRD does not allow appending
+		// Abort after Prep+Upgrade. Delete the original IBGU after Abort
+		// completes so leftover TALM ManifestWorks cannot re-apply Prep
+		// during WaitUntilHealthy.
 		It("Aborts an upgrade at IBU upgrade stage", reportxml.ID("69055"), func() {
-			By("Creating an upgrade IBGU", func() {
-				newIbguBuilder := ibgu.NewIbguBuilder(cnfinittools.TargetHubAPIClient,
-					tsparams.IbguName, tsparams.IbguNamespace).
-					WithClusterLabelSelectors(tsparams.ClusterLabelSelector).
-					WithOadpContent(cnfinittools.CNFConfig.IbguOadpCmName, cnfinittools.CNFConfig.IbguOadpCmNamespace).
-					WithSeedImageRef(cnfinittools.CNFConfig.IbguSeedImage, cnfinittools.CNFConfig.IbguSeedImageVersion).
-					WithPlan([]string{"Prep"}, 20, 20).
-					WithPlan([]string{"Upgrade"}, 20, 20).
-					WithPlan([]string{"FinalizeUpgrade"}, 20, 20)
+			By("Creating Prep+Upgrade IBGU")
 
-				_, err := newIbguBuilder.Create()
-				Expect(err).ToNot(HaveOccurred(), "Failed to create IBGU")
+			_, err := cnfhelper.NewIbgu(tsparams.IbguName).
+				WithPlan([]string{ibguv1alpha1.Prep}, 20, 20).
+				WithPlan([]string{ibguv1alpha1.Upgrade}, 20, 20).
+				Create()
+			Expect(err).ToNot(HaveOccurred(), "Failed to create IBGU")
 
-				// Wait for 10 seconds to avoid upgrade and finalize CGUs getting created simultaneously.
-				time.Sleep(10 * time.Second)
-			})
+			By("Waiting until spoke IBU Prep completes")
 
-			By("Aborting the upgrade phase once prep phase has finished", func() {
-				_, err = ibu.WaitUntilStageComplete("Prep")
-				Expect(err).NotTo(HaveOccurred(), "error waiting for prep stage to complete")
+			Expect(cnfhelper.WaitForSpokeIBU(cnfhelper.SpokePrepCompleted, 20*time.Minute)).To(Succeed(),
+				"Prep did not complete on the spoke IBU")
 
-				newIbguBuilder := ibgu.NewIbguBuilder(cnfinittools.TargetHubAPIClient,
-					tsparams.AbortIbguName, tsparams.IbguNamespace).
-					WithClusterLabelSelectors(tsparams.ClusterLabelSelector).
-					WithOadpContent(cnfinittools.CNFConfig.IbguOadpCmName, cnfinittools.CNFConfig.IbguOadpCmNamespace).
-					WithSeedImageRef(cnfinittools.CNFConfig.IbguSeedImage, cnfinittools.CNFConfig.IbguSeedImageVersion).
-					WithPlan([]string{"Abort"}, 20, 20)
+			By("Waiting until spoke IBU Upgrade starts (pre-pivot)")
 
-				abortIbguBuilder, err = newIbguBuilder.Create()
-				Expect(err).ToNot(HaveOccurred(), "Failed to create IBGU")
-			})
+			Expect(cnfhelper.WaitForSpokeIBU(cnfhelper.SpokeUpgradeInProgress, 10*time.Minute)).To(Succeed(),
+				"Upgrade did not start on the spoke IBU before pivot")
 
-			By("Waiting until the IBU and IBGU have completed without errors", func() {
-				_, err = ibu.WaitUntilStageComplete("Idle")
-				Expect(err).NotTo(HaveOccurred(), "error waiting for idle stage to complete")
+			By("Creating abort IBGU")
 
-				_, err = abortIbguBuilder.WaitUntilComplete(time.Minute * 10)
-				Expect(err).ToNot(HaveOccurred(), "error waiting for IBGU  complete")
-			})
+			abortIbgu, err := cnfhelper.NewIbgu(tsparams.AbortIbguName).
+				WithPlan([]string{ibguv1alpha1.Abort}, 20, 20).
+				Create()
+			Expect(err).ToNot(HaveOccurred(), "Failed to create abort IBGU")
+
+			By("Waiting until spoke IBU returns to Idle")
+
+			Expect(cnfhelper.WaitForSpokeIBU(cnfhelper.SpokeIdle, 10*time.Minute)).To(Succeed(),
+				"spoke IBU did not return to Idle after Abort")
+
+			By("Waiting until abort IBGU completes")
+
+			Expect(cnfhelper.WaitForIbgu(abortIbgu, cnfhelper.IbguCompleted, 10*time.Minute)).To(Succeed(),
+				"Abort IBGU did not complete")
+
+			By("Deleting original Prep+Upgrade IBGU")
+
+			Expect(cnfhelper.DeleteIbgus(tsparams.IbguName)).To(Succeed(),
+				"failed to delete original IBGU after Abort")
+
+			By("Waiting until the spoke is healthy after upgrade abort")
+
+			Expect(cnfhelper.WaitUntilHealthy(cnfhelper.DefaultHealthTimeout)).To(Succeed(),
+				"spoke cluster was not healthy after upgrade abort")
 		})
 	})

--- a/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/upgrade-e2e-test.go
+++ b/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/upgrade-e2e-test.go
@@ -7,13 +7,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/ibgu"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/lca"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	ibguv1alpha1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/imagebasedgroupupgrades/v1alpha1"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfcluster"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfclusterinfo"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfhelper"
-	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfparams"
 	cnfibuvalidations "github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/validations"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/upgrade-talm/internal/tsparams"
 	"k8s.io/klog/v2"
@@ -24,110 +23,126 @@ var _ = Describe(
 	Ordered,
 	ContinueOnFailure,
 	Label(tsparams.LabelEndToEndUpgrade), func() {
-		var (
-			clusterList       []*clients.Settings
-			upgradeSuccessful = true
-		)
+		var clusterList []*clients.Settings
 
 		BeforeAll(func() {
-			// Initialize cluster list.
 			clusterList = cnfhelper.GetAllTestClients()
 
-			// Check that the required clusters are present.
 			err := cnfcluster.CheckClustersPresent(clusterList)
 			if err != nil {
 				Skip(fmt.Sprintf("error occurred validating required clusters are present: %s", err.Error()))
 			}
 
-			By("Saving target sno cluster info before upgrade", func() {
-				err := cnfclusterinfo.PreUpgradeClusterInfo.SaveClusterInfo()
-				Expect(err).ToNot(HaveOccurred(), "Failed to collect and save target sno cluster info before upgrade")
+			By("Ensuring the spoke IBU is Idle and ready for Prep, or already upgraded")
 
-				tsparams.TargetSnoClusterName = cnfclusterinfo.PreUpgradeClusterInfo.Name
+			// 69058 shares this Ordered BeforeAll. A later job that runs only
+			// 69058 finds Upgrade completed with Rollback valid, not Idle/Prep.
+			upgraded, upgradedErr := cnfhelper.HasSuccessfulUpgrade()
+			if upgradedErr == nil && upgraded {
+				cnfibuvalidations.UpgradeSucceeded = true
+			} else {
+				Expect(cnfhelper.EnsureSpokeReadyForNextIbgu()).To(Succeed(),
+					"spoke IBU was not Idle with Prep in validNextStages before upgrade")
+			}
 
-				ibu, err = lca.PullImageBasedUpgrade(cnfinittools.TargetSNOAPIClient)
-				Expect(err).NotTo(HaveOccurred(), "error pulling ibu resource from cluster")
-			})
+			By("Saving target sno cluster info before upgrade")
+
+			err = cnfclusterinfo.PreUpgradeClusterInfo.SaveClusterInfo()
+			Expect(err).ToNot(HaveOccurred(), "Failed to collect and save target sno cluster info before upgrade")
+
+			tsparams.TargetSnoClusterName = cnfclusterinfo.PreUpgradeClusterInfo.Name
 		})
 
 		AfterEach(func() {
-			By("Deleting IBGUs on target hub cluster", func() {
-				_, err := ibgu.NewIbguBuilder(cnfinittools.TargetHubAPIClient,
-					tsparams.IbguName, tsparams.IbguNamespace).DeleteAndWait(1 * time.Minute)
-
-				Expect(err).ToNot(HaveOccurred(), "Failed to delete ibgu on target hub cluster")
-			})
-
-			// Sleep for 10 seconds to allow talm to reconcile state.
-			// Sometimes if the next test re-creates the IBGUs too quickly,
-			// the policies compliance status is not updated correctly.
-			time.Sleep(10 * time.Second)
+			deleteIbgusAndRecoverIfFailed()
 		})
 
+		AfterAll(func() {
+			cnfibuvalidations.UpgradeSucceeded = false
+		})
+
+		// 68954 - Upgrade end to end
 		It("Upgrade end to end", reportxml.ID("68954"), func() {
-			upgradeSuccessful = false
+			By("Creating Prep+Upgrade IBGU")
 
-			By("Create Upgrade IBGU", func() {
-				newIbguBuilder := ibgu.NewIbguBuilder(cnfinittools.TargetHubAPIClient,
-					tsparams.IbguName, tsparams.IbguNamespace).
-					WithClusterLabelSelectors(tsparams.ClusterLabelSelector).
-					WithSeedImageRef(cnfinittools.CNFConfig.IbguSeedImage, cnfinittools.CNFConfig.IbguSeedImageVersion).
-					WithOadpContent(cnfinittools.CNFConfig.IbguOadpCmName, cnfinittools.CNFConfig.IbguOadpCmNamespace).
-					WithPlan([]string{"Prep", "Upgrade"}, 5, 30)
+			upgradeStart := time.Now()
 
-				upgradeStart := time.Now()
+			upgradeIbgu, err := cnfhelper.NewIbgu(tsparams.IbguName).
+				WithPlan([]string{ibguv1alpha1.Prep, ibguv1alpha1.Upgrade}, 5, 30).
+				Create()
+			Expect(err).ToNot(HaveOccurred(), "Failed to create upgrade Ibgu.")
 
-				newIbguBuilder, err := newIbguBuilder.Create()
-				Expect(err).ToNot(HaveOccurred(), "Failed to create upgrade Ibgu.")
+			By("Waiting until spoke IBU Prep completes")
 
-				_, err = newIbguBuilder.WaitUntilComplete(30 * time.Minute)
-				Expect(err).NotTo(HaveOccurred(), "Prep and Upgrade IBGU did not complete in time.")
+			Expect(cnfhelper.WaitForSpokeIBU(cnfhelper.SpokePrepCompleted, 20*time.Minute)).To(Succeed(),
+				"Prep did not complete on the spoke IBU")
 
-				upgradeDuration := time.Since(upgradeStart)
-				By(fmt.Sprintf("Upgrade (Prep+Upgrade) completed in %v", upgradeDuration))
-				klog.Infof("IBU upgrade duration (Prep+Upgrade): %v", upgradeDuration)
-			})
+			By("Waiting until spoke IBU Upgrade completes")
 
-			By("Saving target sno cluster info after upgrade", func() {
-				err := cnfclusterinfo.PostUpgradeClusterInfo.SaveClusterInfo()
-				Expect(err).ToNot(HaveOccurred(), "Failed to collect and save target sno cluster info after upgrade")
-			})
+			Expect(cnfhelper.WaitForSpokeIBU(cnfhelper.SpokeUpgradeCompleted, 30*time.Minute)).To(Succeed(),
+				"Upgrade did not complete on the spoke IBU")
 
-			upgradeSuccessful = true
+			By("Waiting until Prep+Upgrade IBGU completes")
+
+			Expect(cnfhelper.WaitForIbgu(upgradeIbgu, cnfhelper.IbguCompleted, 10*time.Minute)).To(Succeed(),
+				"Prep and Upgrade IBGU did not complete")
+
+			upgradeDuration := time.Since(upgradeStart)
+			By(fmt.Sprintf("Upgrade (Prep+Upgrade) completed in %v", upgradeDuration))
+			klog.V(cnfparams.CNFLogLevel).Infof("IBU upgrade duration (Prep+Upgrade): %v", upgradeDuration)
+
+			By("Saving target sno cluster info after upgrade")
+
+			err = cnfclusterinfo.PostUpgradeClusterInfo.SaveClusterInfo()
+			Expect(err).ToNot(HaveOccurred(), "Failed to collect and save target sno cluster info after upgrade")
+
+			By("Waiting until the spoke is healthy after upgrade")
+
+			Expect(cnfhelper.WaitUntilHealthy(cnfhelper.DefaultHealthTimeout)).To(Succeed(),
+				"spoke cluster was not healthy after upgrade")
+
+			cnfibuvalidations.UpgradeSucceeded = true
 		})
 
-		if upgradeSuccessful {
-			cnfibuvalidations.PostUpgradeValidations()
-		}
+		cnfibuvalidations.PostUpgradeValidations()
 
-		It("Rollback successful upgrade", reportxml.ID("69058"), func() {
-			if !upgradeSuccessful {
-				Skip("Skipping rollback test due to upgrade failure.")
+		// 69058 - Rollback successful upgrade
+		It(tsparams.SpecRollbackSuccessfulUpgrade, reportxml.ID("69058"), func() {
+			if !cnfibuvalidations.UpgradeSucceeded {
+				Skip("Rollback test 69058 requires a successful 68954 upgrade")
 			}
 
-			By("Creating an IBGU to rollback upgrade", func() {
-				rollbackIbguBuilder := ibgu.NewIbguBuilder(cnfinittools.TargetHubAPIClient,
-					tsparams.IbguName, tsparams.IbguNamespace)
-				rollbackIbguBuilder = rollbackIbguBuilder.WithClusterLabelSelectors(tsparams.ClusterLabelSelector)
-				rollbackIbguBuilder = rollbackIbguBuilder.WithSeedImageRef(
-					cnfinittools.CNFConfig.IbguSeedImage,
-					cnfinittools.CNFConfig.IbguSeedImageVersion)
-				rollbackIbguBuilder = rollbackIbguBuilder.WithOadpContent(
-					cnfinittools.CNFConfig.IbguOadpCmName,
-					cnfinittools.CNFConfig.IbguOadpCmNamespace)
-				rollbackIbguBuilder = rollbackIbguBuilder.WithPlan([]string{"Rollback", "FinalizeRollback"}, 5, 30)
+			By("Creating Rollback+FinalizeRollback IBGU")
 
-				rollbackStart := time.Now()
+			rollbackStart := time.Now()
 
-				rollbackIbguBuilder, err = rollbackIbguBuilder.Create()
-				Expect(err).ToNot(HaveOccurred(), "Failed to create rollback Ibgu.")
+			rollbackIbgu, err := cnfhelper.NewIbgu(tsparams.IbguName).
+				WithPlan([]string{ibguv1alpha1.Rollback, ibguv1alpha1.FinalizeRollback}, 5, 30).
+				Create()
+			Expect(err).ToNot(HaveOccurred(), "Failed to create rollback Ibgu.")
 
-				_, err = rollbackIbguBuilder.WaitUntilComplete(30 * time.Minute)
-				Expect(err).NotTo(HaveOccurred(), "Rollback IBGU did not complete in time.")
+			By("Waiting until spoke IBU Rollback completes")
 
-				rollbackDuration := time.Since(rollbackStart)
-				By(fmt.Sprintf("Rollback (Rollback+FinalizeRollback) completed in %v", rollbackDuration))
-				klog.Infof("IBU rollback duration (Rollback+FinalizeRollback): %v", rollbackDuration)
-			})
+			Expect(cnfhelper.WaitForSpokeIBU(cnfhelper.SpokeRollbackCompleted, 30*time.Minute)).To(Succeed(),
+				"Rollback did not complete on the spoke IBU")
+
+			By("Waiting until spoke IBU returns to Idle")
+
+			Expect(cnfhelper.WaitForSpokeIBU(cnfhelper.SpokeIdle, 10*time.Minute)).To(Succeed(),
+				"spoke IBU did not return to Idle after FinalizeRollback")
+
+			By("Waiting until Rollback IBGU completes")
+
+			Expect(cnfhelper.WaitForIbgu(rollbackIbgu, cnfhelper.IbguCompleted, 10*time.Minute)).To(Succeed(),
+				"Rollback IBGU did not complete")
+
+			rollbackDuration := time.Since(rollbackStart)
+			By(fmt.Sprintf("Rollback (Rollback+FinalizeRollback) completed in %v", rollbackDuration))
+			klog.V(cnfparams.CNFLogLevel).Infof("IBU rollback duration (Rollback+FinalizeRollback): %v", rollbackDuration)
+
+			By("Waiting until the spoke is healthy after rollback")
+
+			Expect(cnfhelper.WaitUntilHealthy(cnfhelper.DefaultHealthTimeout)).To(Succeed(),
+				"spoke cluster was not healthy after rollback")
 		})
 	})

--- a/tests/lca/imagebasedupgrade/cnf/upgrade-talm/upgrade_suite_test.go
+++ b/tests/lca/imagebasedupgrade/cnf/upgrade-talm/upgrade_suite_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/reporter"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfhelper"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/upgrade-talm/internal/tsparams"
 	_ "github.com/rh-ecosystem-edge/eco-gotests/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests"
 )
@@ -39,6 +40,14 @@ var _ = BeforeSuite(func() {
 	if TargetSNOAPIClient == nil {
 		Skip("Cannot run test suite when target sno cluster has nil api client")
 	}
+
+	By("Waiting until the spoke cluster is healthy")
+
+	// Fresh deployment often still have ClusterOperators progressing. Wait once
+	// here so the first spec's fail-fast BeforeEach does not fail immediately.
+	// Do not wait in BeforeEach: that would delay cascaded failures.
+	Expect(cnfhelper.WaitUntilHealthy(cnfhelper.DefaultHealthTimeout)).To(Succeed(),
+		"spoke cluster was not healthy before the suite")
 })
 
 var _ = ReportAfterSuite("", func(report Report) {

--- a/vendor/github.com/rh-ecosystem-edge/eco-goinfra/pkg/certificate/signingrequest.go
+++ b/vendor/github.com/rh-ecosystem-edge/eco-goinfra/pkg/certificate/signingrequest.go
@@ -1,0 +1,177 @@
+package certificate
+
+import (
+	"fmt"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SigningRequestBuilder provides a struct for CertificateSigningRequest resource containing a connection to the cluster
+// and the CertificateSigningRequest definition.
+type SigningRequestBuilder struct {
+	// SigningRequest definition, used to create the signing request object.
+	Definition *certificatesv1.CertificateSigningRequest
+	// Created signing request object on cluster.
+	Object *certificatesv1.CertificateSigningRequest
+	// apiClient to interact with the cluster.
+	apiClient runtimeclient.Client
+}
+
+// PullSigningRequest loads an existing signing request into SigningRequestBuilder struct.
+func PullSigningRequest(apiClient *clients.Settings, name string) (*SigningRequestBuilder, error) {
+	klog.V(100).Infof("Pulling existing CertificateSigningRequest with name %s", name)
+
+	if apiClient == nil {
+		klog.V(100).Info("CertificateSigningRequest apiClient cannot be nil")
+
+		return nil, fmt.Errorf("certificateSigniingRequest apiClient cannot be nil")
+	}
+
+	err := apiClient.AttachScheme(certificatesv1.AddToScheme)
+	if err != nil {
+		klog.V(100).Info("Failed to add certificates v1 scheme to client schemes")
+
+		return nil, err
+	}
+
+	builder := &SigningRequestBuilder{
+		apiClient: apiClient.Client,
+		Definition: &certificatesv1.CertificateSigningRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		},
+	}
+
+	if name == "" {
+		klog.V(100).Info("The name of the CertificateSigningRequest is empty")
+
+		return nil, fmt.Errorf("certificateSigningRequest 'name' cannot be empty")
+	}
+
+	if !builder.Exists() {
+		klog.V(100).Infof("CertificateSigningRequest %s does not exist", name)
+
+		return nil, fmt.Errorf("certificateSigningRequest %s does not exist", name)
+	}
+
+	builder.Definition = builder.Object
+
+	return builder, nil
+}
+
+// Get returns the CertificateSigningRequest object if found.
+func (builder *SigningRequestBuilder) Get() (*certificatesv1.CertificateSigningRequest, error) {
+	if valid, err := builder.validate(); !valid {
+		return nil, err
+	}
+
+	klog.V(100).Infof("Collecting CertificateSigningRequest object %s", builder.Definition.Name)
+
+	signingRequest := &certificatesv1.CertificateSigningRequest{}
+
+	err := builder.apiClient.Get(logging.DiscardContext(), runtimeclient.ObjectKey{
+		Name: builder.Definition.Name,
+	}, signingRequest)
+	if err != nil {
+		klog.V(100).Infof("Failed to get CertificateSigningRequest object %s: %v", builder.Definition.Name, err)
+
+		return nil, err
+	}
+
+	return signingRequest, nil
+}
+
+// Exists checks whether the given CertificateSigningRequest object exists.
+func (builder *SigningRequestBuilder) Exists() bool {
+	if valid, _ := builder.validate(); !valid {
+		return false
+	}
+
+	klog.V(100).Infof("Checking if CertificateSigningRequest %s exists", builder.Definition.Name)
+
+	var err error
+
+	builder.Object, err = builder.Get()
+
+	return err == nil || !k8serrors.IsNotFound(err)
+}
+
+// Create creates a new CertificateSigningRequest object if it does not exist.
+func (builder *SigningRequestBuilder) Create() (*SigningRequestBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	klog.V(100).Infof("Creating CertificateSigningRequest %s", builder.Definition.Name)
+
+	if builder.Exists() {
+		return builder, nil
+	}
+
+	err := builder.apiClient.Create(logging.DiscardContext(), builder.Definition)
+	if err != nil {
+		return builder, err
+	}
+
+	builder.Object = builder.Definition
+
+	return builder, nil
+}
+
+// Delete removes a CertificateSigningRequest object from the cluster if it exists.
+func (builder *SigningRequestBuilder) Delete() error {
+	if valid, err := builder.validate(); !valid {
+		return err
+	}
+
+	klog.V(100).Infof("Deleting CertificateSigningRequest %s", builder.Definition.Name)
+
+	if !builder.Exists() {
+		klog.V(100).Infof("CertificateSigningRequest %s does not exist", builder.Definition.Name)
+
+		builder.Object = nil
+
+		return nil
+	}
+
+	err := builder.apiClient.Delete(logging.DiscardContext(), builder.Definition)
+	if err != nil {
+		return err
+	}
+
+	builder.Object = nil
+
+	return nil
+}
+
+func (builder *SigningRequestBuilder) validate() (bool, error) {
+	resourceCRD := "certificateSigningRequest"
+
+	if builder == nil {
+		klog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
+
+		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
+	}
+
+	if builder.Definition == nil {
+		klog.V(100).Infof("The %s is undefined", resourceCRD)
+
+		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceCRD))
+	}
+
+	if builder.apiClient == nil {
+		klog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
+
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
+	}
+
+	return true, nil
+}

--- a/vendor/github.com/rh-ecosystem-edge/eco-goinfra/pkg/certificate/signingrequestlist.go
+++ b/vendor/github.com/rh-ecosystem-edge/eco-goinfra/pkg/certificate/signingrequestlist.go
@@ -1,0 +1,124 @@
+package certificate
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ListSigningRequests returns a list of all CertificateSigningRequest objects in the cluster with the provided options.
+func ListSigningRequests(
+	apiClient *clients.Settings, options ...runtimeclient.ListOptions) ([]*SigningRequestBuilder, error) {
+	if apiClient == nil {
+		klog.V(100).Info("CertificateSigningRequest 'apiClient' cannot be nil")
+
+		return nil, fmt.Errorf("certificateSigningRequest 'apiClient' cannot be nil")
+	}
+
+	err := apiClient.AttachScheme(certificatesv1.AddToScheme)
+	if err != nil {
+		klog.V(100).Info("Failed to add certificates v1 scheme to client schemes")
+
+		return nil, err
+	}
+
+	if len(options) > 1 {
+		klog.V(100).Info("Only one ListOptions object can be provided to ListSigningRequests")
+
+		return nil, fmt.Errorf("error: more than one ListOptions was passed")
+	}
+
+	logMessage := "Listing all CertificateSigningRequests"
+	passedOptions := runtimeclient.ListOptions{}
+
+	if len(options) == 1 {
+		passedOptions = options[0]
+		logMessage += fmt.Sprintf(" with options: %v", passedOptions)
+	}
+
+	klog.V(100).Info(logMessage)
+
+	csrList := new(certificatesv1.CertificateSigningRequestList)
+
+	err = apiClient.List(logging.DiscardContext(), csrList, &passedOptions)
+	if err != nil {
+		klog.V(100).Infof("Failed to list CertificateSigningRequests: %v", err)
+
+		return nil, err
+	}
+
+	var signingRequestBuilders []*SigningRequestBuilder
+
+	for _, csr := range csrList.Items {
+		copiedCSR := csr
+		signingRequestBuilder := &SigningRequestBuilder{
+			apiClient:  apiClient.Client,
+			Definition: &copiedCSR,
+			Object:     &copiedCSR,
+		}
+
+		signingRequestBuilders = append(signingRequestBuilders, signingRequestBuilder)
+	}
+
+	return signingRequestBuilders, nil
+}
+
+// WaitUntilSigningRequestsApproved polls the cluster for all CertificateSigningRequests with the provided options every
+// 3 seconds for up to the timeout duration or until all CertificateSigningRequests are approved.
+func WaitUntilSigningRequestsApproved(
+	apiClient *clients.Settings, timeout time.Duration, options ...runtimeclient.ListOptions) error {
+	if apiClient == nil {
+		klog.V(100).Info("CertificateSigningRequest 'apiClient' cannot be nil")
+
+		return fmt.Errorf("certificateSigningRequest 'apiClient' cannot be nil")
+	}
+
+	if len(options) > 1 {
+		klog.V(100).Info("Only one ListOptions object can be provided to WaitUntilSigningRequestsApproved")
+
+		return fmt.Errorf("error: more than one ListOptions was passed")
+	}
+
+	logMessage := "Waiting for all CertificateSigningRequests to be approved"
+	passedOptions := runtimeclient.ListOptions{}
+
+	if len(options) == 1 {
+		passedOptions = options[0]
+		logMessage += fmt.Sprintf(" with options: %v", passedOptions)
+	}
+
+	klog.V(100).Info(logMessage)
+
+	return wait.PollUntilContextTimeout(
+		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+			signingRequests, err := ListSigningRequests(apiClient, passedOptions)
+			if err != nil {
+				klog.V(100).Infof("Failed to list CertificateSigningRequests: %v", err)
+
+				return false, nil
+			}
+
+			for _, signingRequest := range signingRequests {
+				if !slices.ContainsFunc(signingRequest.Object.Status.Conditions, approvedCondition) {
+					klog.V(100).Infof("CertificateSigningRequest %s is not approved yet", signingRequest.Object.Name)
+
+					return false, nil
+				}
+			}
+
+			return true, nil
+		})
+}
+
+func approvedCondition(cond certificatesv1.CertificateSigningRequestCondition) bool {
+	return cond.Type == certificatesv1.CertificateApproved && cond.Status == corev1.ConditionTrue
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -998,6 +998,7 @@ github.com/rh-ecosystem-edge/eco-goinfra/pkg/argocd
 github.com/rh-ecosystem-edge/eco-goinfra/pkg/assisted
 github.com/rh-ecosystem-edge/eco-goinfra/pkg/bmc
 github.com/rh-ecosystem-edge/eco-goinfra/pkg/bmh
+github.com/rh-ecosystem-edge/eco-goinfra/pkg/certificate
 github.com/rh-ecosystem-edge/eco-goinfra/pkg/cgu
 github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients
 github.com/rh-ecosystem-edge/eco-goinfra/pkg/clusterlogging


### PR DESCRIPTION
Tests claim spoke health in each It, recover leftover IBU state only after a failed spec, and leave a successful upgrade intact for the ordered rollback test.

Add proper cluster health checks similarly as the LCA health check to the end of the test body - test pass means the cluster is completely ready for the next test case.

Upon test failure, various recovery actions will be performed depending on the state of the cluster. Examples including creating abort IBU and/or reboot node to recover sriov reset failure, etc. 

Expand log collection to all relevant components. e.g., upon test failure due to sriov node state unhealthy, the test will collect sriov daemon log which reveals the cause of the sriov node state issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive spoke-cluster health checks covering nodes, operators, storage, backups, certificates, and upgrade resources.
  - Added automated recovery and readiness handling for interrupted, failed, aborted, or rolled-back image-based upgrades.
  - Enhanced upgrade reporting with additional hub and spoke resources, namespaces, and diagnostic information.
  - Added a pre-suite health check to verify spoke readiness before upgrade tests begin.

- **Bug Fixes**
  - Post-upgrade validations now run only when the upgrade succeeds.
  - Improved cleanup so recovery is attempted even when resource deletion encounters errors.

- **Refactor**
  - Standardized upgrade test setup, state tracking, waiting, cleanup, and recovery through shared helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->