### PR TITLE
Add suite properties to reports and PR dependency management

### DIFF
--- a/.github/workflows/eco-goinfra-integration.yml
+++ b/.github/workflows/eco-goinfra-integration.yml
@@ -20,14 +20,34 @@ jobs:
         if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      - name: Install dependent PRs if needed
+        if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
+        uses: depends-on/depends-on-action@c7ac9a6932a7069e83aef80c202d9f60f91e43fd # 0.17.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Go
         if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
-      - name: Check out the eco-goinfra code
+      # If a Depends-On eco-goinfra PR is present, depends-on-action has already added a
+      # replace directive pointing at that branch; in that case we must not override it
+      # with the base_ref checkout below.
+      - name: Detect eco-goinfra replace from Depends-On
+        id: goinfra_dep
         if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
+        run: |
+          if go mod edit -json | jq -e '.Replace[]? | select(.Old.Path == "github.com/rh-ecosystem-edge/eco-goinfra")' >/dev/null; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+            echo "Depends-On already added a replace for eco-goinfra; skipping base_ref checkout."
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check out the eco-goinfra code
+        if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') && steps.goinfra_dep.outputs.present != 'true' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ env.ECO_GOINFRA_REPO }}
@@ -35,14 +55,29 @@ jobs:
           ref:  ${{ github.base_ref }}
           path: ${{ env.ECO_GOINFRA_PATH }}
 
-      # Update the go.mod file in eco-gotests to include the current eco-goinfra code
+      # Point go.mod at the base_ref eco-goinfra checkout, unless a Depends-On replace is already set.
       - name: Update go.mod in eco-gotests
+        if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') && steps.goinfra_dep.outputs.present != 'true' }}
+        run: go mod edit -replace github.com/rh-ecosystem-edge/eco-goinfra=${{ github.workspace }}/${{ env.ECO_GOINFRA_PATH }}
+
+      - name: Vendor eco-goinfra
         if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
         run: |
-          go mod edit -replace github.com/rh-ecosystem-edge/eco-goinfra=${{ github.workspace }}/${{ env.ECO_GOINFRA_PATH }}
           go mod tidy
           go mod vendor
 
       - name: eco-goinfra go vet
         if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
         run: make vet
+
+  check-all-dependencies-are-merged:
+    name: "Check all dependencies are merged"
+    runs-on: ubuntu-24.04
+    if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
+    steps:
+
+      - name: Check all dependent Pull Requests are merged
+        uses: depends-on/depends-on-action@c7ac9a6932a7069e83aef80c202d9f60f91e43fd # 0.17.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          check-unmerged-pr: true

