### PR TITLE
CNF-25757: Add iptables-alerter disable validation test

### DIFF
--- a/iptables-alerter-disabled-reference-cr.yaml
+++ b/iptables-alerter-disabled-reference-cr.yaml
@@ -1,0 +1,40 @@
+---
+# Reference ConfigMap for oc cluster-compare validation
+# This ConfigMap disables the iptables-alerter component in production Telco clusters
+#
+# Purpose:
+#   The iptables-alerter can cause high CPU usage and cluster instability in Telco
+#   production environments. Telco partners tightly control their workloads, making
+#   the iptables-alerter component unnecessary in production.
+#
+# Scope:
+#   Required for RAN, Core, and Hub RDS configurations
+#
+# References:
+#   - KCS Article: https://access.redhat.com/solutions/7134521
+#   - OCPBUGS-87026: NF Pod Readiness Probe Failures in Production Cluster
+#   - OCPBUGS-73767: High CPU usage for iptables-alerter pods
+#
+# Usage:
+#   1. Add this file to your cluster-compare reference CR directory
+#   2. Run: oc cluster-compare -r <reference-directory>
+#   3. The tool will verify this ConfigMap exists in openshift-network-operator namespace
+#
+# Manual Application (for existing clusters):
+#   Step 1: Create the ConfigMap
+#   oc -n openshift-network-operator create configmap iptables-alerter-config --from-literal enabled=false
+#
+#   Step 2: Restart network operator to apply the configuration
+#   oc -n openshift-network-operator delete pod -l name=network-operator
+#
+# Partner Responsibilities:
+#   - Run checks for iptables use in pre-production/lab environments (with iptables-alerter enabled)
+#   - Migrate workloads from iptables to nftables before RHEL10-based OCP releases
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: iptables-alerter-config
+  namespace: openshift-network-operator
+data:
+  enabled: "false"

--- a/tests/system-tests/rdscore/README.md
+++ b/tests/system-tests/rdscore/README.md
@@ -662,3 +662,57 @@ This function never fails and logs output to GinkgoWriter.
 
 **Usage**: Can be called manually or from test hooks when diagnostic snapshots are needed.
 
+
+## Network Operator Configuration
+
+### _VerifyIptablesAlerterDisabled_
+
+This test verifies that the `iptables-alerter` component is disabled in production Telco clusters.
+
+**Background:**
+The `iptables-alerter` can cause significant CPU usage and cluster instability in production environments. Multiple customer escalations (OCPBUGS-87026, OCPBUGS-73767) have demonstrated that even after mitigations, corner cases remain where the component can trigger high CPU usage. Telco partners tightly control their workloads, making the runtime iptables detection component unnecessary in production.
+
+**What the test validates:**
+1. ConfigMap `iptables-alerter-config` exists in namespace `openshift-network-operator`
+2. ConfigMap contains `enabled: "false"`
+3. No `iptables-alerter` pods are running in the cluster
+
+**RDS Requirement:**
+This configuration is **required** for RAN, Core, and Hub RDS configurations. It must be enabled by default in production deployments.
+
+**Partner Responsibilities:**
+While `iptables-alerter` is disabled in production, partners are responsible for:
+- Running iptables usage checks in pre-production/lab environments (with `iptables-alerter` enabled) to validate all anticipated workloads
+- Migrating any workloads using iptables to nftables prior to RHEL10-based OCP releases (where iptables will be removed)
+
+**References:**
+- KCS Article: https://access.redhat.com/solutions/7134521
+- OCPBUGS-87026: Resolving NF Pod Readiness Probe Failures in Production Cluster
+- OCPBUGS-73767: High CPU usage for iptables-alerter pods
+
+**Labels:** `iptables-alerter`, `network-operator-config`
+
+**Example Usage:**
+```bash
+# Run the iptables-alerter test
+ginkgo --label-filter="iptables-alerter" ./tests/system-tests/rdscore
+
+# Run all network operator configuration tests
+ginkgo --label-filter="network-operator-config" ./tests/system-tests/rdscore
+```
+
+**Manual remediation (for non-compliant clusters):**
+```bash
+# Create the ConfigMap to disable iptables-alerter
+oc -n openshift-network-operator create configmap iptables-alerter-config --from-literal enabled=false
+
+# Restart the network operator to apply the configuration
+oc -n openshift-network-operator delete pod -l name=network-operator
+```
+
+**Cluster-compare validation:**
+Add the reference ConfigMap to your cluster-compare reference directory:
+```bash
+# Reference CR location: iptables-alerter-disabled-reference-cr.yaml
+oc cluster-compare -r <reference-directory>
+```

