### PR TITLE
Oran mno test cases

### DIFF
--- a/tests/cnf/ran/README.md
+++ b/tests/cnf/ran/README.md
@@ -104,7 +104,7 @@ These inputs are all specific to the PTP test suites and are optional.
 #### Spoke inputs
 
 * `ECO_CNF_RAN_SPOKE1_NAME`: Name of the spoke 1 cluster. Automatically updated if Spoke1Kubeconfig exists, otherwise provided as input.
-* `ECO_CNF_RAN_SPOKE1_HOSTNAME`: Hostname for the spoke 1 cluster, used as input for the O-RAN suite.
+* `ECO_CNF_RAN_SPOKE1_HOSTNAME`: Hostname for the spoke 1 cluster, used as input for the O-RAN suite when a ClusterInstance file is not provided (SNO).
 * `ECO_CNF_RAN_SPOKE1_PASSWORD`: Path to the admin password for spoke 1, saved in the O-RAN suite.
 
 #### ACM inputs
@@ -136,6 +136,8 @@ These inputs are specific to the O-RAN test suite.
 * `ECO_CNF_RAN_O2IMS_OAUTH_CLIENT_SECRET`: Client secret for requesting an access token from the OAuth endpoint.
 * `ECO_CNF_RAN_O2IMS_TOKEN`: Token for authenticating with the O2IMS API (used when OAuth is not configured).
 * `ECO_CNF_RAN_CLUSTER_TEMPLATE_AFFIX`: Version-dependent affix for naming ClusterTemplates and O-RAN resources.
+* `ECO_CNF_RAN_CLUSTER_TEMPLATE_NAME`: Optional ClusterTemplate base name (without version). Defaults to `sno-ran-du`, or `mno-ran-du` when `ECO_CNF_RAN_CLUSTERINSTANCE_PATH` points to a multi-node ClusterInstance YAML.
+* `ECO_CNF_RAN_CLUSTERINSTANCE_PATH`: Optional path to a site-config `clusterinstance.yaml`. When set, ProvisioningRequest `nodes[].hostName` values are derived from `spec.nodes[].hostName` (used for MNO installs).
 * `ECO_CNF_RAN_MOCK_SMO_NAMESPACE`: Namespace where the mock SMO is deployed.
 * `ECO_CNF_RAN_MOCK_SMO_SUBDOMAIN`: Subdomain for the mock SMO route (the SMO registered in the inventory CR).
 

--- a/tests/cnf/ran/README.md
+++ b/tests/cnf/ran/README.md
@@ -137,7 +137,7 @@ These inputs are specific to the O-RAN test suite.
 * `ECO_CNF_RAN_O2IMS_TOKEN`: Token for authenticating with the O2IMS API (used when OAuth is not configured).
 * `ECO_CNF_RAN_CLUSTER_TEMPLATE_AFFIX`: Version-dependent affix for naming ClusterTemplates and O-RAN resources.
 * `ECO_CNF_RAN_CLUSTER_TEMPLATE_NAME`: Optional ClusterTemplate base name (without version). Defaults to `sno-ran-du`, or `mno-ran-du` when `ECO_CNF_RAN_CLUSTERINSTANCE_PATH` points to a multi-node ClusterInstance YAML.
-* `ECO_CNF_RAN_CLUSTERINSTANCE_PATH`: Optional path to a site-config `clusterinstance.yaml`. When set, ProvisioningRequest `nodes[].hostName` values are derived from `spec.nodes[].hostName` (used for MNO installs).
+* `ECO_CNF_RAN_CLUSTERINSTANCE_PATH`: Optional path to a site-config `clusterinstance.yaml`. When set, ProvisioningRequest `nodes[].hostName` values are derived from `spec.nodes[].hostName` (used for MNO installs). Optional `spec.nodes[].role` values (`master`/`worker`) are used for topology and Metal3 Day2 rolling checks.
 * `ECO_CNF_RAN_MOCK_SMO_NAMESPACE`: Namespace where the mock SMO is deployed.
 * `ECO_CNF_RAN_MOCK_SMO_SUBDOMAIN`: Subdomain for the mock SMO route (the SMO registered in the inventory CR).
 

--- a/tests/cnf/ran/internal/ranconfig/config.go
+++ b/tests/cnf/ran/internal/ranconfig/config.go
@@ -76,6 +76,10 @@ type RANConfig struct {
 	// ClusterTemplateAffix is the version-dependent affix used for naming ClusterTemplates and other O-RAN
 	// resources.
 	ClusterTemplateAffix string `envconfig:"ECO_CNF_RAN_CLUSTER_TEMPLATE_AFFIX"`
+	// ClusterTemplateName is the ClusterTemplate base name (without version) for O-RAN ProvisioningRequests.
+	// When empty, the O-RAN suite defaults to sno-ran-du, or mno-ran-du when a multi-node ClusterInstance
+	// file is provided via ECO_CNF_RAN_CLUSTERINSTANCE_PATH.
+	ClusterTemplateName string `envconfig:"ECO_CNF_RAN_CLUSTER_TEMPLATE_NAME"`
 }
 
 // HubConfig contains the configuration for the hub cluster, if present.