--- a/README.md
+++ b/README.md
@@ -224,6 +224,25 @@ func Function(
 1. Add it to the import section of your test
 2. Run `go mod vendor`
 
+### Depending on an unmerged eco-goinfra change
+
+When an eco-gotests change needs an eco-goinfra change that is still open (not yet merged
+into eco-goinfra `main`), reference the eco-goinfra PR from your eco-gotests PR so CI builds
+against it:
+
+1. Add a `Depends-On:` line to your eco-gotests **PR description**, pointing at the eco-goinfra PR:
+   ```
+   Depends-On: https://github.com/rh-ecosystem-edge/eco-goinfra/pull/<number>
+   ```
+2. The `eco-goinfra integration` check detects this and vets eco-gotests against the referenced
+   eco-goinfra branch instead of `main`, so the check reflects the real build.
+3. Merge the eco-goinfra PR first, then update the vendored copy via the
+   "Update eco-goinfra modules" steps above so `main` matches. Only merge the eco-gotests PR
+   after that — otherwise `main` will not contain the eco-goinfra change and will fail to build.
+
+To bypass the integration check entirely (e.g. an unrelated, temporary failure), add the
+`ignore-dep-check` label to the eco-gotests PR. Use sparingly.
+
 ### Editing `.claude`
 
 When editing the repo's `.claude` directory, please be aware that this is a shared repo between multiple teams. Use `CLAUDE.local.md` and `.claude/settings.local.json` to store your local configuration so it does not affect others working in this repo.

--- a/tests/cnf/core/network/sriov/sriov_suite_test.go
+++ b/tests/cnf/core/network/sriov/sriov_suite_test.go
@@ -63,5 +63,29 @@ var _ = JustAfterEach(func() {
 })
 
 var _ = ReportAfterSuite("", func(report Report) {
-	reportxml.Create(report, NetConfig.GetReportPath(), NetConfig.TCPrefix)
+	clusterTopology := "multi-node"
+
+	if isSNO, err := cluster.IsSNOCluster(APIClient); err != nil {
+		clusterTopology = "unknown"
+	} else if isSNO {
+		clusterTopology = "sno"
+	}
+
+	reportxml.Create(report, NetConfig.GetReportPath(), NetConfig.TCPrefix,
+		reportxml.WithSuiteProperties(map[string]string{
+			"sriov-interface-list":               NetConfig.SriovInterfaces,
+			"sriov-operator-namespace":           NetConfig.SriovOperatorNamespace,
+			"cnf-net-test-container":             NetConfig.CnfNetTestContainer,
+			"dpdk-test-container":                NetConfig.DpdkTestContainer,
+			"cnf-mcp-label":                      NetConfig.CnfMcpLabel,
+			"worker-label":                       NetConfig.WorkerLabelEnvVar,
+			"vlan":                               NetConfig.VLAN,
+			"native-vlan":                        NetConfig.NativeVLAN,
+			"cluster-vlan":                       NetConfig.ClusterVlan,
+			"switch-interfaces":                  NetConfig.SwitchInterfaces,
+			"switch-lags":                        NetConfig.SwitchLagNames,
+			"pf-status-relay-operator-namespace": NetConfig.PFStatusRelayOperatorNamespace,
+			"prometheus-operator-namespace":      NetConfig.PrometheusOperatorNamespace,
+			"cluster-topology":                   clusterTopology,
+		}))
 })

--- a/tests/cnf/internal/nicinfo/nicinfo.go
+++ b/tests/cnf/internal/nicinfo/nicinfo.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"iter"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -134,6 +135,45 @@ func GenerateReport(client *clients.Settings) (string, error) {
 	}
 
 	return string(report), nil
+}
+
+// TestedInterfaceNames returns a compact, deterministic summary of the tested interfaces suitable for use as a
+// suite-level report property (and thus an indexable join key in DCI). The format is:
+//
+//	node=iface,iface;node=iface,iface
+//
+// Nodes are sorted by name and interfaces are sorted within each node. It returns an empty string if no interfaces
+// have been marked as tested. Unlike GenerateReport, this does not contact the cluster; it only reflects what was
+// marked via MarkTested/MarkSeqTested.
+func TestedInterfaceNames() string {
+	nodeNICInfos := getStoredNodeNICInfos()
+
+	nodeSummaries := make([]string, 0, len(nodeNICInfos))
+
+	for _, nodeNICInfo := range nodeNICInfos {
+		var interfaceNames []string
+
+		nodeNICInfo.interfaces.Range(func(interfaceNameUntyped, _ any) bool {
+			if interfaceName, ok := interfaceNameUntyped.(string); ok {
+				interfaceNames = append(interfaceNames, interfaceName)
+			}
+
+			return true
+		})
+
+		if len(interfaceNames) == 0 {
+			continue
+		}
+
+		sort.Strings(interfaceNames)
+
+		nodeSummaries = append(nodeSummaries,
+			fmt.Sprintf("%s=%s", nodeNICInfo.name, strings.Join(interfaceNames, ",")))
+	}
+
+	sort.Strings(nodeSummaries)
+
+	return strings.Join(nodeSummaries, ";")
 }
 
 func getStoredNodeNICInfos() []*NodeNICInfo {

--- a/tests/cnf/internal/nicinfo/nicinfo_test.go
+++ b/tests/cnf/internal/nicinfo/nicinfo_test.go
@@ -1,0 +1,66 @@
+package nicinfo
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// resetClusterNodesNICInfo clears the package-global state so tests are independent.
+func resetClusterNodesNICInfo() {
+	clusterNodesNICInfo = &sync.Map{}
+}
+
+func TestTestedInterfaceNames(t *testing.T) {
+	testCases := []struct {
+		name     string
+		marks    map[string][]string
+		expected string
+	}{
+		{
+			name:     "no interfaces marked",
+			marks:    nil,
+			expected: "",
+		},
+		{
+			name:     "single node single interface",
+			marks:    map[string][]string{"worker-0": {"ens1f0"}},
+			expected: "worker-0=ens1f0",
+		},
+		{
+			name: "interfaces sorted within node",
+			marks: map[string][]string{
+				"worker-0": {"ens1f1", "ens1f0"},
+			},
+			expected: "worker-0=ens1f0,ens1f1",
+		},
+		{
+			name: "nodes sorted and multiple interfaces",
+			marks: map[string][]string{
+				"worker-1": {"ens1f1", "ens1f0"},
+				"worker-0": {"ens1f0", "ens1f1"},
+			},
+			expected: "worker-0=ens1f0,ens1f1;worker-1=ens1f0,ens1f1",
+		},
+		{
+			name: "duplicate marks deduplicated",
+			marks: map[string][]string{
+				"worker-0": {"ens1f0", "ens1f0", "ens1f1"},
+			},
+			expected: "worker-0=ens1f0,ens1f1",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			resetClusterNodesNICInfo()
+
+			for nodeName, interfaces := range testCase.marks {
+				Node(nodeName).MarkTested(interfaces...)
+			}
+
+			assert.Equal(t, testCase.expected, TestedInterfaceNames())
+		})
+	}
+}