--- a/tests/system-tests/rdscore/internal/rdscorecommon/iptables-alerter-disabled.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/iptables-alerter-disabled.go
@@ -1,0 +1,104 @@
+package rdscorecommon
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/configmap"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/rdscore/internal/rdscoreinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/rdscore/internal/rdscoreparams"
+)
+
+const (
+	// IptablesAlerterNamespace is the namespace where iptables-alerter runs.
+	IptablesAlerterNamespace = "openshift-network-operator"
+	// IptablesAlerterConfigMapName is the ConfigMap used to disable iptables-alerter.
+	IptablesAlerterConfigMapName = "iptables-alerter-config"
+	// IptablesAlerterDisableKey is the ConfigMap key to disable iptables-alerter.
+	IptablesAlerterDisableKey = "enabled"
+	// IptablesAlerterPodLabel is the label selector for iptables-alerter pods.
+	IptablesAlerterPodLabel = "app=iptables-alerter"
+)
+
+// VerifyIptablesAlerterDisabled verifies that the iptables-alerter component is disabled
+// in the cluster. This is a critical configuration for Telco production clusters to avoid
+// CPU usage issues and cluster instability.
+//
+// References:
+// - KCS: https://access.redhat.com/solutions/7134521
+// - OCPBUGS-87026: NF Pod Readiness Probe Failures in Production Cluster
+// - OCPBUGS-73767: High CPU usage for iptables-alerter pods
+//
+// The test verifies:
+// 1. ConfigMap "iptables-alerter-config" exists in "openshift-network-operator" namespace
+// 2. ConfigMap contains "enabled: false"
+// 3. No iptables-alerter pods are running in the cluster.
+func VerifyIptablesAlerterDisabled(ctx SpecContext) {
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Verifying iptables-alerter is disabled")
+
+	By("Checking iptables-alerter ConfigMap exists")
+
+	alerterConfigMap, err := configmap.Pull(
+		APIClient,
+		IptablesAlerterConfigMapName,
+		IptablesAlerterNamespace,
+	)
+
+	Expect(err).ToNot(HaveOccurred(),
+		fmt.Sprintf("Failed to get ConfigMap %s/%s: %v",
+			IptablesAlerterNamespace, IptablesAlerterConfigMapName, err))
+	Expect(alerterConfigMap).ToNot(BeNil(),
+		fmt.Sprintf("ConfigMap %s/%s not found",
+			IptablesAlerterNamespace, IptablesAlerterConfigMapName))
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+		"Found ConfigMap %s/%s",
+		IptablesAlerterNamespace,
+		IptablesAlerterConfigMapName,
+	)
+
+	By("Verifying 'enabled' is set to 'false'")
+
+	enabledValue, exists := alerterConfigMap.Object.Data[IptablesAlerterDisableKey]
+
+	Expect(exists).To(BeTrue(),
+		fmt.Sprintf("ConfigMap %s/%s missing key %q",
+			IptablesAlerterNamespace, IptablesAlerterConfigMapName, IptablesAlerterDisableKey))
+	Expect(enabledValue).To(Equal("false"),
+		fmt.Sprintf("Expected %q to be 'false', got %q", IptablesAlerterDisableKey, enabledValue))
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+		"ConfigMap %s/%s correctly has %s='false'",
+		IptablesAlerterNamespace,
+		IptablesAlerterConfigMapName,
+		IptablesAlerterDisableKey,
+	)
+
+	By("Verifying no iptables-alerter pods are running")
+
+	alerterPods, err := pod.List(
+		APIClient,
+		IptablesAlerterNamespace,
+		metav1.ListOptions{LabelSelector: IptablesAlerterPodLabel},
+	)
+
+	Expect(err).ToNot(HaveOccurred(),
+		fmt.Sprintf("Failed to list iptables-alerter pods: %v", err))
+	Expect(len(alerterPods)).To(Equal(0),
+		fmt.Sprintf("Found %d iptables-alerter pods running, expected 0 (iptables-alerter should be disabled)",
+			len(alerterPods)))
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+		"Verified: no iptables-alerter pods running in cluster",
+	)
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+		"iptables-alerter is correctly disabled - verification complete",
+	)
+}

--- a/tests/system-tests/rdscore/tests/00_validate_top_level.go
+++ b/tests/system-tests/rdscore/tests/00_validate_top_level.go
@@ -149,6 +149,11 @@ var _ = Describe(
 			It("Verifies all policies are compliant", reportxml.ID("72354"), Label("validate-policies"),
 				rdscorecommon.ValidateAllPoliciesCompliant)
 
+			It("Verify iptables-alerter is disabled",
+				Label("iptables-alerter", "network-operator-config"),
+				reportxml.ID("95009"),
+				rdscorecommon.VerifyIptablesAlerterDisabled)
+
 			DescribeTable("Verifies ClusterImagePolicy signature validation",
 				rdscorecommon.VerifyImageSignaturePolicy,
 				Entry("Signed publicKey regular image passes validation",


### PR DESCRIPTION
Add RDS test to verify iptables-alerter is disabled in production Telco clusters to prevent high CPU usage and cluster instability.

The test validates:
- ConfigMap iptables-alerter-config exists in openshift-network-operator
- ConfigMap contains enabled: "false"
- No iptables-alerter pods are running

This is a required configuration for RAN, Core, and Hub RDS.

Partners remain responsible for:
- Testing for iptables use in pre-production environments
- Migrating workloads to nftables before RHEL10-based releases

References:
- KCS: https://access.redhat.com/solutions/7134521
- OCPBUGS-87026: NF Pod Readiness Probe Failures
- OCPBUGS-73767: High CPU usage for iptables-alerter pods

Test ID: 95009
Labels: iptables-alerter, network-operator-config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Validation**
  - Added system-test coverage to verify that the iptables-alerter component is disabled.
  - The validation confirms the expected configuration and that no iptables-alerter pods are running.

- **Configuration**
  - Added a reference configuration for cluster comparison, specifying that iptables-alerter is disabled.

- **Documentation**
  - Documented the validation requirements, usage, remediation steps, and cluster-comparison checks for the network operator configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->