@@ -129,11 +133,17 @@ type Spoke1Config struct {
 	Spoke1OCPVersion       string
 	Spoke1OperatorVersions map[ranparam.SpokeOperatorName]string
 
-	// Spoke1Name is automatically updated if Spoke1Kubeconfig exists, otherwise it can be provided as an input.
+	// Spoke1Name can be provided via ECO_CNF_RAN_SPOKE1_NAME. If unset and Spoke1Kubeconfig exists, it is
+	// derived from that kubeconfig. An explicitly set name is never overwritten (hub KUBECONFIG would otherwise
+	// replace the intended spoke name during Day0 provisioning).
 	Spoke1Name string `envconfig:"ECO_CNF_RAN_SPOKE1_NAME"`
-	// Spoke1Hostname is not automatically updated but instead used as an input for the O-RAN suite.
-	Spoke1Hostname   string `envconfig:"ECO_CNF_RAN_SPOKE1_HOSTNAME"`
-	Spoke1Kubeconfig string `envconfig:"KUBECONFIG"`
+	// Spoke1Hostname is not automatically updated but instead used as an input for the O-RAN suite when a
+	// ClusterInstance file is not provided.
+	Spoke1Hostname string `envconfig:"ECO_CNF_RAN_SPOKE1_HOSTNAME"`
+	// ClusterInstancePath is an optional path to a site-config ClusterInstance YAML. When set, the O-RAN suite
+	// derives ProvisioningRequest node hostnames from spec.nodes[].hostName (used for MNO installs).
+	ClusterInstancePath string `envconfig:"ECO_CNF_RAN_CLUSTERINSTANCE_PATH"`
+	Spoke1Kubeconfig    string `envconfig:"KUBECONFIG"`
 	// Spoke1Password is the path to the admin password, saved in the O-RAN suite.
 	Spoke1Password string `envconfig:"ECO_CNF_RAN_SPOKE1_PASSWORD"`
 
@@ -296,15 +306,21 @@ func (ranconfig *RANConfig) newSpoke1Config(configFile string) {
 
 	ranconfig.Spoke1Config.Spoke1APIClient = inittools.APIClient
 
-	if spoke1Kubeconfig := ranconfig.Spoke1Config.Spoke1Kubeconfig; spoke1Kubeconfig != "" {
-		spoke1Name, err := version.GetClusterName(spoke1Kubeconfig)
-		if err != nil {
-			klog.V(ranparam.LogLevel).Infof("Failed to get spoke 1 name from kubeconfig at %s: %v", spoke1Kubeconfig, err)
+	if ranconfig.Spoke1Config.Spoke1Name == "" {
+		if spoke1Kubeconfig := ranconfig.Spoke1Config.Spoke1Kubeconfig; spoke1Kubeconfig != "" {
+			spoke1Name, err := version.GetClusterName(spoke1Kubeconfig)
+			if err != nil {
+				klog.V(ranparam.LogLevel).Infof(
+					"Failed to get spoke 1 name from kubeconfig at %s: %v", spoke1Kubeconfig, err)
+			} else {
+				ranconfig.Spoke1Config.Spoke1Name = spoke1Name
+			}
 		} else {
-			ranconfig.Spoke1Config.Spoke1Name = spoke1Name
+			klog.V(ranparam.LogLevel).Infof("No spoke 1 kubeconfig specified in KUBECONFIG environment variable")
 		}
 	} else {
-		klog.V(ranparam.LogLevel).Infof("No spoke 1 kubeconfig specified in KUBECONFIG environment variable")
+		klog.V(ranparam.LogLevel).Infof(
+			"Using explicit Spoke1Name %q (not derived from KUBECONFIG)", ranconfig.Spoke1Config.Spoke1Name)
 	}
 
 	ranconfig.Spoke1Config.Spoke1OCPVersion, err = version.GetOCPVersion(ranconfig.Spoke1Config.Spoke1APIClient)

--- a/tests/cnf/ran/internal/version/version.go
+++ b/tests/cnf/ran/internal/version/version.go
@@ -97,6 +97,10 @@ func GetZTPVersionFromArgoCd(client *clients.Settings, name, namespace string) (
 	}
 
 	// The format here will be like vX.Y.Z so we need to remove the v at the start.
+	if len(ztpVersion) < 2 || ztpVersion[0] != 'v' {
+		return "", fmt.Errorf("unexpected ztp-site-generate version tag %q", ztpVersion)
+	}
+
 	return ztpVersion[1:], nil
 }
 
@@ -106,6 +110,12 @@ func GetZTPSiteGenerateImage(client *clients.Settings) (string, error) {
 	gitops, err := argocd.Pull(client, ranparam.OpenshiftGitOpsNamespace, ranparam.OpenshiftGitOpsNamespace)
 	if err != nil {
 		return "", err
+	}
+
+	// argocd.Pull can return a nil Definition when Get fails with a non-NotFound error (Exists treats that as
+	// present). Guard so hub config init logs an error instead of panicking.
+	if gitops == nil || gitops.Definition == nil {
+		return "", errors.New("argocd object is nil after pull; cannot read ztp-site-generate image")
 	}
 
 	for _, container := range gitops.Definition.Spec.Repo.InitContainers {

--- a/tests/cnf/ran/oran/internal/helper/allocation.go
+++ b/tests/cnf/ran/oran/internal/helper/allocation.go
@@ -1,0 +1,231 @@
+package helper
+
+import (
+	"errors"
+	"fmt"
+
+	hardwaremanagementv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/bmh"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+// AllocatedNodeLabel is the BareMetalHost label that maps a BMH to its AllocatedNode name.
+const AllocatedNodeLabel = "clcm.openshift.io/allocated-node"
+
+// VerifyAllocatedHardwareForPR validates NAR completeness, unique AllocatedNodes, BMH allocated-node labels, and that
+// each AllocatedNode references the expected Day0 HardwareProfile for its group. Errors are accumulated so every check
+// runs.
+func VerifyAllocatedHardwareForPR(prBuilder *oran.ProvisioningRequestBuilder) error {
+	var accumulatedErrors []error
+
+	resourceStatuses := prBuilder.Object.Status.Extensions.InfrastructureResourceStatuses
+	expectedHostnames, err := GetSpokeHostnames()
+	if err != nil {
+		return fmt.Errorf("resolve expected spoke hostnames: %w", err)
+	}
+
+	if len(resourceStatuses) != len(expectedHostnames) {
+		accumulatedErrors = append(accumulatedErrors, fmt.Errorf(
+			"expected %d infrastructure resource statuses, got %d",
+			len(expectedHostnames), len(resourceStatuses)))
+	}
+
+	allocatedByID := make(map[string]*oran.AllocatedNodeBuilder, len(resourceStatuses))
+	bmhToAllocated := make(map[string]string)
+	narName := ""
+
+	for _, resourceStatus := range resourceStatuses {
+		allocatedNode, err := oran.PullAllocatedNode(HubAPIClient, resourceStatus.ResourceId, tsparams.O2IMSNamespace)
+		if err != nil {
+			accumulatedErrors = append(accumulatedErrors, fmt.Errorf(
+				"pull AllocatedNode %s: %w", resourceStatus.ResourceId, err))
+
+			continue
+		}
+
+		allocatedByID[resourceStatus.ResourceId] = allocatedNode
+
+		if narName == "" {
+			narName = allocatedNode.Object.Spec.NodeAllocationRequest
+		} else if allocatedNode.Object.Spec.NodeAllocationRequest != narName {
+			accumulatedErrors = append(accumulatedErrors, fmt.Errorf(
+				"AllocatedNode %s references NAR %q, expected %q",
+				resourceStatus.ResourceId, allocatedNode.Object.Spec.NodeAllocationRequest, narName))
+		}
+
+		bmhKey := allocatedNode.Object.Spec.HwMgrNodeNs + "/" + allocatedNode.Object.Spec.HwMgrNodeId
+		if existing, exists := bmhToAllocated[bmhKey]; exists {
+			accumulatedErrors = append(accumulatedErrors, fmt.Errorf(
+				"BMH %s claimed by both AllocatedNode %s and %s", bmhKey, existing, resourceStatus.ResourceId))
+		} else {
+			bmhToAllocated[bmhKey] = resourceStatus.ResourceId
+		}
+	}
+
+	if narName != "" {
+		if err := verifyNARProvisioned(narName, len(expectedHostnames)); err != nil {
+			accumulatedErrors = append(accumulatedErrors, err)
+		}
+	}
+
+	expectedProfiles, profileErr := expectedHwProfilesByGroup(prBuilder)
+	if profileErr != nil {
+		accumulatedErrors = append(accumulatedErrors, profileErr)
+	}
+
+	for resourceID, allocatedNode := range allocatedByID {
+		if err := verifyBMHAllocatedNodeLabel(allocatedNode); err != nil {
+			accumulatedErrors = append(accumulatedErrors, err)
+		}
+
+		if expectedProfiles != nil {
+			groupName := allocatedNode.Object.Spec.GroupName
+			expectedProfile, ok := expectedProfiles[groupName]
+
+			if !ok && len(expectedProfiles) == 1 {
+				for _, profile := range expectedProfiles {
+					expectedProfile = profile
+					ok = true
+
+					break
+				}
+			}
+
+			if !ok {
+				accumulatedErrors = append(accumulatedErrors, fmt.Errorf(
+					"AllocatedNode %s group %q has no matching HardwareProfile in ClusterTemplate",
+					resourceID, groupName))
+			} else if allocatedNode.Object.Spec.HwProfile != expectedProfile {
+				accumulatedErrors = append(accumulatedErrors, fmt.Errorf(
+					"AllocatedNode %s has hwProfile %q, expected %q for group %q",
+					resourceID, allocatedNode.Object.Spec.HwProfile, expectedProfile, groupName))
+			}
+		}
+	}
+
+	return joinErrors(accumulatedErrors)
+}
+
+func verifyNARProvisioned(narName string, expectedNodeCount int) error {
+	nars, err := oran.ListNodeAllocationRequests(HubAPIClient)
+	if err != nil {
+		return fmt.Errorf("list NodeAllocationRequests: %w", err)
+	}
+
+	var nar *oran.NARBuilder
+
+	for _, candidate := range nars {
+		if candidate.Object.Name == narName {
+			nar = candidate
+
+			break
+		}
+	}
+
+	if nar == nil {
+		return fmt.Errorf("NodeAllocationRequest %s not found", narName)
+	}
+
+	if len(nar.Object.Status.Properties.NodeNames) != expectedNodeCount {
+		return fmt.Errorf("NAR %s has %d nodeNames, expected %d",
+			narName, len(nar.Object.Status.Properties.NodeNames), expectedNodeCount)
+	}
+
+	provisioned := false
+
+	for _, condition := range nar.Object.Status.Conditions {
+		if condition.Type == string(hardwaremanagementv1alpha1.Provisioned) &&
+			condition.Status == metav1.ConditionTrue &&
+			condition.Reason == string(hardwaremanagementv1alpha1.Completed) {
+			provisioned = true
+
+			break
+		}
+	}
+
+	if !provisioned {
+		return fmt.Errorf("NAR %s Provisioned condition is not Completed", narName)
+	}
+
+	return nil
+}
+
+func verifyBMHAllocatedNodeLabel(allocatedNode *oran.AllocatedNodeBuilder) error {
+	bmhName := allocatedNode.Object.Spec.HwMgrNodeId
+	bmhNamespace := allocatedNode.Object.Spec.HwMgrNodeNs
+
+	if bmhName == "" || bmhNamespace == "" {
+		return fmt.Errorf("AllocatedNode %s missing HwMgrNodeId/HwMgrNodeNs", allocatedNode.Object.Name)
+	}
+
+	bareMetalHost, err := bmh.Pull(HubAPIClient, bmhName, bmhNamespace)
+	if err != nil {
+		return fmt.Errorf("pull BMH %s/%s for AllocatedNode %s: %w",
+			bmhNamespace, bmhName, allocatedNode.Object.Name, err)
+	}
+
+	labelValue, ok := bareMetalHost.Object.Labels[AllocatedNodeLabel]
+	if !ok {
+		return fmt.Errorf("BMH %s/%s missing label %s", bmhNamespace, bmhName, AllocatedNodeLabel)
+	}
+
+	if labelValue != allocatedNode.Object.Name {
+		return fmt.Errorf("BMH %s/%s label %s=%q, expected %q",
+			bmhNamespace, bmhName, AllocatedNodeLabel, labelValue, allocatedNode.Object.Name)
+	}
+
+	return nil
+}
+
+// expectedHwProfilesByGroup returns a map of nodeGroupData name (and role) to HardwareProfile name from the PR's
+// ClusterTemplate.
+func expectedHwProfilesByGroup(prBuilder *oran.ProvisioningRequestBuilder) (map[string]string, error) {
+	clusterTemplateName := fmt.Sprintf("%s.%s",
+		prBuilder.Object.Spec.TemplateName, prBuilder.Object.Spec.TemplateVersion)
+	clusterTemplateNamespace := prBuilder.Object.Spec.TemplateName + "-" + RANConfig.ClusterTemplateAffix
+
+	clusterTemplate, err := oran.PullClusterTemplate(HubAPIClient, clusterTemplateName, clusterTemplateNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("pull ClusterTemplate %s/%s: %w", clusterTemplateNamespace, clusterTemplateName, err)
+	}
+
+	nodeGroupData := clusterTemplate.Object.Spec.TemplateDefaults.HwMgmtDefaults.NodeGroupData
+	if len(nodeGroupData) == 0 {
+		klog.V(tsparams.LogLevel).Infof(
+			"ClusterTemplate %s has no hwMgmtDefaults.nodeGroupData; skipping Day0 hwProfile checks",
+			clusterTemplateName)
+
+		return nil, nil
+	}
+
+	profiles := make(map[string]string, len(nodeGroupData)*2)
+
+	for _, group := range nodeGroupData {
+		if group.HwProfile == "" {
+			continue
+		}
+
+		if group.Name != "" {
+			profiles[group.Name] = group.HwProfile
+		}
+
+		if group.Role != "" {
+			profiles[group.Role] = group.HwProfile
+		}
+	}
+
+	if len(profiles) == 0 {
+		return nil, fmt.Errorf("ClusterTemplate %s hwMgmtDefaults.nodeGroupData has no hwProfile entries",
+			clusterTemplateName)
+	}
+
+	return profiles, nil
+}
+
+func joinErrors(errs []error) error {
+	return errors.Join(errs...)
+}

--- a/tests/cnf/ran/oran/internal/helper/clusterinstance.go
+++ b/tests/cnf/ran/oran/internal/helper/clusterinstance.go
@@ -1,0 +1,101 @@
+package helper
+
+import (
+	"fmt"
+	"os"
+
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
+	"sigs.k8s.io/yaml"
+)
+
+// clusterInstanceFile is a minimal decode target for site-config ClusterInstance YAML. Only the fields needed to
+// derive ProvisioningRequest node hostnames (and optional cluster name) are parsed.
+type clusterInstanceFile struct {
+	Spec struct {
+		ClusterName string `json:"clusterName"`
+		Nodes       []struct {
+			HostName string `json:"hostName"`
+		} `json:"nodes"`
+	} `json:"spec"`
+}
+
+// LoadSpokeHostnamesFromClusterInstance reads a ClusterInstance YAML and returns spec.nodes[].hostName in file order.
+func LoadSpokeHostnamesFromClusterInstance(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read ClusterInstance file %s: %w", path, err)
+	}
+
+	var clusterInstance clusterInstanceFile
+
+	if err := yaml.Unmarshal(data, &clusterInstance); err != nil {
+		return nil, fmt.Errorf("parse ClusterInstance file %s: %w", path, err)
+	}
+
+	if len(clusterInstance.Spec.Nodes) == 0 {
+		return nil, fmt.Errorf("ClusterInstance file %s has no spec.nodes entries", path)
+	}
+
+	hostnames := make([]string, 0, len(clusterInstance.Spec.Nodes))
+
+	for i, node := range clusterInstance.Spec.Nodes {
+		if node.HostName == "" {
+			return nil, fmt.Errorf("ClusterInstance file %s spec.nodes[%d] has empty hostName", path, i)
+		}
+
+		hostnames = append(hostnames, node.HostName)
+	}
+
+	return hostnames, nil
+}
+
+// GetSpokeHostnames returns the hostnames for the primary ProvisioningRequest nodes[]. When
+// ECO_CNF_RAN_CLUSTERINSTANCE_PATH is set, hostnames are read from that ClusterInstance YAML. Otherwise the single
+// ECO_CNF_RAN_SPOKE1_HOSTNAME value is used (SNO).
+func GetSpokeHostnames() ([]string, error) {
+	if RANConfig.ClusterInstancePath != "" {
+		return LoadSpokeHostnamesFromClusterInstance(RANConfig.ClusterInstancePath)
+	}
+
+	if RANConfig.Spoke1Hostname == "" {
+		return nil, fmt.Errorf("ECO_CNF_RAN_SPOKE1_HOSTNAME must be set when ECO_CNF_RAN_CLUSTERINSTANCE_PATH is unset")
+	}
+
+	return []string{RANConfig.Spoke1Hostname}, nil
+}
+
+// GetClusterTemplateName returns the ClusterTemplate base name for O-RAN ProvisioningRequests.
+// Precedence: ECO_CNF_RAN_CLUSTER_TEMPLATE_NAME if set; else mno-ran-du when a ClusterInstance file yields more than
+// one hostname; else sno-ran-du.
+func GetClusterTemplateName() string {
+	if RANConfig.ClusterTemplateName != "" {
+		return RANConfig.ClusterTemplateName
+	}
+
+	if RANConfig.ClusterInstancePath != "" {
+		hostnames, err := LoadSpokeHostnamesFromClusterInstance(RANConfig.ClusterInstancePath)
+		if err == nil && len(hostnames) > 1 {
+			return tsparams.MNOClusterTemplateName
+		}
+	}
+
+	return tsparams.ClusterTemplateName
+}
+
+// GetExtraManifestsName returns the expected extra-manifests ConfigMap name for the resolved ClusterTemplate.
+func GetExtraManifestsName() string {
+	return GetClusterTemplateName() + "-extra-manifest-1"
+}
+
+// buildClusterInstanceNodes builds the clusterInstanceParameters.nodes slice for a ProvisioningRequest.
+func buildClusterInstanceNodes(hostnames []string) []map[string]any {
+	nodes := make([]map[string]any, 0, len(hostnames))
+	for _, hostname := range hostnames {
+		nodes = append(nodes, map[string]any{
+			"hostName": hostname,
+		})
+	}
+
+	return nodes
+}

--- a/tests/cnf/ran/oran/internal/helper/clusterinstance.go
+++ b/tests/cnf/ran/oran/internal/helper/clusterinstance.go
@@ -143,6 +143,57 @@ func GetSpokeHostnames() ([]string, error) {
 	return hostnames, nil
 }
 
+// IsMultiNode returns true when more than one spoke hostname is configured.
+func IsMultiNode() bool {
+	hostnames, err := GetSpokeHostnames()
+
+	return err == nil && len(hostnames) > 1
+}
+
+// HasWorkerNodes returns true when any configured spoke node has role worker.
+func HasWorkerNodes() bool {
+	nodes, err := GetSpokeNodes()
+	if err != nil {
+		return false
+	}
+
+	for _, node := range nodes {
+		if node.Role == "worker" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// CountNodesByRole returns how many configured spoke nodes have the given role.
+func CountNodesByRole(role string) int {
+	nodes, err := GetSpokeNodes()
+	if err != nil {
+		return 0
+	}
+
+	count := 0
+
+	for _, node := range nodes {
+		if node.Role == role {
+			count++
+		}
+	}
+
+	return count
+}
+
+// GetPolicySelectorLabel returns the ManagedCluster ExtraLabel key used to select policy templates.
+func GetPolicySelectorLabel() (string, error) {
+	clusterTemplateName, err := GetClusterTemplateName()
+	if err != nil {
+		return "", err
+	}
+
+	return clusterTemplateName + "-policy", nil
+}
+
 // GetClusterTemplateName returns the ClusterTemplate base name for O-RAN ProvisioningRequests.
 // Precedence: ECO_CNF_RAN_CLUSTER_TEMPLATE_NAME if set; else mno-ran-du when a ClusterInstance file yields more than
 // one hostname; else sno-ran-du. When ECO_CNF_RAN_CLUSTERINSTANCE_PATH is set, a load error is returned instead of

--- a/tests/cnf/ran/oran/internal/helper/clusterinstance.go
+++ b/tests/cnf/ran/oran/internal/helper/clusterinstance.go
@@ -206,6 +206,7 @@ func buildClusterInstanceNodeGroups(nodes []SpokeNode) []map[string]any {
 		nodeEntry := map[string]any{
 			"hostName": node.HostName,
 		}
+
 		if node.NodeNetwork != nil {
 			nodeEntry["nodeNetwork"] = node.NodeNetwork
 		}

--- a/tests/cnf/ran/oran/internal/helper/clusterinstance.go
+++ b/tests/cnf/ran/oran/internal/helper/clusterinstance.go
@@ -6,22 +6,31 @@ import (
 
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
-	"sigs.k8s.io/yaml"
+	"gopkg.in/yaml.v3"
 )
 
 // clusterInstanceFile is a minimal decode target for site-config ClusterInstance YAML. Only the fields needed to
 // derive ProvisioningRequest node hostnames (and optional cluster name) are parsed.
 type clusterInstanceFile struct {
 	Spec struct {
-		ClusterName string `json:"clusterName"`
+		ClusterName string `yaml:"clusterName"`
 		Nodes       []struct {
-			HostName string `json:"hostName"`
-		} `json:"nodes"`
-	} `json:"spec"`
+			HostName    string         `yaml:"hostName"`
+			Role        string         `yaml:"role"`
+			NodeNetwork map[string]any `yaml:"nodeNetwork,omitempty"`
+		} `yaml:"nodes"`
+	} `yaml:"spec"`
 }
 
-// LoadSpokeHostnamesFromClusterInstance reads a ClusterInstance YAML and returns spec.nodes[].hostName in file order.
-func LoadSpokeHostnamesFromClusterInstance(path string) ([]string, error) {
+// SpokeNode is a hostname, optional role, and optional nodeNetwork from a ClusterInstance file or SNO hostname input.
+type SpokeNode struct {
+	HostName    string
+	Role        string
+	NodeNetwork map[string]any
+}
+
+// loadClusterInstanceFile reads and parses a ClusterInstance YAML from path.
+func loadClusterInstanceFile(path string) (*clusterInstanceFile, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read ClusterInstance file %s: %w", path, err)
@@ -37,55 +46,136 @@ func LoadSpokeHostnamesFromClusterInstance(path string) ([]string, error) {
 		return nil, fmt.Errorf("ClusterInstance file %s has no spec.nodes entries", path)
 	}
 
-	hostnames := make([]string, 0, len(clusterInstance.Spec.Nodes))
+	return &clusterInstance, nil
+}
+
+// LoadSpokeNodesFromClusterInstance reads a ClusterInstance YAML and returns spec.nodes[] with hostname and role.
+func LoadSpokeNodesFromClusterInstance(path string) ([]SpokeNode, error) {
+	clusterInstance, err := loadClusterInstanceFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	nodes := make([]SpokeNode, 0, len(clusterInstance.Spec.Nodes))
 
 	for i, node := range clusterInstance.Spec.Nodes {
 		if node.HostName == "" {
 			return nil, fmt.Errorf("ClusterInstance file %s spec.nodes[%d] has empty hostName", path, i)
 		}
 
+		nodes = append(nodes, SpokeNode{
+			HostName:    node.HostName,
+			Role:        node.Role,
+			NodeNetwork: node.NodeNetwork,
+		})
+	}
+
+	return nodes, nil
+}
+
+// LoadSpokeHostnamesFromClusterInstance reads a ClusterInstance YAML and returns spec.nodes[].hostName in file order.
+func LoadSpokeHostnamesFromClusterInstance(path string) ([]string, error) {
+	nodes, err := LoadSpokeNodesFromClusterInstance(path)
+	if err != nil {
+		return nil, err
+	}
+
+	hostnames := make([]string, 0, len(nodes))
+	for _, node := range nodes {
 		hostnames = append(hostnames, node.HostName)
 	}
 
 	return hostnames, nil
 }
 
-// GetSpokeHostnames returns the hostnames for the primary ProvisioningRequest nodes[]. When
-// ECO_CNF_RAN_CLUSTERINSTANCE_PATH is set, hostnames are read from that ClusterInstance YAML. Otherwise the single
-// ECO_CNF_RAN_SPOKE1_HOSTNAME value is used (SNO).
-func GetSpokeHostnames() ([]string, error) {
+// GetClusterInstanceClusterName returns spec.clusterName from the ClusterInstance file when
+// ECO_CNF_RAN_CLUSTERINSTANCE_PATH is set and the field is non-empty; otherwise RANConfig.Spoke1Name.
+func GetClusterInstanceClusterName() (string, error) {
 	if RANConfig.ClusterInstancePath != "" {
-		return LoadSpokeHostnamesFromClusterInstance(RANConfig.ClusterInstancePath)
+		clusterInstance, err := loadClusterInstanceFile(RANConfig.ClusterInstancePath)
+		if err != nil {
+			return "", err
+		}
+
+		if clusterInstance.Spec.ClusterName != "" {
+			return clusterInstance.Spec.ClusterName, nil
+		}
+	}
+
+	if RANConfig.Spoke1Name == "" {
+		return "", fmt.Errorf("ECO_CNF_RAN_SPOKE1_NAME must be set when ClusterInstance file omits spec.clusterName")
+	}
+
+	return RANConfig.Spoke1Name, nil
+}
+
+// GetSpokeNodes returns nodes for ProvisioningRequest generation. When ECO_CNF_RAN_CLUSTERINSTANCE_PATH is set, nodes
+// are read from that file; otherwise a single SNO node is built from ECO_CNF_RAN_SPOKE1_HOSTNAME.
+func GetSpokeNodes() ([]SpokeNode, error) {
+	if RANConfig.ClusterInstancePath != "" {
+		return LoadSpokeNodesFromClusterInstance(RANConfig.ClusterInstancePath)
 	}
 
 	if RANConfig.Spoke1Hostname == "" {
 		return nil, fmt.Errorf("ECO_CNF_RAN_SPOKE1_HOSTNAME must be set when ECO_CNF_RAN_CLUSTERINSTANCE_PATH is unset")
 	}
 
-	return []string{RANConfig.Spoke1Hostname}, nil
+	return []SpokeNode{{
+		HostName: RANConfig.Spoke1Hostname,
+		Role:     "master",
+	}}, nil
+}
+
+// GetSpokeHostnames returns the hostnames for the primary ProvisioningRequest nodes[]. When
+// ECO_CNF_RAN_CLUSTERINSTANCE_PATH is set, hostnames are read from that ClusterInstance YAML. Otherwise the single
+// ECO_CNF_RAN_SPOKE1_HOSTNAME value is used (SNO).
+func GetSpokeHostnames() ([]string, error) {
+	nodes, err := GetSpokeNodes()
+	if err != nil {
+		return nil, err
+	}
+
+	hostnames := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		hostnames = append(hostnames, node.HostName)
+	}
+
+	return hostnames, nil
 }
 
 // GetClusterTemplateName returns the ClusterTemplate base name for O-RAN ProvisioningRequests.
 // Precedence: ECO_CNF_RAN_CLUSTER_TEMPLATE_NAME if set; else mno-ran-du when a ClusterInstance file yields more than
-// one hostname; else sno-ran-du.
-func GetClusterTemplateName() string {
+// one hostname; else sno-ran-du. When ECO_CNF_RAN_CLUSTERINSTANCE_PATH is set, a load error is returned instead of
+// falling back to sno-ran-du.
+func GetClusterTemplateName() (string, error) {
 	if RANConfig.ClusterTemplateName != "" {
-		return RANConfig.ClusterTemplateName
+		return RANConfig.ClusterTemplateName, nil
 	}
 
 	if RANConfig.ClusterInstancePath != "" {
 		hostnames, err := LoadSpokeHostnamesFromClusterInstance(RANConfig.ClusterInstancePath)
-		if err == nil && len(hostnames) > 1 {
-			return tsparams.MNOClusterTemplateName
+		if err != nil {
+			return "", err
 		}
+
+		if len(hostnames) > 1 {
+			return tsparams.MNOClusterTemplateName, nil
+		}
+
+		return tsparams.ClusterTemplateName, nil
 	}
 
-	return tsparams.ClusterTemplateName
+	return tsparams.ClusterTemplateName, nil
 }
 
 // GetExtraManifestsName returns the expected extra-manifests ConfigMap name for the resolved ClusterTemplate.
-func GetExtraManifestsName() string {
-	return GetClusterTemplateName() + "-extra-manifest-1"
+func GetExtraManifestsName() (string, error) {
+	clusterTemplateName, err := GetClusterTemplateName()
+	if err != nil {
+		return "", err
+	}
+
+	return clusterTemplateName + "-extra-manifest-1", nil
 }
 
 // buildClusterInstanceNodes builds the clusterInstanceParameters.nodes slice for a ProvisioningRequest.
@@ -98,4 +188,64 @@ func buildClusterInstanceNodes(hostnames []string) []map[string]any {
 	}
 
 	return nodes
+}
+
+// buildClusterInstanceNodeGroups builds clusterInstanceParameters.nodeGroups for MNO templates.
+func buildClusterInstanceNodeGroups(nodes []SpokeNode) []map[string]any {
+	grouped := map[string][]map[string]any{
+		"master": {},
+		"worker": {},
+	}
+
+	for _, node := range nodes {
+		role := node.Role
+		if role != "master" && role != "worker" {
+			role = "master"
+		}
+
+		nodeEntry := map[string]any{
+			"hostName": node.HostName,
+		}
+		if node.NodeNetwork != nil {
+			nodeEntry["nodeNetwork"] = node.NodeNetwork
+		}
+
+		grouped[role] = append(grouped[role], nodeEntry)
+	}
+
+	nodeGroups := make([]map[string]any, 0, 2)
+	if len(grouped["master"]) > 0 {
+		nodeGroups = append(nodeGroups, map[string]any{
+			"name":  "master",
+			"role":  "master",
+			"nodes": grouped["master"],
+		})
+	}
+
+	if len(grouped["worker"]) > 0 {
+		nodeGroups = append(nodeGroups, map[string]any{
+			"name":  "worker",
+			"role":  "worker",
+			"nodes": grouped["worker"],
+		})
+	}
+
+	return nodeGroups
+}
+
+// buildSecondarySpokeNodes returns spoke nodes with distinct hostnames for a secondary ProvisioningRequest.
+func buildSecondarySpokeNodes(spokeNodes []SpokeNode) []SpokeNode {
+	if len(spokeNodes) == 0 {
+		return []SpokeNode{{HostName: tsparams.TestName2, Role: "master"}}
+	}
+
+	secondaryNodes := make([]SpokeNode, 0, len(spokeNodes))
+	for i, node := range spokeNodes {
+		secondaryNodes = append(secondaryNodes, SpokeNode{
+			HostName: fmt.Sprintf("%s-%d", tsparams.TestName2, i),
+			Role:     node.Role,
+		})
+	}
+
+	return secondaryNodes
 }

--- a/tests/cnf/ran/oran/internal/helper/helper.go
+++ b/tests/cnf/ran/oran/internal/helper/helper.go
@@ -20,21 +20,27 @@ import (
 )
 
 // NewProvisioningRequest creates a ProvisioningRequest builder with templateVersion, setting all the required
-// parameters and using the affix from RANConfig.
-func NewProvisioningRequest(client runtimeclient.Client, templateVersion string) *oran.ProvisioningRequestBuilder {
+// parameters and using the affix from RANConfig. Node hostnames come from ECO_CNF_RAN_CLUSTERINSTANCE_PATH when set,
+// otherwise from ECO_CNF_RAN_SPOKE1_HOSTNAME. The ClusterTemplate name resolves to mno-ran-du for multi-node
+// ClusterInstance files unless ECO_CNF_RAN_CLUSTER_TEMPLATE_NAME overrides it.
+func NewProvisioningRequest(
+	client runtimeclient.Client, templateVersion string) (*oran.ProvisioningRequestBuilder, error) {
+	hostnames, err := GetSpokeHostnames()
+	if err != nil {
+		return nil, fmt.Errorf("resolve spoke hostnames for ProvisioningRequest: %w", err)
+	}
+
 	versionWithAffix := RANConfig.ClusterTemplateAffix + "-" + templateVersion
-	prBuilder := oran.NewPRBuilder(client, tsparams.TestPRName, tsparams.ClusterTemplateName, versionWithAffix).
+	prBuilder := oran.NewPRBuilder(client, tsparams.TestPRName, GetClusterTemplateName(), versionWithAffix).
 		WithTemplateParameter("nodeClusterName", RANConfig.Spoke1Name).
 		WithTemplateParameter("oCloudSiteId", tsparams.OCloudSiteID).
 		WithTemplateParameter("policyTemplateParameters", map[string]any{}).
 		WithTemplateParameter("clusterInstanceParameters", map[string]any{
 			"clusterName": RANConfig.Spoke1Name,
-			"nodes": []map[string]any{{
-				"hostName": RANConfig.Spoke1Hostname,
-			}},
+			"nodes":       buildClusterInstanceNodes(hostnames),
 		})
 
-	return prBuilder
+	return prBuilder, nil
 }
 
 // NewSecondaryProvisioningRequest creates a ProvisioningRequest builder for a secondary PR using TestPRName2 and
@@ -43,7 +49,7 @@ func NewProvisioningRequest(client runtimeclient.Client, templateVersion string)
 func NewSecondaryProvisioningRequest(
 	client runtimeclient.Client, templateVersion string) *oran.ProvisioningRequestBuilder {
 	versionWithAffix := RANConfig.ClusterTemplateAffix + "-" + templateVersion
-	prBuilder := oran.NewPRBuilder(client, tsparams.TestPRName2, tsparams.ClusterTemplateName, versionWithAffix).
+	prBuilder := oran.NewPRBuilder(client, tsparams.TestPRName2, GetClusterTemplateName(), versionWithAffix).
 		WithTemplateParameter("nodeClusterName", tsparams.TestName2).
 		WithTemplateParameter("oCloudSiteId", tsparams.OCloudSiteID).
 		WithTemplateParameter("policyTemplateParameters", map[string]any{}).

--- a/tests/cnf/ran/oran/internal/helper/helper.go
+++ b/tests/cnf/ran/oran/internal/helper/helper.go
@@ -25,42 +25,86 @@ import (
 // ClusterInstance files unless ECO_CNF_RAN_CLUSTER_TEMPLATE_NAME overrides it.
 func NewProvisioningRequest(
 	client runtimeclient.Client, templateVersion string) (*oran.ProvisioningRequestBuilder, error) {
-	hostnames, err := GetSpokeHostnames()
+	spokeNodes, err := GetSpokeNodes()
 	if err != nil {
-		return nil, fmt.Errorf("resolve spoke hostnames for ProvisioningRequest: %w", err)
+		return nil, fmt.Errorf("resolve spoke nodes for ProvisioningRequest: %w", err)
+	}
+
+	clusterTemplateName, err := GetClusterTemplateName()
+	if err != nil {
+		return nil, fmt.Errorf("resolve ClusterTemplate name for ProvisioningRequest: %w", err)
+	}
+
+	clusterName, err := GetClusterInstanceClusterName()
+	if err != nil {
+		return nil, fmt.Errorf("resolve cluster name for ProvisioningRequest: %w", err)
 	}
 
 	versionWithAffix := RANConfig.ClusterTemplateAffix + "-" + templateVersion
-	prBuilder := oran.NewPRBuilder(client, tsparams.TestPRName, GetClusterTemplateName(), versionWithAffix).
+	clusterInstanceParams := map[string]any{
+		"clusterName": clusterName,
+	}
+
+	if clusterTemplateName == tsparams.MNOClusterTemplateName {
+		clusterInstanceParams["nodeGroups"] = buildClusterInstanceNodeGroups(spokeNodes)
+	} else {
+		hostnames := make([]string, 0, len(spokeNodes))
+		for _, node := range spokeNodes {
+			hostnames = append(hostnames, node.HostName)
+		}
+
+		clusterInstanceParams["nodes"] = buildClusterInstanceNodes(hostnames)
+	}
+
+	prBuilder := oran.NewPRBuilder(client, tsparams.TestPRName, clusterTemplateName, versionWithAffix).
 		WithTemplateParameter("nodeClusterName", RANConfig.Spoke1Name).
 		WithTemplateParameter("oCloudSiteId", tsparams.OCloudSiteID).
 		WithTemplateParameter("policyTemplateParameters", map[string]any{}).
-		WithTemplateParameter("clusterInstanceParameters", map[string]any{
-			"clusterName": RANConfig.Spoke1Name,
-			"nodes":       buildClusterInstanceNodes(hostnames),
-		})
+		WithTemplateParameter("clusterInstanceParameters", clusterInstanceParams)
 
 	return prBuilder, nil
 }
 
 // NewSecondaryProvisioningRequest creates a ProvisioningRequest builder for a secondary PR using TestPRName2 and
 // distinct cluster/node names so the request does not fail on clusterName ownership before hardware allocation is
-// attempted.
+// attempted. Node count matches the primary spoke topology so MNO pools remain fully claimed.
 func NewSecondaryProvisioningRequest(
-	client runtimeclient.Client, templateVersion string) *oran.ProvisioningRequestBuilder {
+	client runtimeclient.Client, templateVersion string) (*oran.ProvisioningRequestBuilder, error) {
+	clusterTemplateName, err := GetClusterTemplateName()
+	if err != nil {
+		return nil, fmt.Errorf("resolve ClusterTemplate name for secondary ProvisioningRequest: %w", err)
+	}
+
+	spokeNodes, err := GetSpokeNodes()
+	if err != nil {
+		return nil, fmt.Errorf("resolve spoke nodes for secondary ProvisioningRequest: %w", err)
+	}
+
+	secondaryNodes := buildSecondarySpokeNodes(spokeNodes)
 	versionWithAffix := RANConfig.ClusterTemplateAffix + "-" + templateVersion
-	prBuilder := oran.NewPRBuilder(client, tsparams.TestPRName2, GetClusterTemplateName(), versionWithAffix).
+
+	clusterInstanceParams := map[string]any{
+		"clusterName": tsparams.TestName2,
+	}
+
+	if clusterTemplateName == tsparams.MNOClusterTemplateName {
+		clusterInstanceParams["nodeGroups"] = buildClusterInstanceNodeGroups(secondaryNodes)
+	} else {
+		hostnames := make([]string, 0, len(secondaryNodes))
+		for _, node := range secondaryNodes {
+			hostnames = append(hostnames, node.HostName)
+		}
+
+		clusterInstanceParams["nodes"] = buildClusterInstanceNodes(hostnames)
+	}
+
+	prBuilder := oran.NewPRBuilder(client, tsparams.TestPRName2, clusterTemplateName, versionWithAffix).
 		WithTemplateParameter("nodeClusterName", tsparams.TestName2).
 		WithTemplateParameter("oCloudSiteId", tsparams.OCloudSiteID).
 		WithTemplateParameter("policyTemplateParameters", map[string]any{}).
-		WithTemplateParameter("clusterInstanceParameters", map[string]any{
-			"clusterName": tsparams.TestName2,
-			"nodes": []map[string]any{{
-				"hostName": tsparams.TestName2,
-			}},
-		})
+		WithTemplateParameter("clusterInstanceParameters", clusterInstanceParams)
 
-	return prBuilder
+	return prBuilder, nil
 }
 
 // WaitForNoncompliantImmutable waits up to timeout until one of the policies in namespace is NonCompliant and the

--- a/tests/cnf/ran/oran/internal/helper/helper.go
+++ b/tests/cnf/ran/oran/internal/helper/helper.go
@@ -41,6 +41,7 @@ func NewProvisioningRequest(
 	}
 
 	versionWithAffix := RANConfig.ClusterTemplateAffix + "-" + templateVersion
+
 	clusterInstanceParams := map[string]any{
 		"clusterName": clusterName,
 	}
@@ -81,6 +82,7 @@ func NewSecondaryProvisioningRequest(
 	}
 
 	secondaryNodes := buildSecondarySpokeNodes(spokeNodes)
+
 	versionWithAffix := RANConfig.ClusterTemplateAffix + "-" + templateVersion
 
 	clusterInstanceParams := map[string]any{

--- a/tests/cnf/ran/oran/internal/tsparams/consts.go
+++ b/tests/cnf/ran/oran/internal/tsparams/consts.go
@@ -22,12 +22,16 @@ const (
 )
 
 const (
-	// ClusterTemplateName is the name without the version of the ClusterTemplate used in the ORAN tests. It is also
-	// the namespace the ClusterTemplates are in.
+	// ClusterTemplateName is the default ClusterTemplate base name (without version) for SNO O-RAN tests. It is also
+	// the namespace the ClusterTemplates are in. Prefer helper.GetClusterTemplateName() when building PRs so MNO labs
+	// can resolve to MNOClusterTemplateName.
 	ClusterTemplateName = "sno-ran-du"
+	// MNOClusterTemplateName is the default ClusterTemplate base name for multi-node O-RAN provision tests.
+	MNOClusterTemplateName = "mno-ran-du"
 	// O2IMSNamespace is the namespace used by the oran-o2ims operator.
 	O2IMSNamespace = "oran-o2ims"
-	// ExtraManifestsName is the name of the generated extra manifests ConfigMap in the cluster Namespace.
+	// ExtraManifestsName is the default generated extra manifests ConfigMap name for SNO. Prefer
+	// helper.GetExtraManifestsName() so the name matches the resolved ClusterTemplate.
 	ExtraManifestsName = "sno-ran-du-extra-manifest-1"
 	// ClusterInstanceParamsKey is the key in the TemplateParameters map for the ClusterInstance parameters.
 	ClusterInstanceParamsKey = "clusterInstanceParameters"

--- a/tests/cnf/ran/oran/internal/tsparams/consts.go
+++ b/tests/cnf/ran/oran/internal/tsparams/consts.go
@@ -41,7 +41,8 @@ const (
 	HugePagesSizeKey = "hugepages-size"
 	// OCloudSiteID is the name of the site in the hardware manager to provision in.
 	OCloudSiteID = "rdu3"
-	// PolicySelectorLabel is the ExtraLabel applied to the managed cluster that determines which policies to apply.
+	// PolicySelectorLabel is the ExtraLabel applied to the managed cluster that determines which policies to apply
+	// for SNO. Prefer helper.GetPolicySelectorLabel() so MNO resolves to mno-ran-du-policy.
 	PolicySelectorLabel = "sno-ran-du-policy"
 	// ClusterInstanceDefaultsKey is the key used for the ClusterInstance defaults in its ConfigMap.
 	ClusterInstanceDefaultsKey = "clusterinstance-defaults"
@@ -54,6 +55,9 @@ const (
 	// PRValidationFailedDetailsSubstring is a substring of status.provisioningStatus.provisioningDetails when
 	// ProvisioningRequest validation fails.
 	PRValidationFailedDetailsSubstring = "Failed to validate the ProvisioningRequest"
+	// PRInvalidPolicyTemplateParamDetailsSubstring is a substring of provisioningDetails when
+	// policyTemplateParameters fail schema type validation during policy template rendering.
+	PRInvalidPolicyTemplateParamDetailsSubstring = "policyTemplateParameters/policyTemplateSchema"
 	// PRFulfilledDetailsSubstring is a substring of status.provisioningStatus.provisioningDetails when
 	// provisioning completes successfully.
 	PRFulfilledDetailsSubstring = "Provisioning request has completed successfully"

--- a/tests/cnf/ran/oran/scripts/oran-mno-install-watch.sh
+++ b/tests/cnf/ran/oran/scripts/oran-mno-install-watch.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# Lab helper for MNO O-RAN provision (77394): watch hub/spoke install progress and
+# optionally apply the machine-api finalize workaround before the O2IMS ~1h30m install timeout.
+#
+# Usage:
+#   export ECO_CNF_RAN_KUBECONFIG_HUB=/path/to/hub.kubeconfig
+#   export ECO_CNF_RAN_SPOKE1_NAME=kni-qe-26
+#   ./oran-mno-install-watch.sh              # poll every 60s, report only
+#   ./oran-mno-install-watch.sh --fix        # apply workaround when trap is detected
+#   ./oran-mno-install-watch.sh --once       # single snapshot
+#
+# Spoke kubeconfig defaults to /tmp/<spoke>-admin.kubeconfig and is pulled from the hub
+# secret when missing.
+
+set -uo pipefail
+
+SPOKE_NAME="${ECO_CNF_RAN_SPOKE1_NAME:-kni-qe-26}"
+PR_NAME="${ORAN_TEST_PR_NAME:-9c5372f3-ea1d-4a96-8157-b3b874a55cf9}"
+HUB_KUBECONFIG="${ECO_CNF_RAN_KUBECONFIG_HUB:-${KUBECONFIG:-}}"
+SPOKE_KUBECONFIG="${ORAN_SPOKE_KUBECONFIG:-/tmp/${SPOKE_NAME}-admin.kubeconfig}"
+INTERVAL="${ORAN_WATCH_INTERVAL:-60}"
+EXPECTED_NODES="${ORAN_EXPECTED_NODE_COUNT:-5}"
+FIX_MODE=false
+ONCE=false
+
+usage() {
+	sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+log() {
+	printf '[%s] %s\n' "$(date -u +%H:%M:%SZ)" "$*"
+}
+
+warn() {
+	printf '[%s] WARNING: %s\n' "$(date -u +%H:%M:%SZ)" "$*" >&2
+}
+
+hub_oc() {
+	KUBECONFIG="${HUB_KUBECONFIG}" oc "$@"
+}
+
+spoke_oc() {
+	KUBECONFIG="${SPOKE_KUBECONFIG}" oc "$@"
+}
+
+parse_args() {
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--fix) FIX_MODE=true ;;
+		--once) ONCE=true ;;
+		-h | --help)
+			usage
+			exit 0
+			;;
+		*)
+			echo "unknown argument: $1" >&2
+			usage
+			exit 2
+			;;
+		esac
+		shift
+	done
+}
+
+require_hub_kubeconfig() {
+	if [[ -z "${HUB_KUBECONFIG}" ]]; then
+		echo "set ECO_CNF_RAN_KUBECONFIG_HUB or KUBECONFIG to the hub kubeconfig" >&2
+		exit 1
+	fi
+	if ! hub_oc whoami >/dev/null 2>&1; then
+		echo "hub kubeconfig is not usable: ${HUB_KUBECONFIG}" >&2
+		exit 1
+	fi
+}
+
+ensure_spoke_kubeconfig() {
+	if [[ -f "${SPOKE_KUBECONFIG}" ]] && spoke_oc whoami >/dev/null 2>&1; then
+		return 0
+	fi
+
+	if ! hub_oc get secret "${SPOKE_NAME}-admin-kubeconfig" -n "${SPOKE_NAME}" >/dev/null 2>&1; then
+		return 1
+	fi
+
+	log "pulling spoke admin kubeconfig to ${SPOKE_KUBECONFIG}"
+	hub_oc get secret "${SPOKE_NAME}-admin-kubeconfig" -n "${SPOKE_NAME}" \
+		-o jsonpath='{.data.kubeconfig}' | base64 -d >"${SPOKE_KUBECONFIG}"
+	chmod 600 "${SPOKE_KUBECONFIG}"
+}
+
+print_hub_status() {
+	local aci_state aci_progress pr_phase pr_details agents_done agents_total mc_import
+
+	if ! hub_oc get namespace "${SPOKE_NAME}" >/dev/null 2>&1; then
+		log "hub: namespace ${SPOKE_NAME} not found yet"
+		return 0
+	fi
+
+	aci_state="$(hub_oc get aci "${SPOKE_NAME}" -n "${SPOKE_NAME}" -o jsonpath='{.status.debugInfo.stateInfo}' 2>/dev/null || true)"
+	aci_progress="$(hub_oc get aci "${SPOKE_NAME}" -n "${SPOKE_NAME}" -o jsonpath='{.status.progress.totalPercentage}' 2>/dev/null || true)"
+	pr_phase="$(hub_oc get pr "${PR_NAME}" -o jsonpath='{.status.provisioningStatus.provisioningPhase}' 2>/dev/null || true)"
+	pr_details="$(hub_oc get pr "${PR_NAME}" -o jsonpath='{.status.provisioningStatus.provisioningDetails}' 2>/dev/null || true)"
+	agents_done="$(hub_oc get agents -A --no-headers 2>/dev/null | awk -v c="${SPOKE_NAME}" '$3==c && toupper($6)=="DONE" {n++} END {print n+0}')"
+	agents_total="$(hub_oc get agents -A --no-headers 2>/dev/null | awk -v c="${SPOKE_NAME}" '$3==c {n++} END {print n+0}')"
+	mc_import="$(hub_oc get managedcluster "${SPOKE_NAME}" -o jsonpath='{.status.conditions[?(@.type=="ManagedClusterImportSucceeded")].status}' 2>/dev/null || echo "missing")"
+
+	log "hub: ACI state=${aci_state:-n/a} progress=${aci_progress:-n/a}% agents=${agents_done}/${agents_total} MC import=${mc_import}"
+	log "hub: PR phase=${pr_phase:-n/a} details=${pr_details:-n/a}"
+}
+
+print_spoke_status() {
+	local ready_nodes machine_api_avail cvo_avail
+
+	if ! ensure_spoke_kubeconfig; then
+		log "spoke: admin kubeconfig not available yet"
+		return 0
+	fi
+
+	ready_nodes="$(spoke_oc get nodes --no-headers 2>/dev/null | awk '$2=="Ready"{c++} END{print c+0}')"
+	machine_api_avail="$(spoke_oc get co machine-api -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null || true)"
+	cvo_avail="$(spoke_oc get clusterversion version -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null || true)"
+
+	log "spoke: ready_nodes=${ready_nodes}/${EXPECTED_NODES} machine-api=${machine_api_avail:-n/a} clusterversion=${cvo_avail:-n/a}"
+	log "spoke: machines:"
+	spoke_oc get machines -n openshift-machine-api -o custom-columns=\
+NAME:.metadata.name,PHASE:.status.phase,NODE:.status.nodeRef.name 2>/dev/null || true
+	log "spoke: bmhs:"
+	spoke_oc get bmh -n openshift-machine-api -o custom-columns=\
+NAME:.metadata.name,STATE:.status.provisioning.state,CONSUMER:.spec.consumerRef.name 2>/dev/null || true
+}
+
+trap_detected() {
+	local trap=false
+
+	if ! ensure_spoke_kubeconfig; then
+		return 1
+	fi
+
+	local ready_nodes provisioning provisioned empty_state need_link
+	ready_nodes="$(spoke_oc get nodes --no-headers 2>/dev/null | awk '$2=="Ready"{c++} END{print c+0}')"
+	provisioning="$(spoke_oc get machines -n openshift-machine-api --no-headers 2>/dev/null | awk '$2=="Provisioning"{c++} END{print c+0}')"
+	provisioned="$(spoke_oc get machines -n openshift-machine-api --no-headers 2>/dev/null | awk '$2=="Provisioned"{c++} END{print c+0}')"
+	empty_state="$(spoke_oc get bmh -n openshift-machine-api -o json 2>/dev/null | jq -r '[.items[] | select((.status.provisioning.state // "") == "")] | length')"
+	need_link="$(spoke_oc get machines -n openshift-machine-api -o json 2>/dev/null | jq -r '[.items[] | select(.status.phase=="Provisioned" and (.status.nodeRef.name // "") == "")] | length')"
+
+	if [[ "${ready_nodes}" -ge "${EXPECTED_NODES}" && "${provisioning}" -gt 0 && "${empty_state}" -gt 0 ]]; then
+		trap=true
+		log "trap: nodes Ready but Machines Provisioning with empty BMH provisioning.state"
+	fi
+
+	if [[ "${ready_nodes}" -ge "${EXPECTED_NODES}" && "${need_link}" -gt 0 ]]; then
+		trap=true
+		log "trap: Machines Provisioned without nodeRef while nodes are Ready"
+	fi
+
+	if [[ "${trap}" == true ]]; then
+		return 0
+	fi
+	return 1
+}
+
+apply_bmh_status_fix() {
+	log "applying BMH status patch on spoke"
+	spoke_oc get bmh -n openshift-machine-api -o json | jq -r '.items[].metadata.name' | while read -r bmh; do
+		[[ -z "${bmh}" ]] && continue
+		state="$(spoke_oc get bmh "${bmh}" -n openshift-machine-api -o jsonpath='{.status.provisioning.state}')"
+		if [[ -n "${state}" ]]; then
+			log "  skip ${bmh}: state already ${state}"
+			continue
+		fi
+		uid="$(spoke_oc get bmh "${bmh}" -n openshift-machine-api -o jsonpath='{.metadata.uid}')"
+		spoke_oc patch bmh "${bmh}" -n openshift-machine-api --type=merge --subresource=status -p "{
+			\"status\": {
+				\"operationalStatus\": \"OK\",
+				\"errorMessage\": \"\",
+				\"poweredOn\": true,
+				\"provisioning\": {
+					\"state\": \"externally provisioned\",
+					\"ID\": \"${uid}\"
+				}
+			}
+		}"
+		log "  patched ${bmh}"
+	done
+}
+
+apply_machine_node_link_fix() {
+	log "linking Machines to Nodes on spoke"
+	spoke_oc get bmh -n openshift-machine-api -o json | jq -r '.items[] | [.spec.consumerRef.name, .metadata.name] | @tsv' |
+		while IFS=$'\t' read -r machine node; do
+			[[ -z "${machine}" || -z "${node}" ]] && continue
+
+			phase="$(spoke_oc get machine "${machine}" -n openshift-machine-api -o jsonpath='{.status.phase}')"
+			node_ref="$(spoke_oc get machine "${machine}" -n openshift-machine-api -o jsonpath='{.status.nodeRef.name}')"
+			if [[ "${phase}" == "Running" && -n "${node_ref}" ]]; then
+				log "  skip ${machine}: already Running on ${node_ref}"
+				continue
+			fi
+
+			provider_id="$(spoke_oc get machine "${machine}" -n openshift-machine-api -o jsonpath='{.spec.providerID}')"
+			node_uid="$(spoke_oc get node "${node}" -o jsonpath='{.metadata.uid}')"
+			if [[ -z "${provider_id}" || -z "${node_uid}" ]]; then
+				warn "  skip ${machine}: missing providerID or node uid for ${node}"
+				continue
+			fi
+
+			spoke_oc patch node "${node}" --type=merge -p "{
+				\"metadata\": {
+					\"annotations\": {
+						\"machine.openshift.io/machine\": \"openshift-machine-api/${machine}\"
+					}
+				},
+				\"spec\": {
+					\"providerID\": \"${provider_id}\"
+				}
+			}"
+
+			spoke_oc patch machine "${machine}" -n openshift-machine-api --type=merge --subresource=status -p "{
+				\"status\": {
+					\"phase\": \"Running\",
+					\"nodeRef\": {
+						\"kind\": \"Node\",
+						\"name\": \"${node}\",
+						\"uid\": \"${node_uid}\"
+					}
+				}
+			}"
+			log "  linked ${machine} -> ${node}"
+		done
+}
+
+maybe_apply_fix() {
+	if ! trap_detected; then
+		return 0
+	fi
+
+	if [[ "${FIX_MODE}" != true ]]; then
+		warn "trap detected; rerun with --fix to apply the lab workaround"
+		return 0
+	fi
+
+	apply_bmh_status_fix
+	sleep 10
+	apply_machine_node_link_fix
+	log "workaround applied; waiting for operators to reconcile"
+}
+
+snapshot() {
+	print_hub_status
+	print_spoke_status
+	maybe_apply_fix
+}
+
+main() {
+	parse_args "$@"
+	require_hub_kubeconfig
+
+	if ! command -v jq >/dev/null 2>&1; then
+		echo "jq is required" >&2
+		exit 1
+	fi
+
+	log "watching spoke=${SPOKE_NAME} pr=${PR_NAME} fix_mode=${FIX_MODE}"
+
+	if [[ "${ONCE}" == true ]]; then
+		snapshot
+		exit 0
+	fi
+
+	while true; do
+		snapshot
+
+		pr_phase="$(hub_oc get pr "${PR_NAME}" -o jsonpath='{.status.provisioningStatus.provisioningPhase}' 2>/dev/null || true)"
+		if [[ "${pr_phase}" == "fulfilled" ]]; then
+			log "PR fulfilled; exiting"
+			exit 0
+		fi
+		if [[ "${pr_phase}" == "failed" ]]; then
+			warn "PR failed; exiting"
+			exit 1
+		fi
+
+		sleep "${INTERVAL}"
+	done
+}
+
+main "$@"

--- a/tests/cnf/ran/oran/tests/oran-day2-metal3.go
+++ b/tests/cnf/ran/oran/tests/oran-day2-metal3.go
@@ -47,8 +47,10 @@ var _ = Describe("ORAN Metal3 Day2 Tests", Label(tsparams.LabelMetal3Day2), Orde
 	It("fails when all matching hardware is already allocated", reportxml.ID("83883"), func() {
 		By("creating a second ProvisioningRequest when hardware is already allocated")
 
-		prBuilder2 := helper.NewSecondaryProvisioningRequest(o2imsAPIClient, tsparams.TemplateHardwareAllocated)
-		prBuilder2, err := prBuilder2.Create()
+		prBuilder2, err := helper.NewSecondaryProvisioningRequest(o2imsAPIClient, tsparams.TemplateHardwareAllocated)
+		Expect(err).ToNot(HaveOccurred(), "Failed to build second ProvisioningRequest when hardware is allocated")
+
+		prBuilder2, err = prBuilder2.Create()
 		Expect(err).ToNot(HaveOccurred(), "Failed to create second ProvisioningRequest when hardware is allocated")
 
 		DeferCleanup(func() {

--- a/tests/cnf/ran/oran/tests/oran-day2-metal3.go
+++ b/tests/cnf/ran/oran/tests/oran-day2-metal3.go
@@ -1,14 +1,20 @@
 package tests
 
 import (
+	"context"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
+	bmhv1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	hardwaremanagementv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/bmh"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/mco"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/siteconfig"
@@ -16,13 +22,19 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/auth"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/helper"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Metal3 day2 tests run in their own file so they do not inherit the PR-restore AfterEach from the standard
 // post-provision tests. Rolling back each change would require firmware changes and a reboot, which is extra time we do
 // not need to spend.
-var _ = Describe("ORAN Metal3 Day2 Tests", Label(tsparams.LabelMetal3Day2), Ordered, ContinueOnFailure, func() {
+
+// 83883 only requires hardware to be allocated to the primary PR, not a fulfilled install. It runs in a separate
+// Describe so it can complete TCFE while the primary PR is still failed/progressing but hardware is claimed.
+var _ = Describe("ORAN Metal3 Day2 Hardware Allocation", Label(tsparams.LabelMetal3Day2), func() {
 	var o2imsAPIClient runtimeclient.Client
 
 	BeforeEach(func() {
@@ -34,13 +46,23 @@ var _ = Describe("ORAN Metal3 Day2 Tests", Label(tsparams.LabelMetal3Day2), Orde
 		o2imsAPIClient, err = clientBuilder.BuildProvisioning()
 		Expect(err).ToNot(HaveOccurred(), "Failed to create the O2IMS API client")
 
-		By("verifying ProvisioningRequest is fulfilled to start")
+		By("verifying primary ProvisioningRequest has allocated hardware")
 
 		prBuilder, err := oran.PullPR(o2imsAPIClient, tsparams.TestPRName)
 		Expect(err).ToNot(HaveOccurred(), "Failed to pull spoke 1 ProvisioningRequest")
 
-		_, err = prBuilder.WaitUntilFulfilled(3 * time.Minute)
-		Expect(err).ToNot(HaveOccurred(), "Failed to verify spoke 1 ProvisioningRequest is fulfilled")
+		resourceStatuses := prBuilder.Object.Status.Extensions.InfrastructureResourceStatuses
+		expectedHostnames, err := helper.GetSpokeHostnames()
+		Expect(err).ToNot(HaveOccurred(), "Failed to resolve expected spoke hostnames")
+		Expect(resourceStatuses).To(HaveLen(len(expectedHostnames)),
+			"Expected primary ProvisioningRequest to claim all spoke nodes before running 83883")
+
+		for _, resourceStatus := range resourceStatuses {
+			Expect(resourceStatus.ResourceProvisioningPhase).
+				To(Equal(provisioningv1alpha1.ResourceProvisioningPhaseProvisioned),
+					"Expected infrastructure resource %q to be provisioned before running 83883",
+					resourceStatus.ResourceId)
+		}
 	})
 
 	// 83883 - Failed provisioning due to all matching hardware already allocated
@@ -60,14 +82,6 @@ var _ = Describe("ORAN Metal3 Day2 Tests", Label(tsparams.LabelMetal3Day2), Orde
 				err := prBuilder2.DeleteAndWait(10 * time.Minute)
 				Expect(err).ToNot(HaveOccurred(), "Failed to delete the second ProvisioningRequest")
 			}
-
-			By("waiting for the primary ProvisioningRequest to return to fulfilled after second PR cleanup")
-
-			primaryPR, err := oran.PullPR(o2imsAPIClient, tsparams.TestPRName)
-			Expect(err).ToNot(HaveOccurred(), "Failed to pull primary ProvisioningRequest after second PR cleanup")
-			_, err = primaryPR.WaitUntilFulfilled(5 * time.Minute)
-			Expect(err).ToNot(HaveOccurred(),
-				"Failed to wait for primary ProvisioningRequest to return to fulfilled after second PR cleanup")
 		})
 
 		By("waiting for second ProvisioningRequest to fail due to allocated hardware")
@@ -84,6 +98,28 @@ var _ = Describe("ORAN Metal3 Day2 Tests", Label(tsparams.LabelMetal3Day2), Orde
 		Expect(currentPR.Definition.Status.ProvisioningStatus.ProvisioningDetails).
 			To(ContainSubstring(tsparams.PRNoHardwareMatchDetailsSubstring),
 				"Expected provisioning details to report no free hardware matching the resource selector")
+	})
+})
+
+var _ = Describe("ORAN Metal3 Day2 Tests", Label(tsparams.LabelMetal3Day2), Ordered, ContinueOnFailure, func() {
+	var o2imsAPIClient runtimeclient.Client
+
+	BeforeEach(func() {
+		By("creating the O2IMS API client")
+
+		clientBuilder, err := auth.NewClientBuilderForConfig(RANConfig)
+		Expect(err).ToNot(HaveOccurred(), "Failed to create the O2IMS API client builder")
+
+		o2imsAPIClient, err = clientBuilder.BuildProvisioning()
+		Expect(err).ToNot(HaveOccurred(), "Failed to create the O2IMS API client")
+
+		By("verifying ProvisioningRequest is fulfilled to start")
+
+		prBuilder, err := oran.PullPR(o2imsAPIClient, tsparams.TestPRName)
+		Expect(err).ToNot(HaveOccurred(), "Failed to pull spoke 1 ProvisioningRequest")
+
+		_, err = prBuilder.WaitUntilFulfilled(3 * time.Minute)
+		Expect(err).ToNot(HaveOccurred(), "Failed to verify spoke 1 ProvisioningRequest is fulfilled")
 	})
 
 	// 83877 - Successful day2 upgrade of BMC firmware
@@ -107,11 +143,9 @@ var _ = Describe("ORAN Metal3 Day2 Tests", Label(tsparams.LabelMetal3Day2), Orde
 		Expect(err).ToNot(HaveOccurred(), "Failed to wait for ProvisioningRequest to enter progressing state")
 
 		By("waiting for ProvisioningRequest to be fulfilled after BMC firmware update")
+		waitForPRFulfilledWithMNOExtras(o2imsAPIClient, prBuilder, updateTime, 120*time.Minute)
 
-		err = prBuilder.WaitForPhaseAfter(provisioningv1alpha1.StateFulfilled, updateTime, 120*time.Minute)
-		Expect(err).ToNot(HaveOccurred(), "Failed to wait for ProvisioningRequest to be fulfilled after BMC firmware update")
-
-		By("verifying BMC firmware has been updated")
+		By("verifying BMC firmware has been updated on all nodes")
 		verifyFirmwareUpdate(prBuilder, "bmc")
 	})
 
@@ -136,12 +170,9 @@ var _ = Describe("ORAN Metal3 Day2 Tests", Label(tsparams.LabelMetal3Day2), Orde
 		Expect(err).ToNot(HaveOccurred(), "Failed to wait for ProvisioningRequest to enter progressing state")
 
 		By("waiting for ProvisioningRequest to be fulfilled after BIOS firmware update")
+		waitForPRFulfilledWithMNOExtras(o2imsAPIClient, prBuilder, updateTime, 120*time.Minute)
 
-		err = prBuilder.WaitForPhaseAfter(provisioningv1alpha1.StateFulfilled, updateTime, 120*time.Minute)
-		Expect(err).ToNot(HaveOccurred(),
-			"Failed to wait for ProvisioningRequest to be fulfilled after BIOS firmware update")
-
-		By("verifying BIOS firmware has been updated")
+		By("verifying BIOS firmware has been updated on all nodes")
 		verifyFirmwareUpdate(prBuilder, "bios")
 	})
 
@@ -161,19 +192,21 @@ var _ = Describe("ORAN Metal3 Day2 Tests", Label(tsparams.LabelMetal3Day2), Orde
 		Expect(err).ToNot(HaveOccurred(), "Failed to update ProvisioningRequest with new BIOS settings template")
 
 		By("waiting for ProvisioningRequest to be fulfilled after BIOS settings update")
+		waitForPRFulfilledWithMNOExtras(o2imsAPIClient, prBuilder, updateTime, 120*time.Minute)
 
-		err = prBuilder.WaitForPhaseAfter(provisioningv1alpha1.StateFulfilled, updateTime, 120*time.Minute)
-		Expect(err).ToNot(HaveOccurred(),
-			"Failed to wait for ProvisioningRequest to be fulfilled after BIOS settings update")
-
-		By("verifying BIOS settings have been updated")
+		By("verifying BIOS settings have been updated on all nodes")
 		verifyBIOSSettingsUpdate(prBuilder)
 	})
 })
 
-// getMetal3HostRef returns the BareMetalHost key from the spoke ClusterInstance node HostRef. It uses Spoke1Name to get
-// the ClusterInstance and node. The returned pointer is nil if and only if an error occurs.
-func getMetal3HostRef() (*runtimeclient.ObjectKey, error) {
+// metal3HostRef associates a ClusterInstance node role with its BareMetalHost key.
+type metal3HostRef struct {
+	Role string
+	Key  runtimeclient.ObjectKey
+}
+
+// getMetal3HostRefs returns BareMetalHost keys for every ClusterInstance node with a HostRef.
+func getMetal3HostRefs() ([]metal3HostRef, error) {
 	clusterInstance, err := siteconfig.PullClusterInstance(HubAPIClient, RANConfig.Spoke1Name, RANConfig.Spoke1Name)
 	if err != nil {
 		return nil, fmt.Errorf("pull spoke 1 ClusterInstance: %w", err)
@@ -183,17 +216,25 @@ func getMetal3HostRef() (*runtimeclient.ObjectKey, error) {
 		return nil, fmt.Errorf("cluster instance %s has no nodes", RANConfig.Spoke1Name)
 	}
 
-	node := clusterInstance.Definition.Spec.Nodes[0]
-	if node.HostRef == nil || node.HostRef.Name == "" || node.HostRef.Namespace == "" {
-		return nil, fmt.Errorf("cluster instance %s node has no BareMetalHost hostRef", RANConfig.Spoke1Name)
+	hostRefs := make([]metal3HostRef, 0, len(clusterInstance.Definition.Spec.Nodes))
+
+	for i, node := range clusterInstance.Definition.Spec.Nodes {
+		if node.HostRef == nil || node.HostRef.Name == "" || node.HostRef.Namespace == "" {
+			return nil, fmt.Errorf("cluster instance %s nodes[%d] has no BareMetalHost hostRef",
+				RANConfig.Spoke1Name, i)
+		}
+
+		hostRefs = append(hostRefs, metal3HostRef{
+			Role: node.Role,
+			Key:  runtimeclient.ObjectKey{Name: node.HostRef.Name, Namespace: node.HostRef.Namespace},
+		})
 	}
 
-	return &runtimeclient.ObjectKey{Name: node.HostRef.Name, Namespace: node.HostRef.Namespace}, nil
+	return hostRefs, nil
 }
 
-// getHardwareProfileFromPR returns the HardwareProfileBuilder for the HardwareProfile referenced by the
-// ProvisioningRequest's ClusterTemplate hwMgmtDefaults.
-func getHardwareProfileFromPR(prBuilder *oran.ProvisioningRequestBuilder) *oran.HardwareProfileBuilder {
+// getHardwareProfilesByRole returns HardwareProfile builders keyed by node group role from the PR ClusterTemplate.
+func getHardwareProfilesByRole(prBuilder *oran.ProvisioningRequestBuilder) map[string]*oran.HardwareProfileBuilder {
 	By("getting the ClusterTemplate for hardware profile verification")
 
 	clusterTemplateName := fmt.Sprintf("%s.%s",
@@ -207,86 +248,362 @@ func getHardwareProfileFromPR(prBuilder *oran.ProvisioningRequestBuilder) *oran.
 	Expect(nodeGroupData).ToNot(BeEmpty(),
 		"ClusterTemplate hwMgmtDefaults must include nodeGroupData")
 
-	hwProfileName := nodeGroupData[0].HwProfile
-	Expect(hwProfileName).ToNot(BeEmpty(),
-		"ClusterTemplate hwMgmtDefaults nodeGroupData must specify hwProfile")
+	profilesByRole := make(map[string]*oran.HardwareProfileBuilder, len(nodeGroupData))
 
-	By(fmt.Sprintf("getting the HardwareProfile %s for verification", hwProfileName))
+	for _, group := range nodeGroupData {
+		Expect(group.HwProfile).ToNot(BeEmpty(),
+			"ClusterTemplate hwMgmtDefaults nodeGroupData must specify hwProfile")
 
-	hwProfileBuilder, err := oran.PullHardwareProfile(HubAPIClient, hwProfileName, tsparams.O2IMSNamespace)
-	Expect(err).ToNot(HaveOccurred(), "Failed to pull HardwareProfile %s", hwProfileName)
-	Expect(hwProfileBuilder.Object).ToNot(BeNil(), "HardwareProfile object should not be nil")
+		role := group.Role
+		if role == "" {
+			role = group.Name
+		}
 
-	return hwProfileBuilder
-}
+		By(fmt.Sprintf("getting the HardwareProfile %s for role %s", group.HwProfile, role))
 
-// verifyFirmwareUpdate verifies that the firmware component (bmc or bios) has been updated according to the
-// HardwareProfile specified in the ClusterTemplate referenced by the ProvisioningRequest.
-func verifyFirmwareUpdate(prBuilder *oran.ProvisioningRequestBuilder, componentType string) {
-	hwProfileBuilder := getHardwareProfileFromPR(prBuilder)
+		hwProfileBuilder, err := oran.PullHardwareProfile(HubAPIClient, group.HwProfile, tsparams.O2IMSNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Failed to pull HardwareProfile %s", group.HwProfile)
+		Expect(hwProfileBuilder.Object).ToNot(BeNil(), "HardwareProfile object should not be nil")
 
-	var expectedFirmware hardwaremanagementv1alpha1.Firmware
-	if componentType == "bmc" {
-		expectedFirmware = hwProfileBuilder.Object.Spec.BmcFirmware
-	} else {
-		expectedFirmware = hwProfileBuilder.Object.Spec.BiosFirmware
-	}
+		profilesByRole[role] = hwProfileBuilder
 
-	Expect(expectedFirmware.IsEmpty()).To(BeFalse(),
-		"No %s firmware specification in HardwareProfile", componentType)
-
-	By(fmt.Sprintf("verifying HostFirmwareComponents for %s firmware", componentType))
-
-	hostRef, err := getMetal3HostRef()
-	Expect(err).ToNot(HaveOccurred(), "Failed to get Metal3 BareMetalHost from ClusterInstance")
-
-	hfc, err := bmh.PullHFC(HubAPIClient, hostRef.Name, hostRef.Namespace)
-	Expect(err).ToNot(HaveOccurred(),
-		"Failed to pull HostFirmwareComponents for %s in namespace %s", hostRef.Name, hostRef.Namespace)
-
-	var componentFound bool
-
-	for _, component := range hfc.Object.Status.Components {
-		if component.Component == componentType {
-			componentFound = true
-
-			Expect(component.CurrentVersion).To(Equal(expectedFirmware.Version),
-				"Expected %s firmware version %s, but found %s",
-				componentType, expectedFirmware.Version, component.CurrentVersion)
-
-			break
+		if group.Name != "" && group.Name != role {
+			profilesByRole[group.Name] = hwProfileBuilder
 		}
 	}
 
-	Expect(componentFound).To(BeTrue(), "Component %s not found in HostFirmwareComponents", componentType)
+	return profilesByRole
 }
 
-// verifyBIOSSettingsUpdate verifies that the BIOS settings have been updated according to the HardwareProfile specified
-// in the ClusterTemplate referenced by the ProvisioningRequest.
-func verifyBIOSSettingsUpdate(prBuilder *oran.ProvisioningRequestBuilder) {
-	hwProfileBuilder := getHardwareProfileFromPR(prBuilder)
-
-	expectedBIOSSettings := hwProfileBuilder.Object.Spec.Bios.Attributes
-	Expect(expectedBIOSSettings).ToNot(BeEmpty(),
-		"HardwareProfile must include BIOS attributes")
-
-	By("verifying HostFirmwareSettings for BIOS settings")
-
-	hostRef, err := getMetal3HostRef()
-	Expect(err).ToNot(HaveOccurred(), "Failed to get Metal3 BareMetalHost from ClusterInstance")
-
-	hfs, err := bmh.PullHFS(HubAPIClient, hostRef.Name, hostRef.Namespace)
-	Expect(err).ToNot(HaveOccurred(),
-		"Failed to pull HostFirmwareSettings for %s in namespace %s", hostRef.Name, hostRef.Namespace)
-
-	for settingName, expectedValue := range expectedBIOSSettings {
-		actualValue, exists := hfs.Object.Status.Settings[settingName]
-		Expect(exists).To(BeTrue(), "BIOS setting %s not found in HostFirmwareSettings", settingName)
-
-		// To make the comparison easier, convert IntOrString to string.
-		expectedValueStr := expectedValue.String()
-		Expect(actualValue).To(Equal(expectedValueStr),
-			"Expected BIOS setting %s to be %s, but found %s",
-			settingName, expectedValueStr, actualValue)
+func hardwareProfileForRole(
+	profilesByRole map[string]*oran.HardwareProfileBuilder, role string) *oran.HardwareProfileBuilder {
+	if profile, ok := profilesByRole[role]; ok {
+		return profile
 	}
+
+	if len(profilesByRole) == 1 {
+		for _, profile := range profilesByRole {
+			return profile
+		}
+	}
+
+	return nil
+}
+
+// verifyFirmwareUpdate verifies firmware on every ClusterInstance BareMetalHost.
+func verifyFirmwareUpdate(prBuilder *oran.ProvisioningRequestBuilder, componentType string) {
+	profilesByRole := getHardwareProfilesByRole(prBuilder)
+	hostRefs, err := getMetal3HostRefs()
+	Expect(err).ToNot(HaveOccurred(), "Failed to get Metal3 BareMetalHosts from ClusterInstance")
+
+	By(fmt.Sprintf("verifying HostFirmwareComponents for %s firmware on %d nodes", componentType, len(hostRefs)))
+
+	for _, hostRef := range hostRefs {
+		hwProfileBuilder := hardwareProfileForRole(profilesByRole, hostRef.Role)
+		Expect(hwProfileBuilder).ToNot(BeNil(),
+			"No HardwareProfile found for node role %q on BMH %s/%s",
+			hostRef.Role, hostRef.Key.Namespace, hostRef.Key.Name)
+
+		var expectedFirmware hardwaremanagementv1alpha1.Firmware
+		if componentType == "bmc" {
+			expectedFirmware = hwProfileBuilder.Object.Spec.BmcFirmware
+		} else {
+			expectedFirmware = hwProfileBuilder.Object.Spec.BiosFirmware
+		}
+
+		Expect(expectedFirmware.IsEmpty()).To(BeFalse(),
+			"No %s firmware specification in HardwareProfile for role %s", componentType, hostRef.Role)
+
+		hfc, err := bmh.PullHFC(HubAPIClient, hostRef.Key.Name, hostRef.Key.Namespace)
+		Expect(err).ToNot(HaveOccurred(),
+			"Failed to pull HostFirmwareComponents for %s in namespace %s",
+			hostRef.Key.Name, hostRef.Key.Namespace)
+
+		componentFound := false
+
+		for _, component := range hfc.Object.Status.Components {
+			if component.Component == componentType {
+				componentFound = true
+
+				Expect(component.CurrentVersion).To(Equal(expectedFirmware.Version),
+					"Expected %s firmware version %s on BMH %s/%s, but found %s",
+					componentType, expectedFirmware.Version,
+					hostRef.Key.Namespace, hostRef.Key.Name, component.CurrentVersion)
+
+				break
+			}
+		}
+
+		Expect(componentFound).To(BeTrue(),
+			"Component %s not found in HostFirmwareComponents for BMH %s/%s",
+			componentType, hostRef.Key.Namespace, hostRef.Key.Name)
+	}
+}
+
+// verifyBIOSSettingsUpdate verifies BIOS settings on every ClusterInstance BareMetalHost.
+func verifyBIOSSettingsUpdate(prBuilder *oran.ProvisioningRequestBuilder) {
+	profilesByRole := getHardwareProfilesByRole(prBuilder)
+	hostRefs, err := getMetal3HostRefs()
+	Expect(err).ToNot(HaveOccurred(), "Failed to get Metal3 BareMetalHosts from ClusterInstance")
+
+	By(fmt.Sprintf("verifying HostFirmwareSettings for BIOS settings on %d nodes", len(hostRefs)))
+
+	for _, hostRef := range hostRefs {
+		hwProfileBuilder := hardwareProfileForRole(profilesByRole, hostRef.Role)
+		Expect(hwProfileBuilder).ToNot(BeNil(),
+			"No HardwareProfile found for node role %q on BMH %s/%s",
+			hostRef.Role, hostRef.Key.Namespace, hostRef.Key.Name)
+
+		expectedBIOSSettings := hwProfileBuilder.Object.Spec.Bios.Attributes
+		Expect(expectedBIOSSettings).ToNot(BeEmpty(),
+			"HardwareProfile must include BIOS attributes for role %s", hostRef.Role)
+
+		hfs, err := bmh.PullHFS(HubAPIClient, hostRef.Key.Name, hostRef.Key.Namespace)
+		Expect(err).ToNot(HaveOccurred(),
+			"Failed to pull HostFirmwareSettings for %s in namespace %s",
+			hostRef.Key.Name, hostRef.Key.Namespace)
+
+		for settingName, expectedValue := range expectedBIOSSettings {
+			actualValue, exists := hfs.Object.Status.Settings[settingName]
+			Expect(exists).To(BeTrue(),
+				"BIOS setting %s not found in HostFirmwareSettings for BMH %s/%s",
+				settingName, hostRef.Key.Namespace, hostRef.Key.Name)
+
+			expectedValueStr := expectedValue.String()
+			Expect(actualValue).To(Equal(expectedValueStr),
+				"Expected BIOS setting %s to be %s on BMH %s/%s, but found %s",
+				settingName, expectedValueStr, hostRef.Key.Namespace, hostRef.Key.Name, actualValue)
+		}
+	}
+}
+
+// waitForPRFulfilledWithMNOExtras waits for Fulfilled. When worker nodes are present, it also observes
+// master-before-worker ordering, worker maxUnavailable concurrency, and BMH OK + Ready gating for ConfigApplied.
+func waitForPRFulfilledWithMNOExtras(
+	apiClient runtimeclient.Client,
+	prBuilder *oran.ProvisioningRequestBuilder,
+	updateTime time.Time,
+	timeout time.Duration) {
+	if !helper.HasWorkerNodes() {
+		err := prBuilder.WaitForPhaseAfter(provisioningv1alpha1.StateFulfilled, updateTime, timeout)
+		Expect(err).ToNot(HaveOccurred(), "Failed to wait for ProvisioningRequest to be fulfilled")
+
+		return
+	}
+
+	By("waiting for ProvisioningRequest fulfillment while observing MNO Day2 rolling constraints")
+
+	maxUnavailable := getWorkerMaxUnavailable()
+	var orderingViolation error
+	var concurrencyViolation error
+	var gatingViolation error
+	maxConcurrentWorkers := 0
+
+	err := wait.PollUntilContextTimeout(
+		context.TODO(), 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+			refreshed, err := oran.PullPR(apiClient, prBuilder.Definition.Name)
+			if err != nil {
+				klog.V(tsparams.LogLevel).Infof("Failed to pull ProvisioningRequest while observing: %v", err)
+
+				return false, nil
+			}
+
+			prBuilder.Object = refreshed.Object
+			prBuilder.Definition = refreshed.Definition
+
+			observeAllocatedNodeRolling(
+				maxUnavailable,
+				&maxConcurrentWorkers,
+				&orderingViolation,
+				&concurrencyViolation,
+				&gatingViolation,
+			)
+
+			phase := refreshed.Object.Status.ProvisioningStatus.ProvisioningPhase
+			if phase == provisioningv1alpha1.StateFulfilled {
+				return true, nil
+			}
+
+			if phase == provisioningv1alpha1.StateFailed {
+				return false, fmt.Errorf("ProvisioningRequest failed during Day2 update: %s",
+					refreshed.Object.Status.ProvisioningStatus.ProvisioningDetails)
+			}
+
+			return false, nil
+		})
+	Expect(err).ToNot(HaveOccurred(), "Failed to wait for ProvisioningRequest to be fulfilled with MNO extras")
+	Expect(orderingViolation).ToNot(HaveOccurred(), "Master-before-worker ordering violated during Day2 update")
+	Expect(concurrencyViolation).ToNot(HaveOccurred(), "Worker maxUnavailable violated during Day2 update")
+	Expect(gatingViolation).ToNot(HaveOccurred(), "ConfigApplied gating violated during Day2 update")
+	Expect(maxConcurrentWorkers).To(BeNumerically("<=", maxUnavailable),
+		"Observed %d concurrent worker updates, maxUnavailable=%d", maxConcurrentWorkers, maxUnavailable)
+}
+
+func getWorkerMaxUnavailable() int {
+	if Spoke1APIClient == nil {
+		return 1
+	}
+
+	workerMCP, err := mco.Pull(Spoke1APIClient, "worker")
+	if err != nil {
+		klog.V(tsparams.LogLevel).Infof("Failed to pull worker MachineConfigPool: %v; defaulting maxUnavailable to 1", err)
+
+		return 1
+	}
+
+	if workerMCP.Object.Spec.MaxUnavailable == nil {
+		return 1
+	}
+
+	value := workerMCP.Object.Spec.MaxUnavailable.IntValue()
+	if value > 0 {
+		return value
+	}
+
+	if workerCount := helper.CountNodesByRole("worker"); workerCount > 0 {
+		pctStr := strings.TrimSuffix(workerMCP.Object.Spec.MaxUnavailable.StrVal, "%")
+		pct, err := strconv.Atoi(pctStr)
+		if err == nil && pct > 0 {
+			maxU := workerCount * pct / 100
+			if maxU < 1 {
+				return 1
+			}
+
+			return maxU
+		}
+	}
+
+	return 1
+}
+
+func observeAllocatedNodeRolling(
+	maxUnavailable int,
+	maxConcurrentWorkers *int,
+	orderingViolation *error,
+	concurrencyViolation *error,
+	gatingViolation *error,
+) {
+	allocatedNodes, err := oran.ListAllocatedNodes(HubAPIClient)
+	if err != nil {
+		klog.V(tsparams.LogLevel).Infof("Failed to list AllocatedNodes for MNO observation: %v", err)
+
+		return
+	}
+
+	spokeReady := map[string]bool{}
+	if Spoke1APIClient != nil {
+		nodeList, err := nodes.List(Spoke1APIClient)
+		if err == nil {
+			for _, node := range nodeList {
+				ready := false
+				for _, condition := range node.Object.Status.Conditions {
+					if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+						ready = true
+
+						break
+					}
+				}
+				spokeReady[node.Object.Name] = ready
+			}
+		}
+	}
+
+	allMastersApplied := true
+	anyWorkerUpdating := false
+	activeWorkers := 0
+
+	for _, allocatedNode := range allocatedNodes {
+		if RANConfig.Spoke1Name != "" &&
+			!strings.HasPrefix(allocatedNode.Object.Name, RANConfig.Spoke1Name) {
+			continue
+		}
+
+		role := allocatedNode.Object.Spec.GroupName
+		configuredReason := configuredConditionReason(allocatedNode)
+
+		switch role {
+		case "master":
+			if configuredReason != string(hardwaremanagementv1alpha1.ConfigApplied) &&
+				configuredReason != "" {
+				allMastersApplied = false
+			}
+		case "worker":
+			if isActiveHardwareUpdate(configuredReason) {
+				anyWorkerUpdating = true
+				activeWorkers++
+			}
+		}
+
+		if configuredReason == string(hardwaremanagementv1alpha1.ConfigApplied) {
+			if err := verifyConfigAppliedGating(allocatedNode, spokeReady); err != nil && *gatingViolation == nil {
+				*gatingViolation = err
+			}
+		}
+	}
+
+	if anyWorkerUpdating && !allMastersApplied && *orderingViolation == nil {
+		*orderingViolation = fmt.Errorf(
+			"worker entered active Day2 update before all masters reached ConfigurationApplied")
+	}
+
+	if activeWorkers > *maxConcurrentWorkers {
+		*maxConcurrentWorkers = activeWorkers
+	}
+
+	if activeWorkers > maxUnavailable && *concurrencyViolation == nil {
+		*concurrencyViolation = fmt.Errorf(
+			"observed %d concurrent worker updates, exceeds maxUnavailable %d", activeWorkers, maxUnavailable)
+	}
+}
+
+func configuredConditionReason(allocatedNode *oran.AllocatedNodeBuilder) string {
+	for _, condition := range allocatedNode.Object.Status.Conditions {
+		if condition.Type == string(hardwaremanagementv1alpha1.Configured) {
+			return condition.Reason
+		}
+	}
+
+	return ""
+}
+
+func isActiveHardwareUpdate(reason string) bool {
+	switch reason {
+	case string(hardwaremanagementv1alpha1.ConfigUpdatePending),
+		string(hardwaremanagementv1alpha1.ConfigUpdate),
+		string(hardwaremanagementv1alpha1.InProgress):
+		return true
+	default:
+		return false
+	}
+}
+
+func verifyConfigAppliedGating(allocatedNode *oran.AllocatedNodeBuilder, spokeReady map[string]bool) error {
+	bmhName := allocatedNode.Object.Spec.HwMgrNodeId
+	bmhNamespace := allocatedNode.Object.Spec.HwMgrNodeNs
+
+	if bmhName == "" || bmhNamespace == "" {
+		return fmt.Errorf("AllocatedNode %s missing BMH reference while ConfigApplied", allocatedNode.Object.Name)
+	}
+
+	bareMetalHost, err := bmh.Pull(HubAPIClient, bmhName, bmhNamespace)
+	if err != nil {
+		return fmt.Errorf("pull BMH %s/%s for ConfigApplied gating: %w", bmhNamespace, bmhName, err)
+	}
+
+	if bareMetalHost.Object.Status.OperationalStatus != bmhv1alpha1.OperationalStatusOK {
+		return fmt.Errorf("AllocatedNode %s is ConfigApplied but BMH %s/%s operationalStatus=%s",
+			allocatedNode.Object.Name, bmhNamespace, bmhName, bareMetalHost.Object.Status.OperationalStatus)
+	}
+
+	nodeName := allocatedNode.Object.Status.Hostname
+	if nodeName == "" {
+		return nil
+	}
+
+	if ready, ok := spokeReady[nodeName]; ok && !ready {
+		return fmt.Errorf("AllocatedNode %s is ConfigApplied but spoke node %s is not Ready",
+			allocatedNode.Object.Name, nodeName)
+	}
+
+	return nil
 }

--- a/tests/cnf/ran/oran/tests/oran-pre-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-pre-provision.go
@@ -35,8 +35,10 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 	It("fails to create ProvisioningRequest with invalid ClusterTemplate", reportxml.ID("77392"), func() {
 		By("attempting to create a ProvisioningRequest")
 
-		prBuilder := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateInvalid)
-		_, err := prBuilder.Create()
+		prBuilder, err := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateInvalid)
+		Expect(err).ToNot(HaveOccurred(), "Failed to build ProvisioningRequest")
+
+		_, err = prBuilder.Create()
 		Expect(err).To(HaveOccurred(), "Creating a ProvisioningRequest with an invalid ClusterTemplate should fail")
 	})
 
@@ -44,8 +46,8 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 	It("fails ClusterTemplate validation when inline BMC schema is missing without hwMgmtDefaults",
 		reportxml.ID("78245"), func() {
 			clusterTemplateName := fmt.Sprintf("%s.%s-%s",
-				tsparams.ClusterTemplateName, RANConfig.ClusterTemplateAffix, tsparams.TemplateInlineBMCMissingSchema)
-			clusterTemplateNamespace := tsparams.ClusterTemplateName + "-" + RANConfig.ClusterTemplateAffix
+				helper.GetClusterTemplateName(), RANConfig.ClusterTemplateAffix, tsparams.TemplateInlineBMCMissingSchema)
+			clusterTemplateNamespace := helper.GetClusterTemplateName() + "-" + RANConfig.ClusterTemplateAffix
 
 			By("pulling the ClusterTemplate that omits hwMgmtDefaults and inline BMC schema")
 
@@ -80,8 +82,10 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 		It("fails when no hardware matches resource selector", reportxml.ID("83880"), func() {
 			By("creating a ProvisioningRequest with non-matching resource selector")
 
-			prBuilder := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateNoHardwareMatch)
-			_, err := prBuilder.Create()
+			prBuilder, err := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateNoHardwareMatch)
+			Expect(err).ToNot(HaveOccurred(), "Failed to build ProvisioningRequest")
+
+			_, err = prBuilder.Create()
 			Expect(err).ToNot(HaveOccurred(), "Failed to create ProvisioningRequest with non-matching resource selector")
 
 			By("waiting for ProvisioningRequest to fail due to no matching hardware")
@@ -104,8 +108,10 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 		It("fails when boot interface label is missing", reportxml.ID("83881"), func() {
 			By("creating a ProvisioningRequest with missing boot interface label")
 
-			prBuilder := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateMissingBootInterface)
-			_, err := prBuilder.Create()
+			prBuilder, err := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateMissingBootInterface)
+			Expect(err).ToNot(HaveOccurred(), "Failed to build ProvisioningRequest")
+
+			_, err = prBuilder.Create()
 			Expect(err).ToNot(HaveOccurred(), "Failed to create ProvisioningRequest with missing boot interface label")
 
 			By("waiting for ProvisioningRequest to fail due to missing boot interface")
@@ -128,8 +134,10 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 		It("fails when hardware profile does not exist", reportxml.ID("83882"), func() {
 			By("attempting to create a ProvisioningRequest with nonexistent hardware profile")
 
-			prBuilder := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateNonexistentHWProfile)
-			_, err := prBuilder.Create()
+			prBuilder, err := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateNonexistentHWProfile)
+			Expect(err).ToNot(HaveOccurred(), "Failed to build ProvisioningRequest")
+
+			_, err = prBuilder.Create()
 			Expect(err).To(HaveOccurred(),
 				"Creating a ProvisioningRequest with a nonexistent hardware profile should be rejected by the admission webhook")
 			Expect(err.Error()).To(ContainSubstring("does not exist"),

--- a/tests/cnf/ran/oran/tests/oran-pre-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-pre-provision.go
@@ -45,9 +45,12 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 	// 78245 - ClusterTemplate validation fails when inline BMC schema is missing without hwMgmtDefaults
 	It("fails ClusterTemplate validation when inline BMC schema is missing without hwMgmtDefaults",
 		reportxml.ID("78245"), func() {
+			clusterTemplateBaseName, err := helper.GetClusterTemplateName()
+			Expect(err).ToNot(HaveOccurred(), "Failed to resolve ClusterTemplate name")
+
 			clusterTemplateName := fmt.Sprintf("%s.%s-%s",
-				helper.GetClusterTemplateName(), RANConfig.ClusterTemplateAffix, tsparams.TemplateInlineBMCMissingSchema)
-			clusterTemplateNamespace := helper.GetClusterTemplateName() + "-" + RANConfig.ClusterTemplateAffix
+				clusterTemplateBaseName, RANConfig.ClusterTemplateAffix, tsparams.TemplateInlineBMCMissingSchema)
+			clusterTemplateNamespace := clusterTemplateBaseName + "-" + RANConfig.ClusterTemplateAffix
 
 			By("pulling the ClusterTemplate that omits hwMgmtDefaults and inline BMC schema")
 

--- a/tests/cnf/ran/oran/tests/oran-pre-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-pre-provision.go
@@ -55,7 +55,10 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 			By("pulling the ClusterTemplate that omits hwMgmtDefaults and inline BMC schema")
 
 			clusterTemplate, err := oran.PullClusterTemplate(HubAPIClient, clusterTemplateName, clusterTemplateNamespace)
-			Expect(err).ToNot(HaveOccurred(), "Failed to pull ClusterTemplate with missing inline BMC schema")
+			if err != nil {
+				Skip(fmt.Sprintf("ClusterTemplate %s/%s not deployed for this topology: %v",
+					clusterTemplateNamespace, clusterTemplateName, err))
+			}
 
 			By("verifying the ClusterTemplate omits hwMgmtDefaults and hwMgmtParameters")
 			Expect(clusterTemplate.Definition.Spec.TemplateDefaults.HwMgmtDefaults.NodeGroupData).To(BeEmpty(),

--- a/tests/cnf/ran/oran/tests/oran-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-provision.go
@@ -10,7 +10,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/configmap"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/ocm"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
@@ -19,6 +21,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/auth"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/helper"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -50,12 +53,14 @@ var _ = Describe("ORAN Provision Tests", Label(tsparams.LabelProvision), Ordered
 
 		By("creating a ProvisioningRequest with invalid policyTemplateParameters")
 
-		prBuilder := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateValid).
-			WithTemplateParameter(tsparams.PolicyTemplateParamsKey, map[string]any{
-				// By using an integer when the schema specifies a string we can create an invalid
-				// ProvisioningRequest without being stopped by the webhook.
-				tsparams.TestName: 1,
-			})
+		prBuilder, err := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateValid)
+		Expect(err).ToNot(HaveOccurred(), "Failed to build ProvisioningRequest")
+
+		prBuilder = prBuilder.WithTemplateParameter(tsparams.PolicyTemplateParamsKey, map[string]any{
+			// By using an integer when the schema specifies a string we can create an invalid
+			// ProvisioningRequest without being stopped by the webhook.
+			tsparams.TestName: 1,
+		})
 
 		prBuilder, err = prBuilder.Create()
 		Expect(err).ToNot(HaveOccurred(), "Failed to create an invalid ProvisioningRequest")
@@ -110,7 +115,10 @@ var _ = Describe("ORAN Provision Tests", Label(tsparams.LabelProvision), Ordered
 			if err != nil {
 				By("creating the ProvisioningRequest since it does not exist")
 
-				prBuilder, err = helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateValid).Create()
+				prBuilder, err = helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateValid)
+				Expect(err).ToNot(HaveOccurred(), "Failed to build ProvisioningRequest")
+
+				prBuilder, err = prBuilder.Create()
 				Expect(err).ToNot(HaveOccurred(), "Failed to create ProvisioningRequest since it does not exist")
 			}
 
@@ -183,9 +191,13 @@ func verifyProvisioningRequestFulfilled(prBuilder *oran.ProvisioningRequestBuild
 	By("verifying the InfrastructureResourceStatuses are set")
 
 	resourceStatuses := status.Extensions.InfrastructureResourceStatuses
-	if len(resourceStatuses) == 0 {
-		accumulatedErrors = append(accumulatedErrors,
-			fmt.Errorf("expected provisioned infrastructure nodes in extensions"))
+	expectedHostnames, err := helper.GetSpokeHostnames()
+	if err != nil {
+		accumulatedErrors = append(accumulatedErrors, fmt.Errorf("resolve expected node count: %w", err))
+	} else if len(resourceStatuses) != len(expectedHostnames) {
+		accumulatedErrors = append(accumulatedErrors, fmt.Errorf(
+			"expected %d provisioned infrastructure nodes in extensions, got %d",
+			len(expectedHostnames), len(resourceStatuses)))
 	}
 
 	By("verifying the InfrastructureResourceStatuses are provisioned")
@@ -245,7 +257,7 @@ func verifySpokeProvisioning() error {
 
 	By("verifying spoke 1 extra-manifests was created")
 
-	_, err = configmap.Pull(HubAPIClient, tsparams.ExtraManifestsName, RANConfig.Spoke1Name)
+	_, err = configmap.Pull(HubAPIClient, helper.GetExtraManifestsName(), RANConfig.Spoke1Name)
 	if err != nil {
 		klog.V(tsparams.LogLevel).Infof("Failed to verify the extra-manifests ConfigMap was created: %v", err)
 
@@ -255,7 +267,7 @@ func verifySpokeProvisioning() error {
 
 	By("verifying spoke 1 policy ConfigMap was created")
 
-	ztpNamespace := fmt.Sprintf("ztp-%s-%s", tsparams.ClusterTemplateName, RANConfig.ClusterTemplateAffix)
+	ztpNamespace := fmt.Sprintf("ztp-%s-%s", helper.GetClusterTemplateName(), RANConfig.ClusterTemplateAffix)
 
 	_, err = configmap.Pull(HubAPIClient, RANConfig.Spoke1Name+"-pg", ztpNamespace)
 	if err != nil {
@@ -275,5 +287,72 @@ func verifySpokeProvisioning() error {
 		accumulatedErrors = append(accumulatedErrors, fmt.Errorf("failed to verify all policies are compliant: %w", err))
 	}
 
+	if err := verifySpokeNodesReady(); err != nil {
+		accumulatedErrors = append(accumulatedErrors, err)
+	}
+
 	return errors.Join(accumulatedErrors...)
+}
+
+// verifySpokeNodesReady checks that the provisioned spoke has the expected number of Ready nodes, using the existing
+// spoke client when available or a temporary client built from the hub admin-kubeconfig secret.
+func verifySpokeNodesReady() error {
+	expectedHostnames, err := helper.GetSpokeHostnames()
+	if err != nil {
+		return fmt.Errorf("resolve expected spoke node count: %w", err)
+	}
+
+	spokeClient := Spoke1APIClient
+	if spokeClient == nil {
+		By("building a temporary spoke client from the admin-kubeconfig secret")
+
+		kubeconfigPath, err := os.CreateTemp("", "oran-spoke-kubeconfig-*.yaml")
+		if err != nil {
+			return fmt.Errorf("create temp kubeconfig file: %w", err)
+		}
+
+		defer os.Remove(kubeconfigPath.Name())
+
+		if err := kubeconfigPath.Close(); err != nil {
+			return fmt.Errorf("close temp kubeconfig file: %w", err)
+		}
+
+		if err := saveSpoke1Secret("-admin-kubeconfig", "kubeconfig", kubeconfigPath.Name()); err != nil {
+			return fmt.Errorf("save admin kubeconfig for spoke node verification: %w", err)
+		}
+
+		spokeClient = clients.New(kubeconfigPath.Name())
+		if spokeClient == nil {
+			return fmt.Errorf("failed to create spoke API client from admin kubeconfig")
+		}
+	}
+
+	By("verifying spoke nodes are Ready")
+
+	nodeList, err := nodes.List(spokeClient)
+	if err != nil {
+		return fmt.Errorf("list spoke nodes: %w", err)
+	}
+
+	if len(nodeList) != len(expectedHostnames) {
+		return fmt.Errorf("expected %d spoke nodes, got %d", len(expectedHostnames), len(nodeList))
+	}
+
+	for _, node := range nodeList {
+		ready := false
+
+		for _, condition := range node.Object.Status.Conditions {
+			if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+				ready = true
+
+				break
+			}
+		}
+
+		if !ready {
+			return fmt.Errorf("spoke node %s is not Ready", node.Object.Name)
+		}
+	}
+
+	return nil
 }

--- a/tests/cnf/ran/oran/tests/oran-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-provision.go
@@ -48,37 +48,46 @@ var _ = Describe("ORAN Provision Tests", Label(tsparams.LabelProvision), Ordered
 
 	// 77393 - Apply a ProvisioningRequest with missing required input parameter
 	It("recovers provisioning when invalid ProvisioningRequest is updated", reportxml.ID("77393"), func() {
-		By("verifying the ProvisioningRequest does not already exist")
+		var prBuilder *oran.ProvisioningRequestBuilder
 
-		_, err := oran.PullPR(o2imsAPIClient, tsparams.TestPRName)
+		existingPR, err := oran.PullPR(o2imsAPIClient, tsparams.TestPRName)
 		if err == nil {
-			Skip("cannot run provisioning tests if the ProvisioningRequest already exists")
+			if existingPR.Object.Status.ProvisioningStatus.ProvisioningPhase != provisioningv1alpha1.StateFailed {
+				Skip("cannot run provisioning tests if the ProvisioningRequest already exists")
+			}
+
+			By("continuing from an existing failed ProvisioningRequest")
+
+			prBuilder = existingPR
+		} else {
+			By("creating a ProvisioningRequest with invalid policyTemplateParameters")
+
+			prBuilder, err = helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateValid)
+			Expect(err).ToNot(HaveOccurred(), "Failed to build ProvisioningRequest")
+
+			prBuilder = prBuilder.WithTemplateParameter(tsparams.PolicyTemplateParamsKey, map[string]any{
+				// By using an integer when the schema specifies a string we can create an invalid
+				// ProvisioningRequest without being stopped by the webhook.
+				tsparams.TestName: 1,
+			})
+
+			prBuilder, err = prBuilder.Create()
+			Expect(err).ToNot(HaveOccurred(), "Failed to create an invalid ProvisioningRequest")
+
+			By("waiting for the ProvisioningRequest to be failed")
+
+			err = prBuilder.WaitForPhaseAfter(provisioningv1alpha1.StateFailed, time.Time{}, time.Minute)
+			Expect(err).ToNot(HaveOccurred(), "Failed to wait for the ProvisioningRequest to fail")
 		}
-
-		By("creating a ProvisioningRequest with invalid policyTemplateParameters")
-
-		prBuilder, err := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateValid)
-		Expect(err).ToNot(HaveOccurred(), "Failed to build ProvisioningRequest")
-
-		prBuilder = prBuilder.WithTemplateParameter(tsparams.PolicyTemplateParamsKey, map[string]any{
-			// By using an integer when the schema specifies a string we can create an invalid
-			// ProvisioningRequest without being stopped by the webhook.
-			tsparams.TestName: 1,
-		})
-
-		prBuilder, err = prBuilder.Create()
-		Expect(err).ToNot(HaveOccurred(), "Failed to create an invalid ProvisioningRequest")
-
-		By("waiting for the ProvisioningRequest to be failed")
-
-		err = prBuilder.WaitForPhaseAfter(provisioningv1alpha1.StateFailed, time.Time{}, time.Minute)
-		Expect(err).ToNot(HaveOccurred(), "Failed to wait for the ProvisioningRequest to fail")
 
 		Expect(prBuilder.Object.Status.ProvisioningStatus.ProvisioningPhase).
 			To(Equal(provisioningv1alpha1.StateFailed), "Expected ProvisioningRequest to be failed after invalid parameters")
-		Expect(prBuilder.Object.Status.ProvisioningStatus.ProvisioningDetails).
-			To(ContainSubstring(tsparams.PRValidationFailedDetailsSubstring),
-				"Expected provisioning details to report a validation failure")
+
+		details := prBuilder.Object.Status.ProvisioningStatus.ProvisioningDetails
+		Expect(details).To(Or(
+			ContainSubstring(tsparams.PRValidationFailedDetailsSubstring),
+			ContainSubstring(tsparams.PRInvalidPolicyTemplateParamDetailsSubstring),
+		), "Expected provisioning details to report invalid policyTemplateParameters")
 
 		updateTime := time.Now()
 
@@ -224,6 +233,22 @@ func verifyProvisioningRequestFulfilled(prBuilder *oran.ProvisioningRequestBuild
 			accumulatedErrors = append(accumulatedErrors, fmt.Errorf(
 				"failed to verify AllocatedNode %s exists: %w", resourceStatus.ResourceId, err))
 		}
+	}
+
+	By("verifying allocated infrastructure resource count matches spoke topology")
+
+	if err == nil && status.Extensions.AllocatedNodeHostMap != nil {
+		if len(status.Extensions.AllocatedNodeHostMap) != len(expectedHostnames) {
+			accumulatedErrors = append(accumulatedErrors, fmt.Errorf(
+				"expected AllocatedNodeHostMap length %d, got %d",
+				len(expectedHostnames), len(status.Extensions.AllocatedNodeHostMap)))
+		}
+	}
+
+	By("verifying AllocatedNodes, BMH labels, and Day0 HardwareProfiles")
+
+	if err := helper.VerifyAllocatedHardwareForPR(prBuilder); err != nil {
+		accumulatedErrors = append(accumulatedErrors, err)
 	}
 
 	return errors.Join(accumulatedErrors...)
@@ -447,6 +472,38 @@ func validateSpokeNodeIdentities(nodeList []*nodes.Builder, expectedHostnames []
 
 		if !matched {
 			return fmt.Errorf("unexpected spoke node %q found in cluster", node.Object.Name)
+		}
+	}
+
+	expectedMasters := helper.CountNodesByRole("master")
+	expectedWorkers := helper.CountNodesByRole("worker")
+
+	if expectedMasters > 0 || expectedWorkers > 0 {
+		By("verifying spoke node roles match the ClusterInstance topology")
+
+		actualMasters := 0
+		actualWorkers := 0
+
+		for _, node := range nodeList {
+			_, isMaster := node.Object.Labels["node-role.kubernetes.io/master"]
+			_, isWorker := node.Object.Labels["node-role.kubernetes.io/worker"]
+
+			if isMaster {
+				actualMasters++
+			}
+
+			// Count dedicated workers only; control-plane nodes often also carry the worker role label.
+			if isWorker && !isMaster {
+				actualWorkers++
+			}
+		}
+
+		if expectedMasters > 0 && actualMasters != expectedMasters {
+			return fmt.Errorf("expected %d master nodes, got %d", expectedMasters, actualMasters)
+		}
+
+		if expectedWorkers > 0 && actualWorkers != expectedWorkers {
+			return fmt.Errorf("expected %d dedicated worker nodes, got %d", expectedWorkers, actualWorkers)
 		}
 	}
 

--- a/tests/cnf/ran/oran/tests/oran-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-provision.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -22,10 +23,13 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/helper"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const spokeNodesReadyTimeout = 30 * time.Minute
 
 var _ = Describe("ORAN Provision Tests", Label(tsparams.LabelProvision), Ordered, ContinueOnFailure, func() {
 	var o2imsAPIClient runtimeclient.Client
@@ -191,6 +195,7 @@ func verifyProvisioningRequestFulfilled(prBuilder *oran.ProvisioningRequestBuild
 	By("verifying the InfrastructureResourceStatuses are set")
 
 	resourceStatuses := status.Extensions.InfrastructureResourceStatuses
+
 	expectedHostnames, err := helper.GetSpokeHostnames()
 	if err != nil {
 		accumulatedErrors = append(accumulatedErrors, fmt.Errorf("resolve expected node count: %w", err))
@@ -306,65 +311,155 @@ func verifySpokeProvisioning() error {
 	return errors.Join(accumulatedErrors...)
 }
 
-// verifySpokeNodesReady checks that the provisioned spoke has the expected number of Ready nodes, using the existing
-// spoke client when available or a temporary client built from the hub admin-kubeconfig secret.
+// verifySpokeNodesReady polls until the provisioned spoke has the expected Ready nodes, using the existing spoke client
+// when available or a temporary client built from the hub admin-kubeconfig secret.
 func verifySpokeNodesReady() error {
 	expectedHostnames, err := helper.GetSpokeHostnames()
 	if err != nil {
 		return fmt.Errorf("resolve expected spoke node count: %w", err)
 	}
 
-	spokeClient := Spoke1APIClient
-	if spokeClient == nil {
-		By("building a temporary spoke client from the admin-kubeconfig secret")
-
-		kubeconfigPath, err := os.CreateTemp("", "oran-spoke-kubeconfig-*.yaml")
-		if err != nil {
-			return fmt.Errorf("create temp kubeconfig file: %w", err)
-		}
-
-		defer os.Remove(kubeconfigPath.Name())
-
-		if err := kubeconfigPath.Close(); err != nil {
-			return fmt.Errorf("close temp kubeconfig file: %w", err)
-		}
-
-		if err := saveSpoke1Secret("-admin-kubeconfig", "kubeconfig", kubeconfigPath.Name()); err != nil {
-			return fmt.Errorf("save admin kubeconfig for spoke node verification: %w", err)
-		}
-
-		spokeClient = clients.New(kubeconfigPath.Name())
-		if spokeClient == nil {
-			return fmt.Errorf("failed to create spoke API client from admin kubeconfig")
-		}
-	}
-
-	By("verifying spoke nodes are Ready")
-
-	nodeList, err := nodes.List(spokeClient)
+	spokeClient, cleanup, err := spokeClientForNodeVerification()
 	if err != nil {
-		return fmt.Errorf("list spoke nodes: %w", err)
+		return err
 	}
 
-	if len(nodeList) != len(expectedHostnames) {
-		return fmt.Errorf("expected %d spoke nodes, got %d", len(expectedHostnames), len(nodeList))
+	if cleanup != nil {
+		defer cleanup()
 	}
 
-	for _, node := range nodeList {
-		ready := false
+	By("waiting for spoke nodes to become Ready")
 
-		for _, condition := range node.Object.Status.Conditions {
-			if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
-				ready = true
+	err = wait.PollUntilContextTimeout(
+		context.TODO(), 15*time.Second, spokeNodesReadyTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			nodeList, err := nodes.List(spokeClient)
+			if err != nil {
+				klog.V(tsparams.LogLevel).Infof("Failed to list spoke nodes: %v", err)
+
+				return false, nil
+			}
+
+			if len(nodeList) != len(expectedHostnames) {
+				klog.V(tsparams.LogLevel).Infof(
+					"Waiting for spoke nodes: expected %d, got %d",
+					len(expectedHostnames), len(nodeList))
+
+				return false, nil
+			}
+
+			if err := validateSpokeNodeIdentities(nodeList, expectedHostnames); err != nil {
+				klog.V(tsparams.LogLevel).Infof("Spoke node identity check: %v", err)
+
+				return false, nil
+			}
+
+			for _, node := range nodeList {
+				if !isSpokeNodeReady(node) {
+					klog.V(tsparams.LogLevel).Infof("Waiting for spoke node %s to become Ready", node.Object.Name)
+
+					return false, nil
+				}
+			}
+
+			return true, nil
+		})
+	if err != nil {
+		return fmt.Errorf("timed out waiting for spoke nodes to become Ready: %w", err)
+	}
+
+	return nil
+}
+
+// spokeClientForNodeVerification returns the spoke API client, building a temporary client from the hub
+// admin-kubeconfig secret when Spoke1APIClient is not configured. When a temp kubeconfig is created, cleanup removes
+// the file and must be called after node verification completes.
+func spokeClientForNodeVerification() (*clients.Settings, func(), error) {
+	if Spoke1APIClient != nil {
+		return Spoke1APIClient, nil, nil
+	}
+
+	By("building a temporary spoke client from the admin-kubeconfig secret")
+
+	kubeconfigPath, err := os.CreateTemp("", "oran-spoke-kubeconfig-*.yaml")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create temp kubeconfig file: %w", err)
+	}
+
+	kubeconfigFile := kubeconfigPath.Name()
+
+	if err := kubeconfigPath.Close(); err != nil {
+		return nil, nil, fmt.Errorf("close temp kubeconfig file: %w", err)
+	}
+
+	if err := saveSpoke1Secret("-admin-kubeconfig", "kubeconfig", kubeconfigFile); err != nil {
+		return nil, nil, fmt.Errorf("save admin kubeconfig for spoke node verification: %w", err)
+	}
+
+	spokeClient := clients.New(kubeconfigFile)
+	if spokeClient == nil {
+		return nil, nil, fmt.Errorf("failed to create spoke API client from admin kubeconfig")
+	}
+
+	return spokeClient, func() { os.Remove(kubeconfigFile) }, nil
+}
+
+// spokeNodeNameMatches reports whether a Kubernetes node name corresponds to an expected ClusterInstance hostname.
+// Node objects use the short hostname while ClusterInstance files may specify an FQDN.
+func spokeNodeNameMatches(expectedHostname, nodeName string) bool {
+	if nodeName == expectedHostname {
+		return true
+	}
+
+	shortExpectedHostname, _, _ := strings.Cut(expectedHostname, ".")
+
+	return nodeName == shortExpectedHostname
+}
+
+// validateSpokeNodeIdentities ensures every expected hostname maps to a cluster node and no unexpected nodes exist.
+func validateSpokeNodeIdentities(nodeList []*nodes.Builder, expectedHostnames []string) error {
+	for _, expectedHostname := range expectedHostnames {
+		found := false
+
+		for _, node := range nodeList {
+			if spokeNodeNameMatches(expectedHostname, node.Object.Name) {
+				found = true
 
 				break
 			}
 		}
 
-		if !ready {
-			return fmt.Errorf("spoke node %s is not Ready", node.Object.Name)
+		if !found {
+			return fmt.Errorf("expected spoke node %q not found in cluster", expectedHostname)
+		}
+	}
+
+	for _, node := range nodeList {
+		matched := false
+
+		for _, expectedHostname := range expectedHostnames {
+			if spokeNodeNameMatches(expectedHostname, node.Object.Name) {
+				matched = true
+
+				break
+			}
+		}
+
+		if !matched {
+			return fmt.Errorf("unexpected spoke node %q found in cluster", node.Object.Name)
 		}
 	}
 
 	return nil
+}
+
+// isSpokeNodeReady reports whether the node has a True NodeReady condition.
+func isSpokeNodeReady(node *nodes.Builder) bool {
+	for _, condition := range node.Object.Status.Conditions {
+		if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
 }

--- a/tests/cnf/ran/oran/tests/oran-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-provision.go
@@ -257,24 +257,36 @@ func verifySpokeProvisioning() error {
 
 	By("verifying spoke 1 extra-manifests was created")
 
-	_, err = configmap.Pull(HubAPIClient, helper.GetExtraManifestsName(), RANConfig.Spoke1Name)
+	extraManifestsName, err := helper.GetExtraManifestsName()
 	if err != nil {
-		klog.V(tsparams.LogLevel).Infof("Failed to verify the extra-manifests ConfigMap was created: %v", err)
-
 		accumulatedErrors = append(accumulatedErrors,
-			fmt.Errorf("failed to verify the extra-manifests ConfigMap was created: %w", err))
+			fmt.Errorf("resolve extra-manifests ConfigMap name: %w", err))
+	} else {
+		_, err = configmap.Pull(HubAPIClient, extraManifestsName, RANConfig.Spoke1Name)
+		if err != nil {
+			klog.V(tsparams.LogLevel).Infof("Failed to verify the extra-manifests ConfigMap was created: %v", err)
+
+			accumulatedErrors = append(accumulatedErrors,
+				fmt.Errorf("failed to verify the extra-manifests ConfigMap was created: %w", err))
+		}
 	}
 
 	By("verifying spoke 1 policy ConfigMap was created")
 
-	ztpNamespace := fmt.Sprintf("ztp-%s-%s", helper.GetClusterTemplateName(), RANConfig.ClusterTemplateAffix)
-
-	_, err = configmap.Pull(HubAPIClient, RANConfig.Spoke1Name+"-pg", ztpNamespace)
+	clusterTemplateName, err := helper.GetClusterTemplateName()
 	if err != nil {
-		klog.V(tsparams.LogLevel).Infof("Failed to verify spoke 1 policy ConfigMap was created: %v", err)
-
 		accumulatedErrors = append(accumulatedErrors,
-			fmt.Errorf("failed to verify spoke 1 policy ConfigMap was created: %w", err))
+			fmt.Errorf("resolve ClusterTemplate name for policy ConfigMap verification: %w", err))
+	} else {
+		ztpNamespace := fmt.Sprintf("ztp-%s-%s", clusterTemplateName, RANConfig.ClusterTemplateAffix)
+
+		_, err = configmap.Pull(HubAPIClient, RANConfig.Spoke1Name+"-pg", ztpNamespace)
+		if err != nil {
+			klog.V(tsparams.LogLevel).Infof("Failed to verify spoke 1 policy ConfigMap was created: %v", err)
+
+			accumulatedErrors = append(accumulatedErrors,
+				fmt.Errorf("failed to verify spoke 1 policy ConfigMap was created: %w", err))
+		}
 	}
 
 	By("verifying all the policies are compliant")

--- a/tests/cnf/ran/oran/tests/oran-template-inventory.go
+++ b/tests/cnf/ran/oran/tests/oran-template-inventory.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/auth"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/helper"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
 	"gopkg.in/yaml.v3"
 )
@@ -67,9 +68,9 @@ var _ = Describe("ORAN Template Inventory", Label(tsparams.LabelPreProvision, ts
 	It("successfully filters ManagedInfrastructureTemplates", reportxml.ID("82941"), func() {
 		By("getting the specific ClusterTemplate resource for the valid template")
 
-		clusterTemplateNamespace := tsparams.ClusterTemplateName + "-" + RANConfig.ClusterTemplateAffix
+		clusterTemplateNamespace := helper.GetClusterTemplateName() + "-" + RANConfig.ClusterTemplateAffix
 		clusterTemplateName := fmt.Sprintf("%s.%s-%s",
-			tsparams.ClusterTemplateName, RANConfig.ClusterTemplateAffix, tsparams.TemplateValid)
+			helper.GetClusterTemplateName(), RANConfig.ClusterTemplateAffix, tsparams.TemplateValid)
 
 		chosenClusterTemplate, err := oran.PullClusterTemplate(HubAPIClient, clusterTemplateName, clusterTemplateNamespace)
 		Expect(err).ToNot(HaveOccurred(),
@@ -104,9 +105,9 @@ var _ = Describe("ORAN Template Inventory", Label(tsparams.LabelPreProvision, ts
 	It("successfully retrieves ManagedInfrastructureTemplate defaults", reportxml.ID("82942"), func() {
 		By("getting the specific ClusterTemplate resource for the valid template")
 
-		clusterTemplateNamespace := tsparams.ClusterTemplateName + "-" + RANConfig.ClusterTemplateAffix
+		clusterTemplateNamespace := helper.GetClusterTemplateName() + "-" + RANConfig.ClusterTemplateAffix
 		clusterTemplateName := fmt.Sprintf("%s.%s-%s",
-			tsparams.ClusterTemplateName, RANConfig.ClusterTemplateAffix, tsparams.TemplateValid)
+			helper.GetClusterTemplateName(), RANConfig.ClusterTemplateAffix, tsparams.TemplateValid)
 
 		chosenClusterTemplate, err := oran.PullClusterTemplate(HubAPIClient, clusterTemplateName, clusterTemplateNamespace)
 		Expect(err).ToNot(HaveOccurred(),

--- a/tests/cnf/ran/oran/tests/oran-template-inventory.go
+++ b/tests/cnf/ran/oran/tests/oran-template-inventory.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	hardwaremanagementv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/configmap"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran"
 	oranapi "github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran/api"
@@ -62,6 +63,15 @@ var _ = Describe("ORAN Template Inventory", Label(tsparams.LabelPreProvision, ts
 			Expect(found).To(BeTrue(), "ClusterTemplate %s (version %s) does not have a matching ManagedInfrastructureTemplate",
 				clusterTemplate.Definition.Spec.Name, clusterTemplate.Definition.Spec.Version)
 		}
+
+		By("verifying the expected ClusterTemplate name is present in ManagedInfrastructureTemplates")
+
+		expectedTemplateName, err := helper.GetClusterTemplateName()
+		Expect(err).ToNot(HaveOccurred(), "Failed to resolve ClusterTemplate name")
+		Expect(slices.ContainsFunc(managedInfrastructureTemplates,
+			func(managedInfrastructureTemplate oranapi.ManagedInfrastructureTemplate) bool {
+				return managedInfrastructureTemplate.Name == expectedTemplateName
+			})).To(BeTrue(), "Expected ManagedInfrastructureTemplate %s to be listed", expectedTemplateName)
 	})
 
 	// 82941 - Successfully filter ManagedInfrastructureTemplates
@@ -181,6 +191,46 @@ var _ = Describe("ORAN Template Inventory", Label(tsparams.LabelPreProvision, ts
 		Expect(isMap).To(BeTrue(), "editable key in ManagedInfrastructureTemplateDefaults should be a map")
 		Expect(policyTemplateEditable).To(Equal(expectedPolicyTemplateDefaults),
 			"editable content in ManagedInfrastructureTemplateDefaults should match the ConfigMap")
+
+		By("verifying hwMgmtDefaults include a master node group")
+
+		nodeGroupData := chosenClusterTemplate.Definition.Spec.TemplateDefaults.HwMgmtDefaults.NodeGroupData
+		Expect(nodeGroupData).ToNot(BeEmpty(),
+			"ClusterTemplate hwMgmtDefaults.nodeGroupData should not be empty")
+
+		hasMasterGroup := slices.ContainsFunc(nodeGroupData,
+			func(group hardwaremanagementv1alpha1.NodeGroupData) bool {
+				return group.Role == "master" || group.Name == "master"
+			})
+		Expect(hasMasterGroup).To(BeTrue(),
+			"ClusterTemplate hwMgmtDefaults.nodeGroupData should include a master group")
+
+		if helper.IsMultiNode() {
+			By("verifying multi-node ClusterTemplate includes a worker node group and multi-node schema")
+
+			hasWorkerGroup := slices.ContainsFunc(nodeGroupData,
+				func(group hardwaremanagementv1alpha1.NodeGroupData) bool {
+					return group.Role == "worker" || group.Name == "worker"
+				})
+			Expect(hasWorkerGroup).To(BeTrue(),
+				"MNO ClusterTemplate hwMgmtDefaults.nodeGroupData should include a worker group")
+
+			var clusterTemplateSchema map[string]any
+
+			err = json.Unmarshal(chosenClusterTemplate.Definition.Spec.TemplateParameterSchema.Raw, &clusterTemplateSchema)
+			Expect(err).ToNot(HaveOccurred(), "Failed to unmarshal ClusterTemplate parameter schema")
+
+			properties, ok := clusterTemplateSchema["properties"].(map[string]any)
+			Expect(ok).To(BeTrue(), "templateParameterSchema.properties should be a map")
+
+			ciParams, ok := properties[tsparams.ClusterInstanceParamsKey].(map[string]any)
+			Expect(ok).To(BeTrue(), "clusterInstanceParameters schema should be present")
+
+			ciProps, ok := ciParams["properties"].(map[string]any)
+			Expect(ok).To(BeTrue(), "clusterInstanceParameters.properties should be a map")
+			Expect(ciProps).To(HaveKey("nodes"),
+				"clusterInstanceParameters schema should allow nodes[] for multi-node installs")
+		}
 	})
 })
 

--- a/tests/cnf/ran/oran/tests/oran-template-inventory.go
+++ b/tests/cnf/ran/oran/tests/oran-template-inventory.go
@@ -68,9 +68,12 @@ var _ = Describe("ORAN Template Inventory", Label(tsparams.LabelPreProvision, ts
 	It("successfully filters ManagedInfrastructureTemplates", reportxml.ID("82941"), func() {
 		By("getting the specific ClusterTemplate resource for the valid template")
 
-		clusterTemplateNamespace := helper.GetClusterTemplateName() + "-" + RANConfig.ClusterTemplateAffix
+		clusterTemplateBaseName, err := helper.GetClusterTemplateName()
+		Expect(err).ToNot(HaveOccurred(), "Failed to resolve ClusterTemplate name")
+
+		clusterTemplateNamespace := clusterTemplateBaseName + "-" + RANConfig.ClusterTemplateAffix
 		clusterTemplateName := fmt.Sprintf("%s.%s-%s",
-			helper.GetClusterTemplateName(), RANConfig.ClusterTemplateAffix, tsparams.TemplateValid)
+			clusterTemplateBaseName, RANConfig.ClusterTemplateAffix, tsparams.TemplateValid)
 
 		chosenClusterTemplate, err := oran.PullClusterTemplate(HubAPIClient, clusterTemplateName, clusterTemplateNamespace)
 		Expect(err).ToNot(HaveOccurred(),
@@ -105,9 +108,12 @@ var _ = Describe("ORAN Template Inventory", Label(tsparams.LabelPreProvision, ts
 	It("successfully retrieves ManagedInfrastructureTemplate defaults", reportxml.ID("82942"), func() {
 		By("getting the specific ClusterTemplate resource for the valid template")
 
-		clusterTemplateNamespace := helper.GetClusterTemplateName() + "-" + RANConfig.ClusterTemplateAffix
+		clusterTemplateBaseName, err := helper.GetClusterTemplateName()
+		Expect(err).ToNot(HaveOccurred(), "Failed to resolve ClusterTemplate name")
+
+		clusterTemplateNamespace := clusterTemplateBaseName + "-" + RANConfig.ClusterTemplateAffix
 		clusterTemplateName := fmt.Sprintf("%s.%s-%s",
-			helper.GetClusterTemplateName(), RANConfig.ClusterTemplateAffix, tsparams.TemplateValid)
+			clusterTemplateBaseName, RANConfig.ClusterTemplateAffix, tsparams.TemplateValid)
 
 		chosenClusterTemplate, err := oran.PullClusterTemplate(HubAPIClient, clusterTemplateName, clusterTemplateNamespace)
 		Expect(err).ToNot(HaveOccurred(),


### PR DESCRIPTION
Update o-ran SNO test cases to support MNO use case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring O-RAN ClusterTemplate names and ClusterInstance file paths.
  - ClusterInstance files can now define spoke hostnames, node roles, and multi-node topologies.
  - Provisioning and verification now support separate master and worker node configurations.

- **Bug Fixes**
  - Explicitly configured spoke names are preserved.
  - Improved handling of invalid version data and missing provisioning information.
  - Hardware allocation checks now validate node assignments, profiles, labels, and provisioning status.

- **Tests**
  - Expanded provisioning, hardware allocation, firmware, BIOS, and node-readiness coverage for multi-node environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->