--- a/tests/cnf/ran/ptp/ptp_suite_test.go
+++ b/tests/cnf/ran/ptp/ptp_suite_test.go
@@ -2,6 +2,7 @@ package ptp
 
 import (
 	"runtime"
+	"strconv"
 	"testing"
 	"time"
 
@@ -110,7 +111,23 @@ var _ = JustAfterEach(func() {
 })
 
 var _ = ReportAfterSuite("", func(report Report) {
-	reportxml.Create(report, RANConfig.GetReportPath(), RANConfig.TCPrefix)
+	reportxml.Create(report, RANConfig.GetReportPath(), RANConfig.TCPrefix,
+		reportxml.WithSuiteProperties(map[string]string{
+			"ptp-operator-version":      RANConfig.Spoke1OperatorVersions[ranparam.PTP],
+			"ptp-operator-namespace":    RANConfig.PtpOperatorNamespace,
+			"ptp-stability-duration":    RANConfig.PtpStabilityDuration.String(),
+			"ptp-stability-threshold":   strconv.FormatInt(RANConfig.PtpStabilityThreshold, 10),
+			"ptp-event-consumer-image":  RANConfig.PtpEventConsumerImage,
+			"ptp-event-consumer-v1-tag": RANConfig.PtpEventConsumerV1Tag,
+			"ptp-event-consumer-v2-tag": RANConfig.PtpEventConsumerV2Tag,
+			"ptp-must-gather-image":     RANConfig.PtpMustGatherImage,
+			"metric-sampling-interval":  RANConfig.MetricSamplingInterval,
+			"workload-duration":         RANConfig.WorkloadDuration,
+			"no-workload-duration":      RANConfig.NoWorkloadDuration,
+			"spoke1-name":               RANConfig.Spoke1Name,
+			"spoke1-ocp-version":        RANConfig.Spoke1OCPVersion,
+			"tested-interfaces":         nicinfo.TestedInterfaceNames(),
+		}))
 
 	By("generating network interface information report")
 


### PR DESCRIPTION
- Extend report creation to support suite-level properties
- Implement `TestedInterfaceNames` for deterministic summaries
- Modify `sriov_suite_test.go` and `ptp_suite_test.go` to include suite properties
- Enhance `createOptions` with optional suite property handling
- Update `reportxml.go` to integrate suite properties into JUnit reports
- Use the depends-on GHA

Depends-On: https://github.com/rh-ecosystem-edge/eco-goinfra/pull/1616


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added detailed network interface information and cluster topology to SR-IOV test reports.
  - Expanded PTP reports with cluster, operator, timing, image, duration, and interface details.
  - Reports now include consistent, deterministic summaries of tested interfaces.
  - Integration checks can validate dependent, unmerged changes before testing.

- **Documentation**
  - Added guidance for testing against an unmerged dependency change, including merge-order requirements and an option to bypass dependency checks.

- **Bug Fixes**
  - Improved dependency validation to prevent integration checks from proceeding until required changes are merged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->